### PR TITLE
Remove dependency on derive, which lets us use a newer stack lts

### DIFF
--- a/lib/term/src/Term/Maude/Signature.hs
+++ b/lib/term/src/Term/Maude/Signature.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt
 -- License     : GPL v3 (see LICENSE)
@@ -51,7 +53,8 @@ import Control.Monad.Fresh
 -- import Control.Applicative
 import Control.DeepSeq
 
-import Data.DeriveTH
+import GHC.Generics (Generic)
+import Data.Data
 import Data.Binary
 import Data.Foldable (asum)
 -- import Data.Monoid
@@ -80,7 +83,7 @@ data MaudeSig = MaudeSig
                                           -- can be computed from enableX and stFunSyms
     , irreducibleFunSyms :: FunSig        -- ^ irreducible function symbols (can be computed)
     }
-    deriving (Ord, Show, Eq)
+    deriving (Ord, Show, Eq, Generic, NFData, Binary)
 
 -- | Smart constructor for maude signatures. Computes funSyms and irreducibleFunSyms.
 maudeSig :: MaudeSig -> MaudeSig
@@ -188,9 +191,3 @@ prettyMaudeSig sig = P.vcat
       where showPriv Private = " [private]"
             showPriv Public  = ""
 
-
--- derived instances
---------------------
-
-$(derive makeBinary ''MaudeSig)
-$(derive makeNFData ''MaudeSig)

--- a/lib/term/src/Term/SubtermRule.hs
+++ b/lib/term/src/Term/SubtermRule.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, FlexibleInstances, DeriveDataTypeable, ViewPatterns #-}
+{-# LANGUAGE TemplateHaskell, FlexibleInstances, DeriveDataTypeable, ViewPatterns, DeriveGeneric, DeriveAnyClass #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
   -- spurious warnings for view patterns
 -- |
@@ -21,7 +21,8 @@ module Term.SubtermRule (
 
 import Control.DeepSeq
 
-import Data.DeriveTH
+import GHC.Generics (Generic)
+import Data.Data
 import Data.Binary
 
 import Term.LTerm
@@ -32,12 +33,12 @@ import Text.PrettyPrint.Highlight
 -- | The righthand-side of a context subterm rewrite rule.
 --   Does not enforce that the term for RhsGround must be ground.
 data StRhs = StRhs [Position] LNTerm
-    deriving (Show,Ord,Eq)
+    deriving (Show,Ord,Eq, Generic, NFData, Binary)
 
 -- | A context subterm rewrite rule.
 --   The left hand side as a LNTerm, and a StRHS.
 data CtxtStRule = CtxtStRule LNTerm StRhs
-    deriving (Show,Ord,Eq)
+    deriving (Show,Ord,Eq, Generic, NFData, Binary)
 
 -- | Convert a rewrite rule to a context subterm rewrite rule if possible.
 rRuleToCtxtStRule :: RRule LNTerm -> Maybe CtxtStRule
@@ -88,11 +89,3 @@ prettyCtxtStRule r = case ctxtStRuleToRRule r of
   (lhs `RRule` rhs) -> sep [ nest 2 $ prettyLNTerm lhs
                            , operator_ "=" <-> prettyLNTerm rhs ]
 
--- derived instances
---------------------
-
-$(derive makeBinary ''StRhs)
-$(derive makeBinary ''CtxtStRule)
-
-$(derive makeNFData ''StRhs)
-$(derive makeNFData ''CtxtStRule)

--- a/lib/term/src/Term/Term/FunctionSymbols.hs
+++ b/lib/term/src/Term/Term/FunctionSymbols.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
   -- for ByteString
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
@@ -50,10 +52,11 @@ module Term.Term.FunctionSymbols (
     , implicitFunSig
     ) where
 
+import           GHC.Generics (Generic)
 import           Data.Typeable
-import           Data.Generics
-import           Data.DeriveTH
 import           Data.Binary
+import           Data.Data
+
 
 import           Control.DeepSeq
 
@@ -70,25 +73,25 @@ import qualified Data.Set as S
 
 -- | AC function symbols.
 data ACSym = Union | Mult
-  deriving (Eq, Ord, Typeable, Data, Show)
+  deriving (Eq, Ord, Typeable, Data, Show, Generic, NFData, Binary)
 
 -- | A function symbol can be either Private (unknown to adversary) or Public.
 data Privacy = Private | Public
-  deriving (Eq, Ord, Typeable, Data, Show)
+  deriving (Eq, Ord, Typeable, Data, Show, Generic, NFData, Binary)
 
 -- | NoEq function symbols (with respect to the background theory).
 type NoEqSym = (ByteString, (Int, Privacy)) -- ^ operator name, arity, private
 
 -- | C(ommutative) function symbols
 data CSym = EMap
-  deriving (Eq, Ord, Typeable, Data, Show)
+  deriving (Eq, Ord, Typeable, Data, Show, Generic, NFData, Binary)
 
 -- | Function symbols
 data FunSym = NoEq  NoEqSym   -- ^ a free function function symbol of a given arity
             | AC    ACSym     -- ^ an AC function symbol, can be used n-ary
             | C     CSym      -- ^ a C function symbol of a given arity
             | List            -- ^ a free n-ary function symbol of TOP sort
-  deriving (Eq, Ord, Typeable, Data, Show)
+  deriving (Eq, Ord, Typeable, Data, Show, Generic, NFData, Binary)
 
 -- | Function signatures.
 type FunSig = Set FunSym
@@ -166,17 +169,3 @@ bpReducibleFunSig = S.fromList [ NoEq pmultSym, C EMap ]
 implicitFunSig :: FunSig
 implicitFunSig = S.fromList [ NoEq invSym, NoEq pairSym
                             , AC Mult, AC Union ]
-
-----------------------------------------------------------------------
--- Derived instances
-----------------------------------------------------------------------
-
-$( derive makeNFData ''Privacy)
-$( derive makeNFData ''CSym)
-$( derive makeNFData ''FunSym)
-$( derive makeNFData ''ACSym)
-
-$( derive makeBinary ''Privacy)
-$( derive makeBinary ''CSym)
-$( derive makeBinary ''FunSym)
-$( derive makeBinary ''ACSym)

--- a/lib/term/src/Term/Term/Raw.hs
+++ b/lib/term/src/Term/Term/Raw.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -38,14 +40,14 @@ module Term.Term.Raw (
 
     ) where
 
+import           GHC.Generics (Generic)
 import           Data.List
 -- import           Data.Monoid
 -- import           Data.Foldable (Foldable, foldMap)
 -- import           Data.Traversable
 import           Data.Typeable
-import           Data.Generics
-import           Data.DeriveTH
 import           Data.Binary
+import           Data.Data
 
 import           Control.DeepSeq
 -- import           Control.Basics
@@ -64,7 +66,7 @@ import           Term.Term.FunctionSymbols
 -- or 'viewTerm2' to inspect it.
 data Term a = LIT a                 -- ^ atomic terms (constants, variables, ..)
             | FAPP FunSym [Term a]  -- ^ function applications
-  deriving (Eq, Ord, Typeable, Data )
+  deriving (Eq, Ord, Typeable, Data, Generic, NFData, Binary )
 
 ----------------------------------------------------------------------
 -- Diff Type - whether left/right interpretation of diff is desired,
@@ -236,10 +238,3 @@ foldTerm fLIT fFAPP t = go t
 instance Sized a => Sized (Term a) where
     size = foldTerm size (const $ \xs -> sum xs + 1)
 
-----------------------------------------------------------------------
--- Derived Instances
-----------------------------------------------------------------------
-
-$( derive makeNFData ''Term )
-
-$( derive makeBinary ''Term )

--- a/lib/term/src/Term/VTerm.hs
+++ b/lib/term/src/Term/VTerm.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -32,10 +34,10 @@ module Term.VTerm (
 
 -- import Data.Foldable
 -- import Data.Traversable
+import GHC.Generics (Generic)
 import qualified Data.DList as D
 import Data.Typeable
-import Data.Generics
-import Data.DeriveTH
+import Data.Data
 import Data.Binary
 import Data.Monoid
 import Control.DeepSeq
@@ -53,7 +55,7 @@ import Term.Term
 
 -- | A Lit is either a constant or a variable. (@Const@ is taken by Control.Applicative)
 data Lit c v = Con c | Var v
-  deriving (Eq, Ord, Data, Typeable)
+  deriving (Eq, Ord, Data, Typeable, Generic, NFData, Binary)
 
 -- | A VTerm is a term with constants and variables
 type VTerm c v = Term (Lit c v)
@@ -140,9 +142,3 @@ termVar' :: (Show c, Show v) => VTerm c v -> v
 termVar' t =
     fromJustNote ("termVar': non-variable term " ++ show t) (termVar t)
 
-
--- Derived instances
---------------------
-
-$( derive makeNFData ''Lit)
-$( derive makeBinary ''Lit)

--- a/lib/term/tamarin-prover-term.cabal
+++ b/lib/term/tamarin-prover-term.cabal
@@ -47,7 +47,6 @@ library
       , bytestring
       , containers
       , deepseq
-      , derive
       , directory
       , dlist
       , mtl
@@ -56,6 +55,7 @@ library
       , safe
       , split
       , syb
+      , template-haskell
 
       , tamarin-prover-utils
 

--- a/lib/term/tamarin-prover-term.cabal
+++ b/lib/term/tamarin-prover-term.cabal
@@ -55,7 +55,6 @@ library
       , safe
       , split
       , syb
-      , template-haskell
 
       , tamarin-prover-utils
 

--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 -- FIXME: for functions prove
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveAnyClass       #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -179,8 +181,10 @@ module Theory (
 
 import           Prelude                             hiding (id, (.))
 
+import           GHC.Generics                        (Generic)
+
 import           Data.Binary
-import           Data.DeriveTH
+import           Data.Data
 -- import           Data.Foldable                       (Foldable, foldMap)
 import           Data.List
 import           Data.Maybe
@@ -253,7 +257,7 @@ data ClosedProtoRule = ClosedProtoRule
        { _cprRuleE  :: ProtoRuleE             -- original rule modulo E
        , _cprRuleAC :: ProtoRuleAC            -- variant modulo AC
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 type OpenRuleCache = [IntrRuleAC]
 
@@ -263,7 +267,7 @@ data ClosedRuleCache = ClosedRuleCache
        , _crcRefinedSources      :: [Source]
        , _crcInjectiveFactInsts  :: S.Set FactTag
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 
 $(mkLabels [''ClosedProtoRule, ''ClosedRuleCache])
@@ -378,7 +382,7 @@ data Restriction = Restriction
        { _rstrName    :: String
        , _rstrFormula :: LNFormula
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 $(mkLabels [''Restriction])
 
@@ -396,11 +400,11 @@ data LemmaAttribute =
        | LHSLemma
        | RHSLemma
 --        | BothLemma
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | A 'TraceQuantifier' stating whether we check satisfiability of validity.
 data TraceQuantifier = ExistsTrace | AllTraces
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | A lemma describes a property that holds in the context of a theory
 -- together with a proof of its correctness.
@@ -411,7 +415,7 @@ data Lemma p = Lemma
        , _lAttributes      :: [LemmaAttribute]
        , _lProof           :: p
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 $(mkLabels [''Lemma])
 
@@ -424,7 +428,7 @@ data DiffLemma p = DiffLemma
        , _lDiffAttributes      :: [LemmaAttribute]
        , _lDiffProof           :: p
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 $(mkLabels [''DiffLemma])
 
@@ -528,7 +532,7 @@ data TheoryItem r p =
      | LemmaItem (Lemma p)
      | RestrictionItem Restriction
      | TextItem FormalComment
-     deriving( Show, Eq, Ord, Functor )
+     deriving( Show, Eq, Ord, Functor, Generic, NFData, Binary )
 
 -- | A diff theory item built over the given rule type.
 --   This includes
@@ -543,7 +547,7 @@ data DiffTheoryItem r r2 p p2 =
      | EitherLemmaItem (Side, Lemma p2)
      | EitherRestrictionItem (Side, Restriction)
      | DiffTextItem FormalComment
-     deriving( Show, Eq, Ord, Functor )
+     deriving( Show, Eq, Ord, Functor, Generic, NFData, Binary )
 
 -- | A theory contains a single set of rewriting rules modeling a protocol
 -- and the lemmas that
@@ -553,7 +557,7 @@ data Theory sig c r p = Theory {
        , _thyCache     :: c
        , _thyItems     :: [TheoryItem r p]
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 $(mkLabels [''Theory])
 
@@ -568,7 +572,7 @@ data DiffTheory sig c r r2 p p2 = DiffTheory {
        , _diffThyDiffCacheRight :: c
        , _diffThyItems          :: [DiffTheoryItem r r2 p p2]
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
        
 $(mkLabels [''DiffTheory])
@@ -1941,31 +1945,4 @@ prettyTraceQuantifier :: Document d => TraceQuantifier -> d
 prettyTraceQuantifier ExistsTrace = text "exists-trace"
 prettyTraceQuantifier AllTraces   = text "all-traces"
 
-
--- Instances: FIXME: Sort them into the right files
---------------------------------------------------
-
-$( derive makeBinary ''TheoryItem)
-$( derive makeBinary ''DiffTheoryItem)
-$( derive makeBinary ''LemmaAttribute)
-$( derive makeBinary ''TraceQuantifier)
-$( derive makeBinary ''Restriction)
-$( derive makeBinary ''Lemma)
-$( derive makeBinary ''DiffLemma)
-$( derive makeBinary ''ClosedProtoRule)
-$( derive makeBinary ''ClosedRuleCache)
-$( derive makeBinary ''Theory)
-$( derive makeBinary ''DiffTheory)
-
-$( derive makeNFData ''TheoryItem)
-$( derive makeNFData ''DiffTheoryItem)
-$( derive makeNFData ''LemmaAttribute)
-$( derive makeNFData ''TraceQuantifier)
-$( derive makeNFData ''Restriction)
-$( derive makeNFData ''Lemma)
-$( derive makeNFData ''DiffLemma)
-$( derive makeNFData ''ClosedProtoRule)
-$( derive makeNFData ''ClosedRuleCache)
-$( derive makeNFData ''Theory)
-$( derive makeNFData ''DiffTheory)
-
+-- FIXME: Sort instances into the right files

--- a/lib/theory/src/Theory/Constraint/Solver/Contradictions.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Contradictions.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns    #-}
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE DeriveAnyClass  #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -25,9 +27,9 @@ module Theory.Constraint.Solver.Contradictions (
 
 import           Prelude                        hiding (id, (.))
 
+import           GHC.Generics                   (Generic)
 import           Data.Binary
 import qualified Data.DAG.Simple                as D (cyclic, reachableSet)
-import           Data.DeriveTH
 import qualified Data.Foldable                  as F
 import           Data.List
 import qualified Data.Map                       as M
@@ -74,7 +76,7 @@ data Contradiction =
   | FormulasFalse                  -- ^ False in formulas
   | SuperfluousLearn LNTerm NodeId -- ^ A term is derived both before and after a learn
   | NodeAfterLast (NodeId, NodeId) -- ^ There is a node after the last node.
-  deriving( Eq, Ord, Show )
+  deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 
 -- | 'True' if the constraint system is contradictory.
@@ -459,6 +461,3 @@ instance HasFrees Contradiction where
   mapFrees f (NonInjectiveFactInstance x) = NonInjectiveFactInstance <$> mapFrees f x
   mapFrees f (NodeAfterLast x)            = NodeAfterLast <$> mapFrees f x
   mapFrees _ c                            = pure c
-
-$( derive makeBinary ''Contradiction)
-$( derive makeNFData ''Contradiction)

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections   #-}
 {-# LANGUAGE ViewPatterns    #-}
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE DeriveAnyClass  #-}
 -- |
 -- Copyright   : (c) 2010-2012 Simon Meier & Benedikt Schmidt
 -- License     : GPL v3 (see LICENSE)
@@ -33,9 +35,8 @@ module Theory.Constraint.Solver.ProofMethod (
   , prettyDiffProofMethod
 
 ) where
-
+import           GHC.Generics                              (Generic)
 import           Data.Binary
-import           Data.DeriveTH
 import           Data.Function                             (on)
 import           Data.Label                                hiding (get)
 import qualified Data.Label                                as L
@@ -111,7 +112,7 @@ data ProofMethod =
   | Induction                            -- ^ Use inductive strengthening on
                                          -- the single formula constraint in
                                          -- the system.
-  deriving( Eq, Ord, Show )
+  deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Sound transformations of diff sequents.
 -- FIXME
@@ -123,7 +124,7 @@ data DiffProofMethod =
 --   | DiffTrivial                              -- ^ The rule is trivially sound - REMOVED and merged with solved!
   | DiffBackwardSearch                       -- ^ Do the backward search starting from a rule
   | DiffBackwardSearchStep ProofMethod       -- ^ A step in the backward search starting from a rule
-  deriving( Eq, Ord, Show )
+  deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
   
 instance HasFrees ProofMethod where
@@ -365,7 +366,7 @@ data GoalRanking =
   | SmartRanking Bool
   | SmartDiffRanking
   | InjRanking
-  deriving( Eq, Ord, Show )
+  deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | The name/explanation of a 'GoalRanking'.
 goalRankingName :: GoalRanking -> String
@@ -447,7 +448,7 @@ rankDiffProofMethods ranking ctxt sys = do
       Nothing    -> []
 
 newtype Heuristic = Heuristic [GoalRanking]
-    deriving( Eq, Ord, Show )
+    deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Smart constructor for heuristics. Schedules the goal rankings in a
 -- round-robin fashion dependent on the proof depth.
@@ -1312,17 +1313,4 @@ prettyDiffProofMethod method = case method of
     DiffRuleEquivalence      -> keyword_ "rule-equivalence"
     DiffBackwardSearch       -> keyword_ "backward-search"  
     DiffBackwardSearchStep s -> keyword_ "step(" <-> prettyProofMethod s <-> keyword_ ")"
-    
-    
--- Derived instances
---------------------
 
-$( derive makeBinary ''ProofMethod)
-$( derive makeBinary ''DiffProofMethod)
-$( derive makeBinary ''GoalRanking)
-$( derive makeBinary ''Heuristic)
-
-$( derive makeNFData ''ProofMethod)
-$( derive makeNFData ''DiffProofMethod)
-$( derive makeNFData ''GoalRanking)
-$( derive makeNFData ''Heuristic)

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -196,7 +196,6 @@ import           GHC.Generics                         (Generic)
 import           Data.Binary
 import qualified Data.ByteString.Char8                as BC
 import qualified Data.DAG.Simple                      as D
-import           Data.Data
 import           Data.List                            (foldl', partition, intersect)
 import qualified Data.Map                             as M
 import           Data.Maybe                           (fromMaybe)

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeOperators      #-}
 {-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -189,10 +191,12 @@ module Theory.Constraint.System (
 
 import           Prelude                              hiding (id, (.))
 
+import           GHC.Generics                         (Generic)
+
 import           Data.Binary
 import qualified Data.ByteString.Char8                as BC
 import qualified Data.DAG.Simple                      as D
-import           Data.DeriveTH
+import           Data.Data
 import           Data.List                            (foldl', partition, intersect)
 import qualified Data.Map                             as M
 import           Data.Maybe                           (fromMaybe)
@@ -225,7 +229,7 @@ data ClassifiedRules = ClassifiedRules
      , _crDestruct      :: [RuleAC] -- destruction rules
      , _crConstruct     :: [RuleAC] -- construction rules
      }
-     deriving( Eq, Ord, Show )
+     deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 $(mkLabels [''ClassifiedRules])
 
@@ -247,7 +251,7 @@ nonSilentRules = filter (not . null . L.get rActs) . joinAllRules
 ------------------------------------------------------------------------------
 
 -- | In the diff type, we have either the Left Hand Side or the Right Hand Side
-data Side = LHS | RHS deriving(Show, Eq, Ord, Read)
+data Side = LHS | RHS deriving ( Show, Eq, Ord, Read, Generic, NFData, Binary )
 
 opposite :: Side -> Side
 opposite LHS = RHS
@@ -257,12 +261,12 @@ opposite RHS = LHS
 -- current constraint system or whether we're checking that no traces
 -- satisfies the current constraint system.
 data SystemTraceQuantifier = ExistsSomeTrace | ExistsNoTrace
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Source kind that are allowed. The order of the kinds
 -- corresponds to the subkinding relation: raw < refined.
 data SourceKind = RawSource | RefinedSource
-       deriving( Eq )
+       deriving( Eq, Generic, NFData, Binary )
 
 instance Show SourceKind where
     show RawSource     = "raw"
@@ -298,7 +302,7 @@ data GoalStatus = GoalStatus
        -- True if this goal should be solved with care because it may lead to
        -- non-termination.
     }
-    deriving( Eq, Ord, Show )
+    deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | A constraint system.
 data System = System
@@ -318,7 +322,7 @@ data System = System
     -- NOTE: Don't forget to update 'substSystem' in
     -- "Constraint.Solver.Reduction" when adding further fields to the
     -- constraint system.
-    deriving( Eq, Ord )
+    deriving( Eq, Ord, Generic, NFData, Binary )
 
 $(mkLabels [''System, ''GoalStatus])
 
@@ -347,10 +351,10 @@ data Source = Source
        -- being the path of proof steps required to arrive at these cases
      , _cdCases    :: Disj ([String], System)
      }
-     deriving( Eq, Ord, Show )
+     deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 data InductionHint = UseInduction | AvoidInduction
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | A proof context contains the globally fresh facts, classified rewrite
 -- rules and the corresponding precomputed premise source theorems.
@@ -368,7 +372,7 @@ data ProofContext = ProofContext
        , _pcTrueSubterm        :: Bool -- true if in all rules the RHS is a subterm of the LHS
        , _pcConstantRHS        :: Bool -- true if there are rules with a constant RHS
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | A diff proof context contains the two proof contexts for either side
 -- and all rules.
@@ -409,7 +413,7 @@ instance HasFrees Source where
                                     <*> mapFrees f (L.get cdCases th)
 
 data DiffProofType = RuleEquivalence | None
-    deriving( Eq, Ord, Show )
+    deriving( Eq, Ord, Show, Generic, NFData, Binary )
     
 -- | A system used in diff proofs. 
 data DiffSystem = DiffSystem
@@ -423,7 +427,7 @@ data DiffSystem = DiffSystem
     , _dsDestrRules     :: S.Set RuleAC                     -- the descruction rules of the theory
     , _dsCurrentRule    :: Maybe String                     -- the name of the rule under consideration
     }
-    deriving( Eq, Ord )
+    deriving( Eq, Ord, Generic, NFData, Binary )
 
 $(mkLabels [''DiffSystem])
 
@@ -1297,32 +1301,3 @@ instance HasFrees System where
                <*> mapFrees fun j
                <*> mapFrees fun k
                <*> mapFrees fun l
-
--- NFData
----------
-
-$( derive makeBinary ''Source)
-$( derive makeBinary ''ClassifiedRules)
-$( derive makeBinary ''InductionHint)
-$( derive makeBinary ''ProofContext)
-
-$( derive makeBinary ''Side)
-$( derive makeBinary ''SourceKind)
-$( derive makeBinary ''GoalStatus)
-$( derive makeBinary ''DiffProofType)
-$( derive makeBinary ''System)
-$( derive makeBinary ''DiffSystem)
-$( derive makeBinary ''SystemTraceQuantifier)
-
-$( derive makeNFData ''Source)
-$( derive makeNFData ''ClassifiedRules)
-$( derive makeNFData ''InductionHint)
-$( derive makeNFData ''ProofContext)
-
-$( derive makeNFData ''Side)
-$( derive makeNFData ''SourceKind)
-$( derive makeNFData ''GoalStatus)
-$( derive makeNFData ''DiffProofType)
-$( derive makeNFData ''System)
-$( derive makeNFData ''DiffSystem)
-$( derive makeNFData ''SystemTraceQuantifier)

--- a/lib/theory/src/Theory/Constraint/System/Constraints.hs
+++ b/lib/theory/src/Theory/Constraint/System/Constraints.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -35,10 +37,9 @@ module Theory.Constraint.System.Constraints (
   , prettyLess
   , prettyGoal
   ) where
-
+import           GHC.Generics (Generic)
 import           Data.Binary
-import           Data.DeriveTH
-import           Data.Generics
+import           Data.Data
 -- import           Extension.Data.Monoid            (Monoid(..))
 
 -- import           Control.Basics
@@ -68,7 +69,7 @@ data Edge = Edge {
       eSrc :: NodeConc
     , eTgt :: NodePrem
     }
-  deriving (Show, Ord, Eq, Data, Typeable)
+  deriving (Show, Ord, Eq, Data, Typeable, Generic, NFData, Binary)
 
 -- | A *⋖* constraint between 'NodeId's.
 type Less = (NodeId, NodeId)
@@ -103,7 +104,7 @@ data Goal =
        -- ^ A case split over equalities.
      | DisjG (Disj LNGuarded)
        -- ^ A case split over a disjunction.
-     deriving( Eq, Ord, Show )
+     deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- Indicators
 -------------
@@ -207,11 +208,3 @@ prettyGoal (DisjG (Disj gfs)) = fsep $
 prettyGoal (SplitG x) =
     text "splitEqs" <> parens (text $ show (unSplitId x))
 
--- Derived instances
---------------------
-
-$( derive makeBinary ''Edge)
-$( derive makeBinary ''Goal)
-
-$( derive makeNFData ''Edge)
-$( derive makeNFData ''Goal)

--- a/lib/theory/src/Theory/Constraint/System/Guarded.hs
+++ b/lib/theory/src/Theory/Constraint/System/Guarded.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeSynonymInstances       #-}
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
 -- |
 -- Copyright   : (c) 2011 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -89,9 +90,9 @@ import qualified Control.Monad.Trans.PreciseFresh as Precise (Fresh, evalFresh, 
 
 import           Debug.Trace
 
+import           GHC.Generics                     (Generic)
 import           Data.Data
 import           Data.Binary
-import           Data.DeriveTH
 import           Data.Either                      (partitionEithers)
 -- import           Data.Foldable                    (Foldable(..), foldMap)
 import           Data.List
@@ -118,7 +119,11 @@ data Guarded s c v = GAto  (Atom (VTerm c (BVar v)))
                     -- depending on the 'Quantifier'.
                     -- We assume that all bound variables xs occur in
                     -- f@i atoms in as.
-                   deriving (Eq, Ord, Show)
+                   deriving (Eq, Ord, Show, Generic)
+
+instance (NFData s, NFData c, NFData v) => NFData (Guarded s c v)
+instance (Binary s, Binary c, Binary v) => Binary (Guarded s c v)
+
 
 isConjunction :: Guarded s c v -> Bool
 isConjunction (GConj _)  = True
@@ -834,10 +839,3 @@ prettyGuarded fm =
         ppVars      = fsep . map (text . show)
         ppQuant All = "∀"  -- "All "
         ppQuant Ex  = "∃"  -- "Ex "
-
-
--- Derived instances
---------------------
-
-$( derive makeBinary ''Guarded)
-$( derive makeNFData ''Guarded)

--- a/lib/theory/src/Theory/Model/Atom.hs
+++ b/lib/theory/src/Theory/Model/Atom.hs
@@ -6,6 +6,8 @@
 -- {-# LANGUAGE TupleSections        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ViewPatterns         #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveAnyClass       #-}
 -- {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
   -- spurious warnings for view patterns
@@ -40,10 +42,10 @@ where
 -- import           Control.Basics
 import           Control.DeepSeq
 
+import           GHC.Generics (Generic)
 import           Data.Binary
-import           Data.DeriveTH
 -- import           Data.Foldable      (Foldable, foldMap)
-import           Data.Generics
+import           Data.Data
 -- import           Data.Monoid        (mappend, mempty)
 -- import           Data.Traversable
 
@@ -63,7 +65,7 @@ data Atom t = Action   t (Fact t)
             | EqE  t t
             | Less t t
             | Last t
-            deriving( Eq, Ord, Show, Data, Typeable )
+            deriving( Eq, Ord, Show, Data, Typeable, Generic, NFData, Binary )
 
 -- | @LAtom@ are the atoms we actually use in graph formulas input by the user.
 type NAtom v = Atom (VTerm Name v)
@@ -148,10 +150,3 @@ prettyNAtom (EqE l r) =
     -- sep [prettyNTerm l <-> text "≈", prettyNTerm r]
 prettyNAtom (Less u v) = text (show u) <-> opLess <-> text (show v)
 prettyNAtom (Last i)   = operator_ "last" <> parens (text (show i))
-
-
--- derived instances
---------------------
-
-$( derive makeNFData ''Atom)
-$( derive makeBinary ''Atom)

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -380,14 +380,3 @@ prettyNFact = prettyFact prettyNTerm
 -- | Pretty print a 'LFact'.
 prettyLNFact :: Document d => LNFact -> d
 prettyLNFact fa = prettyFact prettyNTerm fa
-
--- derived instances
---------------------
-
-$( derive makeBinary ''Multiplicity)
-$( derive makeBinary ''FactTag)
-$( derive makeBinary ''Fact)
-
-$( derive makeNFData ''Multiplicity)
-$( derive makeNFData ''FactTag)
-$( derive makeNFData ''Fact)

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveAnyClass       #-}
 -- |
 -- Copyright   : (c) 2011, 2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -75,10 +77,10 @@ module Theory.Model.Fact (
 -- import           Control.Basics
 import           Control.DeepSeq
 
+import           GHC.Generics (Generic)
 import           Data.Binary
-import           Data.DeriveTH
 -- import           Data.Foldable          (Foldable(..))
-import           Data.Generics
+import           Data.Data
 import           Data.Maybe             (isJust)
 import           Data.Monoid
 -- import           Data.Traversable       (Traversable(..))
@@ -94,7 +96,7 @@ import           Text.PrettyPrint.Class
 ------------------------------------------------------------------------------
 
 data Multiplicity = Persistent | Linear
-                  deriving( Eq, Ord, Show, Typeable, Data )
+                  deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
 
 -- | Fact tags/symbols
 data FactTag = ProtoFact Multiplicity String Int
@@ -106,14 +108,14 @@ data FactTag = ProtoFact Multiplicity String Int
              | KDFact     -- ^ Down-knowledge fact in message deduction.
              | DedFact    -- ^ Log-fact denoting that the intruder deduced
                           -- a message using a construction rule.
-    deriving( Eq, Ord, Show, Typeable, Data )
+    deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
 
 -- | Facts.
 data Fact t = Fact
     { factTag   :: FactTag
     , factTerms :: [t]
     }
-    deriving( Eq, Ord, Show, Typeable, Data )
+    deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
 
 
 -- Instances

--- a/lib/theory/src/Theory/Model/Formula.hs
+++ b/lib/theory/src/Theory/Model/Formula.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ViewPatterns         #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveAnyClass       #-}
 -- |
 -- Copyright   : (c) 2010-2012 Simon Meier & Benedikt Schmidt
 -- License     : GPL v3 (see LICENSE)
@@ -48,10 +50,10 @@ module Theory.Model.Formula (
 
 import           Prelude                          hiding (negate)
 
+import           GHC.Generics (Generic)
 import           Data.Binary
-import           Data.DeriveTH
 -- import           Data.Foldable                    (Foldable, foldMap)
-import           Data.Generics
+import           Data.Data
 import           Data.Monoid                      hiding (All)
 -- import           Data.Traversable
 
@@ -74,11 +76,11 @@ import           Term.Substitution
 
 -- | Logical connectives.
 data Connective = And | Or | Imp | Iff
-                deriving( Eq, Ord, Show, Enum, Bounded, Data, Typeable )
+                deriving( Eq, Ord, Show, Enum, Bounded, Data, Typeable, Generic, NFData, Binary )
 
 -- | Quantifiers.
 data Quantifier = All | Ex
-                deriving( Eq, Ord, Show, Enum, Bounded, Data, Typeable )
+                deriving( Eq, Ord, Show, Enum, Bounded, Data, Typeable, Generic, NFData, Binary )
 
 
 -- | First-order formulas in locally nameless representation with hints for the
@@ -88,6 +90,7 @@ data Formula s c v = Ato (Atom (VTerm c (BVar v)))
                    | Not (Formula s c v)
                    | Conn !Connective (Formula s c v) (Formula s c v)
                    | Qua !Quantifier s (Formula s c v)
+                   deriving ( Generic, NFData, Binary )
 
 -- Folding
 ----------
@@ -312,15 +315,3 @@ prettyLFormula ppAtom =
 prettyLNFormula :: HighlightDocument d => LNFormula -> d
 prettyLNFormula fm =
     Precise.evalFresh (prettyLFormula prettyNAtom fm) (avoidPrecise fm)
-
-
--- Derived instances
---------------------
-
-$( derive makeBinary ''Connective)
-$( derive makeBinary ''Quantifier)
-$( derive makeBinary ''Formula)
-
-$( derive makeNFData ''Connective)
-$( derive makeNFData ''Quantifier)
-$( derive makeNFData ''Formula)

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -163,7 +162,10 @@ data Rule i = Rule {
        , _rConcs :: [LNFact]
        , _rActs  :: [LNFact]
        }
-       deriving( Eq, Ord, Show, Data, Typeable, Generic, NFData, Binary )
+       deriving( Eq, Ord, Show, Data, Typeable, Generic)
+
+instance NFData i => NFData (Rule i)
+instance Binary i => Binary (Rule i)
 
 $(mkLabels [''Rule])
 
@@ -232,7 +234,10 @@ instance Sized (Rule i) where
 data RuleInfo p i =
          ProtoInfo p
        | IntrInfo i
-       deriving( Eq, Ord, Show, Generic, NFData, Binary )
+       deriving( Eq, Ord, Show, Generic)
+
+instance (NFData i, NFData p) => NFData (RuleInfo p i)
+instance (Binary i, Binary p) => Binary (RuleInfo p i)
 
 -- | @ruleInfo proto intr@ maps the protocol information with @proto@ and the
 -- intruder information with @intr@.
@@ -263,7 +268,10 @@ instance (Apply p, Apply i) => Apply (RuleInfo p i) where
 data ProtoRuleName =
          FreshRule
        | StandRule String -- ^ Some standard protocol rule
-       deriving( Eq, Ord, Show, Data, Typeable, Generic, NFData, Binary )
+       deriving( Eq, Ord, Show, Data, Typeable, Generic)
+
+instance NFData ProtoRuleName
+instance Binary ProtoRuleName
 
 
 -- | Information for protocol rules modulo AC. The variants list the possible
@@ -274,14 +282,18 @@ data ProtoRuleACInfo = ProtoRuleACInfo
        , _pracVariants     :: Disj (LNSubstVFresh)
        , _pracLoopBreakers :: [PremIdx]
        }
-       deriving( Eq, Ord, Show, Generic, NFData, Binary )
+       deriving( Eq, Ord, Show, Generic)
+instance NFData ProtoRuleACInfo
+instance Binary ProtoRuleACInfo
 
 -- | Information for instances of protocol rules modulo AC.
 data ProtoRuleACInstInfo = ProtoRuleACInstInfo
        { _praciName         :: ProtoRuleName
        , _praciLoopBreakers :: [PremIdx]
        }
-       deriving( Eq, Ord, Show, Generic, NFData, Binary )
+       deriving( Eq, Ord, Show, Generic)
+instance NFData ProtoRuleACInstInfo
+instance Binary ProtoRuleACInstInfo
 
 
 $(mkLabels [''ProtoRuleACInfo, ''ProtoRuleACInstInfo])
@@ -352,7 +364,9 @@ data IntrRuleACInfo =
   | PubConstrRule
   | FreshConstrRule
   | IEqualityRule -- Necessary for diff
-  deriving( Ord, Eq, Show, Data, Typeable, Generic, NFData, Binary )
+  deriving( Ord, Eq, Show, Data, Typeable, Generic)
+instance NFData IntrRuleACInfo
+instance Binary IntrRuleACInfo
 
 -- | An intruder rule modulo AC.
 type IntrRuleAC = Rule IntrRuleACInfo

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -119,11 +121,11 @@ module Theory.Model.Rule (
 
 import           Prelude              hiding (id, (.))
 
+import           GHC.Generics (Generic)
 import           Data.Binary
 import qualified Data.ByteString.Char8 as BC
-import           Data.DeriveTH
 -- import           Data.Foldable        (foldMap)
-import           Data.Generics
+import           Data.Data
 import           Data.List
 import qualified Data.Set              as S
 import qualified Data.Map              as M
@@ -161,7 +163,7 @@ data Rule i = Rule {
        , _rConcs :: [LNFact]
        , _rActs  :: [LNFact]
        }
-       deriving( Eq, Ord, Show, Data, Typeable )
+       deriving( Eq, Ord, Show, Data, Typeable, Generic, NFData, Binary )
 
 $(mkLabels [''Rule])
 
@@ -230,7 +232,7 @@ instance Sized (Rule i) where
 data RuleInfo p i =
          ProtoInfo p
        | IntrInfo i
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | @ruleInfo proto intr@ maps the protocol information with @proto@ and the
 -- intruder information with @intr@.
@@ -261,7 +263,7 @@ instance (Apply p, Apply i) => Apply (RuleInfo p i) where
 data ProtoRuleName =
          FreshRule
        | StandRule String -- ^ Some standard protocol rule
-       deriving( Eq, Ord, Show, Data, Typeable )
+       deriving( Eq, Ord, Show, Data, Typeable, Generic, NFData, Binary )
 
 
 -- | Information for protocol rules modulo AC. The variants list the possible
@@ -272,14 +274,14 @@ data ProtoRuleACInfo = ProtoRuleACInfo
        , _pracVariants     :: Disj (LNSubstVFresh)
        , _pracLoopBreakers :: [PremIdx]
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Information for instances of protocol rules modulo AC.
 data ProtoRuleACInstInfo = ProtoRuleACInstInfo
        { _praciName         :: ProtoRuleName
        , _praciLoopBreakers :: [PremIdx]
        }
-       deriving( Eq, Ord, Show )
+       deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 
 $(mkLabels [''ProtoRuleACInfo, ''ProtoRuleACInstInfo])
@@ -350,7 +352,7 @@ data IntrRuleACInfo =
   | PubConstrRule
   | FreshConstrRule
   | IEqualityRule -- Necessary for diff
-  deriving( Ord, Eq, Show, Data, Typeable )
+  deriving( Ord, Eq, Show, Data, Typeable, Generic, NFData, Binary )
 
 -- | An intruder rule modulo AC.
 type IntrRuleAC = Rule IntrRuleACInfo
@@ -893,20 +895,3 @@ prettyProtoRuleAC = prettyNamedRule (kwRuleModulo "AC") prettyProtoRuleACInfo
 
 prettyRuleACInst :: HighlightDocument d => RuleACInst -> d
 prettyRuleACInst = prettyNamedRule (kwInstanceModulo "AC") (const emptyDoc)
-
--- derived instances
---------------------
-
-$( derive makeBinary ''Rule)
-$( derive makeBinary ''ProtoRuleName)
-$( derive makeBinary ''ProtoRuleACInfo)
-$( derive makeBinary ''ProtoRuleACInstInfo)
-$( derive makeBinary ''RuleInfo)
-$( derive makeBinary ''IntrRuleACInfo)
-
-$( derive makeNFData ''Rule)
-$( derive makeNFData ''ProtoRuleName)
-$( derive makeNFData ''ProtoRuleACInfo)
-$( derive makeNFData ''ProtoRuleACInstInfo)
-$( derive makeNFData ''RuleInfo)
-$( derive makeNFData ''IntrRuleACInfo)

--- a/lib/theory/src/Theory/Tools/EquationStore.hs
+++ b/lib/theory/src/Theory/Tools/EquationStore.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -50,6 +51,7 @@ module Theory.Tools.EquationStore (
   , prettyEqStore
 ) where
 
+import           GHC.Generics          (Generic)
 import           Logic.Connectives
 import           Term.Unification
 import           Theory.Text.Pretty
@@ -68,7 +70,7 @@ import           Control.Monad.State   hiding (get, modify, put)
 import qualified Control.Monad.State   as MS
 
 import           Data.Binary
-import           Data.DeriveTH
+import           Data.Data
 import qualified Data.Foldable         as F
 import           Data.List          (delete,find,intersect,intersperse,nub,(\\))
 import           Data.Maybe
@@ -115,7 +117,10 @@ data EqStore = EqStore {
     , _eqsConj        :: Conj (SplitId, S.Set LNSubstVFresh)
     , _eqsNextSplitId :: SplitId
     }
-  deriving( Eq, Ord )
+  deriving( Eq, Ord, Generic )
+
+instance NFData EqStore
+instance Binary EqStore
 
 $(mkLabels [''EqStore])
 
@@ -582,6 +587,3 @@ prettyEqStore eqs@(EqStore substFree (Conj disjs) _nextSplitId) = vcat $
 
 instance Show EqStore where
     show = render . prettyEqStore
-
-$( derive makeBinary ''EqStore)
-$( derive makeNFData ''EqStore)

--- a/lib/theory/tamarin-prover-theory.cabal
+++ b/lib/theory/tamarin-prover-theory.cabal
@@ -47,7 +47,6 @@ library
       , cmdargs
       , containers
       , deepseq
-      , derive
       , directory
       , dlist
       , fclabels

--- a/src/Web/Instances.hs
+++ b/src/Web/Instances.hs
@@ -8,26 +8,18 @@ Stability   :  experimental
 Portability :  non-portable
 -}
 
-{-# LANGUAGE TemplateHaskell, GADTs, CPP #-}
+{-# LANGUAGE TemplateHaskell, GADTs, CPP, DeriveGeneric #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Web.Instances where
 
+import           GHC.Generics (Generic)
 import           Data.Binary
-import           Data.DeriveTH
+import           Data.Binary.Orphans
+import           Data.Data
 
-import           Control.DeepSeq
 import           Data.Time.Calendar
 import           Data.Time.LocalTime
 import           Web.Types
-
-$( derive makeBinary ''TheoryOrigin)
-$( derive makeBinary ''TheoryInfo)
-$( derive makeBinary ''DiffTheoryInfo)
-$( derive makeBinary ''EitherTheoryInfo)
-
-$( derive makeBinary ''TimeZone)
-$( derive makeBinary ''Day)
-$( derive makeBinary ''TimeOfDay)
 
 -- | Needed for GHC < 8.0
 #if __GLASGOW_HASKELL__ < 800
@@ -39,8 +31,3 @@ instance HasResolution a => Binary (Fixed a) where
     -- round to seconds for now
     return . fromInteger . read $ takeWhile (/='.') s
 #endif
-
-$( derive makeBinary ''LocalTime)
-$( derive makeBinary ''ZonedTime)
-
-$( derive makeNFData ''TheoryOrigin)

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,6 @@ packages:
 - lib/term/
 - lib/utils/
 extra-deps: []
-resolver: lts-7.18
+resolver: lts-8.2
 # for GHC 7.10 use:
 # lts-6.27

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >= 1.2
+cabal-version:      >= 1.10
 build-type:         Simple
 name:               tamarin-prover
 version:            1.3.0
@@ -136,7 +136,6 @@ executable tamarin-prover
       , conduit
       , containers
       , deepseq
-      , derive
       , directory
       , dlist
       , fclabels

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -128,6 +128,7 @@ executable tamarin-prover
       , array
       , base
       , binary
+      , binary-orphans
       , blaze-builder
       , blaze-html
       , bytestring


### PR DESCRIPTION
Newer stack has a newer GHC version which fixes a compiler issue when using very long paths (as in the homebrew build environment).

Could someone who knows more about the $( derive ) template haskell stuff ensure that this is sane? I have tested it against old files and it works correctly, but I'm worried there is some additional magic incantation that derive was doing previously.