### PR TITLE
Include login name in image cache directory

### DIFF
--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -19,6 +19,7 @@ import           Data.Maybe
 import           Data.String                     (fromString)
 import           System.Console.CmdArgs.Explicit as CmdArgs
 import           System.Directory                (doesDirectoryExist, doesFileExist, getTemporaryDirectory)
+import           System.Environment              (lookupEnv)
 import           System.FilePath
 
 import           Network.Wai.Handler.Warp        (defaultSettings, setHost, setPort)
@@ -74,7 +75,10 @@ run thisMode as = case findArg "workDir" as of
         then do
           -- determine caching directory
           tempDir <- getTemporaryDirectory
-          let cacheDir = tempDir </> "tamarin-prover-cache"
+          winLoginName <- lookupEnv "USERNAME"
+	  unixLoginName <- lookupEnv "USER"
+	  let loginName = fromMaybe "" (winLoginName <|> unixLoginName)
+	      cacheDir = tempDir </> ("tamarin-prover-cache-" ++ loginName)
           -- process theories
           case (fst $ graphPath as) of
               "dot"  -> ensureGraphVizDot as


### PR DESCRIPTION
Fixes tamarin-prover/tamarin-prover#142. The other potential approach was to create the directory +rw, but on reflection I think the user separation here is nice to have.