### PR TITLE
Show git hash, branch and compile time in version

### DIFF
--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -6,6 +6,9 @@
 -- Portability : GHC only
 --
 -- Support for interaction with the console: argument parsing.
+
+{-# LANGUAGE TemplateHaskell #-}
+
 module Main.Console (
 
     defaultMain
@@ -44,6 +47,7 @@ module Main.Console (
 
 import           Data.Maybe
 import           Data.Version                    (showVersion)
+import           Data.Time
 import           Safe
 
 import           Control.Monad
@@ -55,6 +59,9 @@ import           System.Exit
 import qualified Text.PrettyPrint.Class          as PP
 
 import           Paths_tamarin_prover (version)
+
+import           Language.Haskell.TH
+import           Development.GitRev
 
 ------------------------------------------------------------------------------
 -- Static constants for the tamarin-prover
@@ -72,6 +79,19 @@ versionStr = unlines
     , " "
     , showVersion version
     , ", (C) Benedikt Schmidt, Simon Meier, Jannik Dreier, Ralf Sasse, ETH Zurich 2010-2015"
+    ]
+  , concat
+    [ "Git revision: "
+    , $(gitHash)
+    , case $(gitDirty) of
+          True  -> " (with uncommited changes)"
+          False -> ""
+    , ", branch: "
+    , $(gitBranch)
+    ]
+  , concat
+    [ "Compiled at: "
+    , $(stringE =<< runIO (show `fmap` Data.Time.getCurrentTime))
     ]
   , ""
   , "This program comes with ABSOLUTELY NO WARRANTY. It is free software, and you"

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -139,6 +139,7 @@ executable tamarin-prover
       , fclabels
       , file-embed
       , filepath
+      , gitrev
       , http-types
       , lifted-base
       , mtl
@@ -146,6 +147,7 @@ executable tamarin-prover
       , resourcet
       , safe
       , shakespeare
+      , template-haskell
       , text
       , threads
       , time


### PR DESCRIPTION
When using the command line switch --version, tamarin-prover
currently only displays the version number. During development
of tamarin, displaying more detailed information such as the git
hash and branch would be useful to enable faster checking of what
version was used during testing.

This commit includes two new cabal dependencies (gitrev and
template-haskell). The former is not strictly necessary and the
commit could be rewritten to extract the git metadata manually -
but I believe using it improves the supportability of such a minor
feature.