### PR TITLE
Request for comments: rule colouring support

### DIFF
--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -884,7 +884,7 @@ openDiffTheory  (DiffTheory n sig c1 c2 c3 c4 items) =
 -- | Find the open protocol rule with the given name.
 lookupOpenProtoRule :: ProtoRuleName -> OpenTheory -> Maybe OpenProtoRule
 lookupOpenProtoRule name =
-    find ((name ==) . L.get rInfo) . theoryRules
+    find ((name ==) . L.get (preName . rInfo)) . theoryRules
 
 -- | Find the open protocol rule with the given name.
 -- REMOVE
@@ -895,7 +895,7 @@ lookupOpenProtoRule name =
 -- | Find the open protocol rule with the given name.
 lookupOpenDiffProtoDiffRule :: ProtoRuleName -> OpenDiffTheory -> Maybe OpenProtoRule
 lookupOpenDiffProtoDiffRule name =
-    find ((name ==) . L.get rInfo) . diffTheoryDiffRules
+    find ((name ==) . L.get (preName . rInfo)) . diffTheoryDiffRules
 
 -- | Add a new protocol rules. Fails, if a protocol rule with the same name
 -- exists.
@@ -905,7 +905,7 @@ addProtoRule ruE thy = do
     return $ modify thyItems (++ [RuleItem ruE]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True ((ruE ==)) $ lookupOpenProtoRule (L.get rInfo ruE) thy
+        maybe True ((ruE ==)) $ lookupOpenProtoRule (L.get (preName . rInfo) ruE) thy
 
 -- | Add a new protocol rules. Fails, if a protocol rule with the same name
 -- exists.
@@ -915,7 +915,7 @@ addProtoDiffRule ruE thy = do
     return $ modify diffThyItems (++ [DiffRuleItem ruE]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True ((ruE ==)) $ lookupOpenDiffProtoDiffRule (L.get rInfo ruE) thy
+        maybe True ((ruE ==)) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo) ruE) thy
 
 -- | Add intruder proof rules.
 addIntrRuleACs :: [IntrRuleAC] -> OpenTheory -> OpenTheory

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -226,7 +226,7 @@ labelNodeId = \i rules parent -> do
                                     [kuFact m] [inFact m] [kLogFact m]
 
 
-    mkFreshRuleAC m = Rule (ProtoInfo (ProtoRuleACInstInfo FreshRule []))
+    mkFreshRuleAC m = Rule (ProtoInfo (ProtoRuleACInstInfo FreshRule [] []))
                            [] [freshFact m] []
 
     exploitPrems i ru = mapM_ (exploitPrem i ru) (enumPrems ru)

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -331,7 +331,8 @@ dotNodeCompact boringStyle v = dotOnce dsNodes v $ do
       Just ru -> do
           let color     = M.lookup (get rInfo ru) colorMap
               nodeColor = maybe "white" rgbToHex color
-              attrs     = [("fillcolor", nodeColor),("style","filled")]
+              attrs     = [("fillcolor", nodeColor),("style","filled")
+                            , ("fontcolor", if colorUsesWhiteFont color then "white" else "black")]
           ids <- mkNode ru attrs hasOutgoingEdge
           let prems = [ ((v, i), nid) | (Just (Left i),  nid) <- ids ]
               concs = [ ((v, i), nid) | (Just (Right i), nid) <- ids ]
@@ -339,6 +340,10 @@ dotNodeCompact boringStyle v = dotOnce dsNodes v $ do
           modM dsConcs $ M.union $ M.fromList concs
           return $ fromJust $ lookup Nothing ids
   where
+    --True if there's a colour, and it's 'darker' than 0.5 in apparent luminosity
+    --This assumes a linear colourspace, which is what graphviz seems to use
+    colorUsesWhiteFont (Just (RGB r g b)) = (0.2126*r + 0.7152*g + 0.0722*b) < 0.5
+    colorUsesWhiteFont _                  = False
 
     mkSimpleNode lbl attrs =
         liftDot $ D.node $ [("label", lbl),("shape","ellipse")] ++ attrs

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -21,7 +21,7 @@ import           Data.Char                (isSpace)
 import           Data.Color
 import qualified Data.DAG.Simple          as D
 import qualified Data.Foldable            as F
-import           Data.List                (find,foldl',intersect,uncons,(\\))
+import           Data.List                (find,foldl',intersect)
 import qualified Data.Map                 as M
 import           Data.Maybe
 import           Data.Monoid              (Any(..))
@@ -273,7 +273,7 @@ setDefaultAttributes = do
 nodeColorMap :: [RuleACInst] -> NodeColorMap
 nodeColorMap rules =
     M.fromList $
-      [ (get rInfo ru, case getColorAction ru of
+      [ (get rInfo ru, case getColorAttr ru of
             Just ruColor -> ruColor
             Nothing      -> hsvToRGB $ getColor (gIdx, mIdx))
       | (gIdx, grp) <- groups, (mIdx, ru) <- zip [0..] grp ]
@@ -292,16 +292,14 @@ nodeColorMap rules =
     colors = M.fromList $ lightColorGroups intruderHue (map (length . snd) groups)
     getColor idx = fromMaybe (HSV 0 1 1) $ M.lookup idx colors
 
-    -- Setting colour based on the first __color fact in the rule actions
-    getColorAction ru = do
-        fa    <- find (isColorTag . factTag) $ get rActs ru
-        (x,_) <- uncons $ getFactTerms fa
-        hexToRGB (show x \\ "''")
+    -- Setting colour based on the first colour attribute in the rule attributes
+    getColorAttr ru = do
+        c  <- firstColorAttr $ ruleAttributes ru
+        hexToRGB c
       where
-        isColorTag tag = case showFactTag tag of
-            "__color"  -> True
-            "__colour" -> True
-            _          -> False
+        firstColorAttr []                   = Nothing
+        firstColorAttr ((RuleColor c) : _)  = Just c
+        firstColorAttr (_ : xs)             = firstColorAttr xs
 
     -- The hue of the intruder rules
     intruderHue :: Rational
@@ -369,7 +367,7 @@ dotNodeCompact boringStyle v = dotOnce dsNodes v $ do
         ruleLabel =
             prettyNodeId v <-> colon <-> text (showRuleCaseName ru) <>
             (brackets $ vcat $ punctuate comma $
-                map prettyLNFact $ filter (not . isHiddenFact) $ get rActs ru)
+                map prettyLNFact $ get rActs ru)
 
         renderRow annDocs =
           zipWith (\(ann, _) lbl -> (ann, lbl)) annDocs $

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -273,9 +273,9 @@ setDefaultAttributes = do
 nodeColorMap :: [RuleACInst] -> NodeColorMap
 nodeColorMap rules =
     M.fromList $
-      [ (get rInfo ru, case getColorAttr ru of
-            Just ruColor -> ruColor
-            Nothing      -> hsvToRGB $ getColor (gIdx, mIdx))
+      [ (get rInfo ru, case find colorAttr $ ruleAttributes ru of
+            Just (RuleColor c)  -> c
+            Nothing             -> hsvToRGB $ getColor (gIdx, mIdx))
       | (gIdx, grp) <- groups, (mIdx, ru) <- zip [0..] grp ]
   where
     groupIdx ru | isDestrRule ru                   = 0
@@ -292,14 +292,11 @@ nodeColorMap rules =
     colors = M.fromList $ lightColorGroups intruderHue (map (length . snd) groups)
     getColor idx = fromMaybe (HSV 0 1 1) $ M.lookup idx colors
 
-    -- Setting colour based on the first colour attribute in the rule attributes
-    getColorAttr ru = do
-        c  <- firstColorAttr $ ruleAttributes ru
-        hexToRGB c
-      where
-        firstColorAttr []                   = Nothing
-        firstColorAttr ((RuleColor c) : _)  = Just c
-        firstColorAttr (_ : xs)             = firstColorAttr xs
+-- Note: Currently RuleColors are the only Rule Attributes, so the second line is
+-- commented out to remove the redundant pattern compiler warning. If more are added,
+-- the second line can be uncommented.
+    colorAttr (RuleColor _) = True
+--    colorAttr _             = False
 
     -- The hue of the intruder rules
     intruderHue :: Rational

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -50,8 +50,6 @@ module Theory.Model.Fact (
   , isKUFact
   , isKDFact
 
-  , isHiddenFact
-
   -- ** Construction
   , freshFact
   , outFact
@@ -188,14 +186,6 @@ isKUFact _               = False
 isKDFact :: LNFact -> Bool
 isKDFact (Fact KDFact _) = True
 isKDFact _               = False
-
--- | True if the the fact name should be hidden in the UI
--- (e.g. for color annotations)
-isHiddenFact :: Fact t -> Bool
-isHiddenFact (Fact (ProtoFact _ name _) _) = case name of
-    '_':'_':_ -> True
-    _         -> False
-isHiddenFact _ = False
 
 -- | Mark a fact as malformed.
 errMalformed :: String -> LNFact -> a

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -50,6 +50,8 @@ module Theory.Model.Fact (
   , isKUFact
   , isKDFact
 
+  , isHiddenFact
+
   -- ** Construction
   , freshFact
   , outFact
@@ -186,6 +188,14 @@ isKUFact _               = False
 isKDFact :: LNFact -> Bool
 isKDFact (Fact KDFact _) = True
 isKDFact _               = False
+
+-- | True if the the fact name should be hidden in the UI
+-- (e.g. for color annotations)
+isHiddenFact :: Fact t -> Bool
+isHiddenFact (Fact (ProtoFact _ name _) _) = case name of
+    '_':'_':_ -> True
+    _         -> False
+isHiddenFact _ = False
 
 -- | Mark a fact as malformed.
 errMalformed :: String -> LNFact -> a

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -877,7 +877,7 @@ prettyNamedRule prefix ppInfo ru =
                 , nest 1 $ ppFactsList rConcs]) $-$
     nest 2 (ppInfo $ L.get rInfo ru)
   where
-    acts             = filter isNotDiffAnnotation (L.get rActs ru)
+    acts             = filter isNotDiffAnnotation $ filter (not . isHiddenFact) (L.get rActs ru)
     ppList pp        = fsep . punctuate comma . map pp
     ppFacts' list    = ppList prettyLNFact list
     ppFacts proj     = ppList prettyLNFact $ L.get proj ru

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -139,6 +139,7 @@ import qualified Data.Set              as S
 import qualified Data.Map              as M
 import           Data.Monoid
 import           Data.Maybe            (fromMaybe)
+import           Data.Color
 import           Safe
 
 -- import           Control.Basics
@@ -272,10 +273,9 @@ instance (Apply p, Apply i) => Apply (RuleInfo p i) where
 -- Protocol Rule Information
 ------------------------------------------------------------------------------
 
--- | An attribute for a 'Lemma'.
-data RuleAttribute =
-         RuleColor String
-       deriving( Eq, Ord, Show, Data, Generic )
+-- | An attribute for a Rule, which does not affect the semantics.
+data RuleAttribute = RuleColor (RGB Rational)
+       deriving( Eq, Ord, Show, Data, Generic)
 instance NFData RuleAttribute
 instance Binary RuleAttribute
 
@@ -921,7 +921,7 @@ prettyRuleName = ruleInfo prettyProtoRuleName prettyIntrRuleACInfo . ruleName
 
 prettyRuleAttribute :: (HighlightDocument d) => RuleAttribute -> d
 prettyRuleAttribute attr = case attr of
-    RuleColor c -> text "color=" <> text c
+    RuleColor c -> text "color=" <> text (rgbToHex c)
 
 -- | Pretty print the rule name such that it can be used as a case name
 showRuleCaseName :: HasRuleName (Rule i) => Rule i -> String

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -29,6 +29,7 @@ import qualified Data.Set                   as S
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as TE
 import qualified Data.List                  as L
+import           Data.Color
 
 import           Control.Applicative        hiding (empty, many, optional)
 import           Control.Category
@@ -284,9 +285,15 @@ typeAssertions = fmap TypingE $
 -- | Parse a 'RuleAttribute'.
 ruleAttribute :: Parser RuleAttribute
 ruleAttribute = asum
-  [ symbol "colour=" *> (RuleColor <$> identifier)
-  , symbol "color="  *> (RuleColor <$> identifier)
-  ]
+    [ symbol "colour=" *> (RuleColor <$> parseColor)
+    , symbol "color="  *> (RuleColor <$> parseColor)
+    ]
+  where
+    parseColor = do
+        hc <- hexColor
+        case hexToRGB hc of
+            Just rgb  -> return rgb
+            Nothing -> fail $ "Color could not be parsed to RGB"
 
 -- | Parse RuleInfo
 protoRuleInfo :: Parser ProtoRuleEInfo

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -235,7 +235,6 @@ fact plit = try (
        case i of
          []                -> fail "empty identifier"
          (c:_) | isUpper c -> return ()
-               | c == '_'  -> return ()
                | otherwise -> fail "facts must start with upper-case letters"
        ts    <- parens (commaSep (multterm plit))
        mkProtoFact multi i ts
@@ -291,9 +290,9 @@ ruleAttribute = asum
 
 -- | Parse RuleInfo
 protoRuleInfo :: Parser ProtoRuleEInfo
-protoRuleInfo = ProtoRuleEInfo <$> (StandRule <$> 
+protoRuleInfo = (ProtoRuleEInfo <$> (StandRule <$>
                                         (symbol "rule" *> optional moduloE *> identifier))
-                               <*> (option [] $ list ruleAttribute) <*  colon
+                               <*> (option [] $ list ruleAttribute)) <*  colon
 
 -- | Parse a protocol rule. For the special rules 'Reveal_fresh', 'Fresh',
 -- 'Knows', and 'Learn' no rule is returned as the default theory already

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -235,6 +235,7 @@ fact plit = try (
        case i of
          []                -> fail "empty identifier"
          (c:_) | isUpper c -> return ()
+               | c == '_'  -> return ()
                | otherwise -> fail "facts must start with upper-case letters"
        ts    <- parens (commaSep (multterm plit))
        mkProtoFact multi i ts

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -25,6 +25,8 @@ module Theory.Text.Parser.Token (
   , identifier
   , indexedIdentifier
 
+  , hexColor
+
   , freshName
   , pubName
 
@@ -248,6 +250,10 @@ indexedIdentifier :: Parser (String, Integer)
 indexedIdentifier = do
     (,) <$> identifier
         <*> option 0 (try (dot *> (fromIntegral <$> natural)))
+
+-- | Parse a hex RGB color code
+hexColor :: Parser String
+hexColor = optional (symbol "'") *> optional (symbol "#") *> identifier <* optional (symbol "'")
 
 -- | Parse a logical variable with the given sorts allowed.
 sortedLVar :: [LSort] -> Parser LVar

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -118,7 +118,7 @@ spthy =
       , T.commentEnd     = "*/"
       , T.commentLine    = "//"
       , T.nestedComments = True
-      , T.identStart     = alphaNum
+      , T.identStart     = alphaNum <|> oneOf "_"
       , T.identLetter    = alphaNum <|> oneOf "_"
       , T.reservedNames  = ["in","let","rule","diff"]
       , T.opStart        = oneOf ":!$%&*+./<=>?@\\^|-"

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -118,7 +118,7 @@ spthy =
       , T.commentEnd     = "*/"
       , T.commentLine    = "//"
       , T.nestedComments = True
-      , T.identStart     = alphaNum <|> oneOf "_"
+      , T.identStart     = alphaNum
       , T.identLetter    = alphaNum <|> oneOf "_"
       , T.reservedNames  = ["in","let","rule","diff"]
       , T.opStart        = oneOf ":!$%&*+./<=>?@\\^|-"

--- a/lib/theory/src/Theory/Tools/RuleVariants.hs
+++ b/lib/theory/src/Theory/Tools/RuleVariants.hs
@@ -58,7 +58,7 @@ tmpdir = "/tmp/tamarin/"
 --      to obtain DNF of equations.
 --   4. Simplify rule.
 variantsProtoRule :: MaudeHandle -> ProtoRuleE -> ProtoRuleAC
-variantsProtoRule hnd ru@(Rule ri prems0 concs0 acts0) =
+variantsProtoRule hnd ru@(Rule (ProtoRuleEInfo na attr) prems0 concs0 acts0) =
     -- rename rule to decrease variable indices
     (`Precise.evalFresh` Precise.nothingUsed) . renamePrecise  $ convertRule `evalFreshAvoiding` ru
   where
@@ -106,7 +106,7 @@ variantsProtoRule hnd ru@(Rule ri prems0 concs0 acts0) =
             getHint _                         = "z"
 
     makeRule (ps, cs, as) subst freshSubsts0 =
-        Rule (ProtoRuleACInfo ri (Disj freshSubsts) []) prems concs acts
+        Rule (ProtoRuleACInfo na attr (Disj freshSubsts) []) prems concs acts
       where prems = apply subst ps
             concs = apply subst cs
             acts  = apply subst as

--- a/lib/utils/src/Data/Color.hs
+++ b/lib/utils/src/Data/Color.hs
@@ -207,7 +207,7 @@ genColorGroups (ColorParams {
 
 -- | A good default style for the 'genColorGroups' color palette function. The
 -- parameter shifts the hue for the first group.
-colorGroupStyle :: Double -> ColorParams Double
+colorGroupStyle :: RealFrac t => t -> ColorParams t
 colorGroupStyle zeroHue = ColorParams {
     cpScale   = 0.6
   , cpZeroHue = zeroHue
@@ -217,13 +217,13 @@ colorGroupStyle zeroHue = ColorParams {
 
 -- | Build color groups according to the list of group sizes using the default
 -- 'colorGroupStyle' for the function 'genColorGroups'.
-colorGroups :: Double -> [Int] -> [((Int, Int), HSV Double)]
+colorGroups :: RealFrac t => t -> [Int] -> [((Int, Int), HSV t)]
 colorGroups zeroHue = genColorGroups (colorGroupStyle zeroHue)
 
 
 -- | A good light color style for the @genColorGroups@ color palette
 -- function. The parameter shifts the hue for the first group.
-lightColorGroupStyle :: Double -> ColorParams Double
+lightColorGroupStyle :: RealFrac t => t -> ColorParams t
 lightColorGroupStyle zeroHue = ColorParams {
     cpScale   = 0.6
   , cpZeroHue = zeroHue
@@ -234,7 +234,7 @@ lightColorGroupStyle zeroHue = ColorParams {
 -- | Build color groups according to the list of group sizes using the
 -- default light 'lightColorGroupStyle' for the function
 -- 'genColorGroups'.
-lightColorGroups :: Double -> [Int] -> [((Int, Int), HSV Double)]
+lightColorGroups :: RealFrac t => t -> [Int] -> [((Int, Int), HSV t)]
 lightColorGroups zeroHue = genColorGroups (lightColorGroupStyle zeroHue)
 
 

--- a/lib/utils/src/Data/Color.hs
+++ b/lib/utils/src/Data/Color.hs
@@ -1,4 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
 -- remove the two benign defaults
 
 -- |
@@ -37,8 +40,12 @@ module Data.Color (
  -       palettes for reporting various data
  -}
 
-import Numeric (showHex, readHex)
-import Safe    (headMay)
+import GHC.Generics     (Generic)
+import Control.DeepSeq  (NFData)
+import Data.Binary      (Binary)
+import Data.Data        (Data)
+import Numeric          (showHex, readHex)
+import Safe             (headMay)
 
 -- import Text.XHtml.Strict
 -- import Text.XHtml.Table
@@ -48,7 +55,7 @@ data RGB a = RGB {
   , rgbG :: !a
   , rgbB :: !a
   }
-  deriving( Eq, Ord )
+  deriving( Eq, Ord, Generic, Data, NFData, Binary )
 
 instance Show a => Show (RGB a) where
   show (RGB r g b) = "RGB("++show r++", "++show g++", "++show b++")"
@@ -141,13 +148,12 @@ rgbToHex (RGB r g b) = ('#':) . showHex' r . showHex' g . showHex' b $ ""
           i = max 0 (min 255 (floor (256 * f)))
 
 hexToRGB :: RealFrac t => String -> Maybe (RGB t)
-hexToRGB rgb = do
-    let (rs,gb) = splitAt 2 rgb
-        (gs, bs) = splitAt 2 gb
-    (r,_) <- headMay $ readHex rs
-    (g,_) <- headMay $ readHex gs
-    (b,_) <- headMay $ readHex bs
+hexToRGB [r1,r2,g1,g2,b1,b2] = do
+    (r,_) <- headMay $ readHex [r1,r2]
+    (g,_) <- headMay $ readHex [g1,g2]
+    (b,_) <- headMay $ readHex [b1,b2]
     return (RGB (r / 255) (g / 255) (b / 255))
+hexToRGB _ = Nothing
 
 -- | Hexadecimal representation of an HSV value; i.e., of its corresponding RGB
 -- value.

--- a/lib/utils/src/Data/Color.hs
+++ b/lib/utils/src/Data/Color.hs
@@ -13,6 +13,7 @@ module Data.Color (
     RGB(..)
   , HSV(..)
   , rgbToHex
+  , hexToRGB
   , hsvToHex
 
   -- ** Predefined colors
@@ -36,7 +37,8 @@ module Data.Color (
  -       palettes for reporting various data
  -}
 
-import Numeric (showHex)
+import Numeric (showHex, readHex)
+import Safe    (headMay)
 
 -- import Text.XHtml.Strict
 -- import Text.XHtml.Table
@@ -137,6 +139,15 @@ rgbToHex (RGB r g b) = ('#':) . showHex' r . showHex' g . showHex' b $ ""
           where
           i :: Int
           i = max 0 (min 255 (floor (256 * f)))
+
+hexToRGB :: RealFrac t => String -> Maybe (RGB t)
+hexToRGB rgb = do
+    let (rs,gb) = splitAt 2 rgb
+        (gs, bs) = splitAt 2 gb
+    (r,_) <- headMay $ readHex rs
+    (g,_) <- headMay $ readHex gs
+    (b,_) <- headMay $ readHex bs
+    return (RGB (r / 255) (g / 255) (b / 255))
 
 -- | Hexadecimal representation of an HSV value; i.e., of its corresponding RGB
 -- value.

--- a/lib/utils/tamarin-prover-utils.cabal
+++ b/lib/utils/tamarin-prover-utils.cabal
@@ -45,6 +45,7 @@ library
       , fclabels
       , mtl
       , pretty
+      , safe
       , syb
       , time
       , transformers


### PR DESCRIPTION
These commits introduce two changes: 

1. A way of manually specifying the colour a rule should be rendered in generated graph. This is done with an action `__color('RRGGBB')` or `__colour('RRGGBB')` included in the rule, where `RRGGBB` is a 24-bit colour in hexadecimal. (Currently, `#` is not allowed in string literals, or I would have had that in front too)

2. To support this, facts identifiers can now begin with `_`, and the facts in rule actions beginning with `__` (double underscore) are hidden when printing the rule and in the dot output.

Since identifiers beginning with `_` were previously unsupported, this should not introduce any incompatibilities. However, I would like feedback on the format or potential alternatives, as well as any other ideas for useful rendering annotations beyond colour.

(Separately, if some way of specifying hidden actions gets merged, we may want to switch the diff code to use the same thing rather than the current method of manually reconstructing diff annotations to compare against actions to hide them, as is done for example at Rule.hs#L885. I don't know the diff code very well though)