### PR TITLE
Fix cleandot graphs due to the changed graph_from_dot_file API.

### DIFF
--- a/misc/cleandot/tamarincleandotlib.py
+++ b/misc/cleandot/tamarincleandotlib.py
@@ -1973,7 +1973,7 @@ def newDot(infile):
     fp = os.fdopen(fpint,'w')
 
     appendLog("Parsing graph from '%s'.\n" % infile)
-    G = graph_from_dot_file(infile)
+    G = graph_from_dot_file(infile)[0]
     if G == None:
         appendLog("Could not prase graph sensibly.\n")
         return None


### PR DESCRIPTION
The pydot API changed to return a list from `graph_from_dot_file`: https://github.com/erocarrera/pydot/commit/f8d2b5e4e04a544eea37b599ec40947582c0ed68.