### PR TITLE
Heuristic ranking parameter passed through correctly now

### DIFF
--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -346,12 +346,14 @@ constructAutoDiffProver as =
 
     ranking 's' = SmartRanking False
     ranking 'S' = SmartRanking True
+    ranking 'o' = OracleRanking
     ranking 'c' = UsefulGoalNrRanking
     ranking 'C' = GoalNrRanking
     ranking r   = error $ render $ fsep $ map text $ words $
       "Unknown goal ranking '" ++ [r] ++ "'. Use one of the following:\
       \ 's' for the smart ranking without loop breakers,\
       \ 'S' for the smart ranking with loop breakers,\
+      \ 'o' for oracle ranking,\
       \ 'c' for the creation order and useful goals first,\
       \ and 'C' for the creation order."
 


### PR DESCRIPTION
The oracle ranking heuristic selection was not passed to the diff mode, so that oracle ranking could not be combined with diff. Now it can.
