### PR TITLE
Print partial deconstructions in case listing

### DIFF
--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -730,13 +730,15 @@ htmlSource renderUrl tidx kind (j, th) =
       ]
     ppCase (i, (names, se)) =
       [ withTag "h3" [] $ fsep [ text "Source", int i, text "of", nCases
-                               , text " / named ", doubleQuotes (text name) ]
+                               , text " / named ", doubleQuotes (text name),
+                                 if isPartial then text "(partial deconstructions)" else text "" ]
       , refDotPath renderUrl tidx (TheorySource kind j i)
       , withTag "p" [] $ ppPrem
       , wrapP $ prettyNonGraphSystem se
       ]
       where
         name = intercalate "_" names
+        isPartial = not $ null $ unsolvedChains se
 
 -- | A Html document representing the requires case splitting theorem.
 htmlSourceDiff :: HtmlDocument d


### PR DESCRIPTION
This puts some searchable text in the case listing when a case has partial deconstructions so that they're easier to find with cmd/ctrl + f. 