### PR TITLE
Change injective instance comment to multi-line comment.

### DIFF
--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -1758,7 +1758,7 @@ prettyClosedTheory thy =
     ppInjectiveFactInsts crc =
         case S.toList $ L.get crcInjectiveFactInsts crc of
             []   -> emptyDoc
-            tags -> lineComment $ sep
+            tags -> multiComment $ sep
                       [ text "looping facts with injective instances:"
                       , nest 2 $ fsepList (text . showFactTagArity) tags ]
 
@@ -1776,7 +1776,7 @@ prettyClosedDiffTheory thy =
     ppInjectiveFactInsts crc =
         case S.toList $ L.get crcInjectiveFactInsts crc of
             []   -> emptyDoc
-            tags -> lineComment $ sep
+            tags -> multiComment $ sep
                       [ text "looping facts with injective instances:"
                       , nest 2 $ fsepList (text . showFactTagArity) tags ]
 


### PR DESCRIPTION
Having long injective instance names (or many) will break proof files when pretty printed:
```
theory long_injective_instances
begin

rule injective:
	[VeryLongInjectiveInstanceFactName(x)]-->[VeryLongInjectiveInstanceFactName(x)]

end
```

becomes

```
theory long_injective_instances begin
...
// looping facts with injective instances:
     VeryLongInjectiveInstanceFactName/1
...
```

This commit simply changes these comments to multi-line comments: 

```
/*
looping facts with injective instances:
  VeryLongInjectiveInstanceFactName/1,
*/

```