### PR TITLE
Test injectivity constraint-reduction rule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,13 +252,13 @@ ake-bp-case-studies:	$(AKE_BP_CS_TARGETS)
 ## Features
 ###########
 
-FEATURES_CASE_STUDIES=cav13/DH_example.spthy features//multiset/counter.spthy features//private_function_symbols/NAXOS_eCK_PFS_private.spthy features//private_function_symbols/NAXOS_eCK_private.spthy
+FEATURES_CASE_STUDIES=cav13/DH_example.spthy features//multiset/counter.spthy features//private_function_symbols/NAXOS_eCK_PFS_private.spthy features//private_function_symbols/NAXOS_eCK_private.spthy features//injectivity/injectivity.spthy
 
 FEATURES_CS_TARGETS=$(subst .spthy,_analyzed.spthy,$(addprefix case-studies/,$(FEATURES_CASE_STUDIES)))
 
 # case studies
 features-case-studies:	$(FEATURES_CS_TARGETS)
-	grep "verified\|falsified\|processing time" case-studies/features/multiset/*.spthy case-studies/features/private_function_symbols/*.spthy case-studies/cav13/*.spthy
+	grep "verified\|falsified\|processing time" case-studies/features/multiset/*.spthy case-studies/features/private_function_symbols/*.spthy case-studies/cav13/*.spthy case-studies/features/injectivity/*.spthy
 
 
 ## SAPIC

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ case-studies/%_analyzed.spthy:	examples/%.spthy $(TAMARIN)
 	mkdir -p case-studies/ake/dh
 	mkdir -p case-studies/features/private_function_symbols
 	mkdir -p case-studies/features/multiset
+	mkdir -p case-studies/features/injectivity
 	mkdir -p case-studies/cav13
 	mkdir -p case-studies/related_work/AIF_Moedersheim_CCS10
 	mkdir -p case-studies/related_work/StatVerif_ARR_CSF11

--- a/case-studies-regression/features/injectivity/injectivity_analyzed.spthy
+++ b/case-studies-regression/features/injectivity/injectivity_analyzed.spthy
@@ -1,0 +1,95 @@
+theory injectivity begin
+
+// Function signature and definition of the equational theory E
+
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+/* looping facts with injective instances: Inj/1 */
+
+rule (modulo E) Init:
+   [ Fr( ~i ) ] --[ Initiated( ~i ) ]-> [ Inj( ~i ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) Copy:
+   [ Inj( i ) ] --[ Copied( i ) ]-> [ Inj( i ) ]
+
+  // loop breaker: [0]
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) Remove:
+   [ Inj( i ) ] --[ Removed( i ) ]-> [ ]
+
+  /* has exactly the trivial AC variant */
+
+lemma injectivity_check [use_induction]:
+  all-traces
+  "¬(∃ id #i #j #k.
+      ((((Initiated( id ) @ #i) ∧ (Removed( id ) @ #j)) ∧
+        (Copied( id ) @ #k)) ∧
+       (#i < #j)) ∧
+      (#j < #k))"
+/*
+guarded formula characterizing all counter-examples:
+"∃ id #i #j #k.
+  (Initiated( id ) @ #i) ∧ (Removed( id ) @ #j) ∧ (Copied( id ) @ #k)
+ ∧
+  (#i < #j) ∧ (#j < #k)"
+*/
+induction
+  case empty_trace
+  by contradiction /* from formulas */
+next
+  case non_empty_trace
+  simplify
+  solve( Inj( ~i.1 ) ▶₀ #j )
+    case Copy
+    solve( Inj( ~i.1 ) ▶₀ #k )
+      case Copy
+      by contradiction /* non-injective facts (#vr.1,#j,#k) */
+    next
+      case Init
+      by contradiction /* non-injective facts (#i,#j,#k) */
+    qed
+  next
+    case Init
+    solve( Inj( ~i.1 ) ▶₀ #k )
+      case Copy
+      by contradiction /* non-injective facts (#vr,#j,#k) */
+    qed
+  qed
+qed
+
+/* All well-formedness checks were successful. */
+
+end\n/* Output
+maude tool: 'maude'
+ checking version: 2.7.1. OK.
+ checking installation: OK.
+SAPIC tool: 'sapic'
+Checking availablity ... OK.
+
+
+analyzing: examples/features//injectivity/injectivity.spthy
+
+------------------------------------------------------------------------------
+analyzed: examples/features//injectivity/injectivity.spthy
+
+  output:          case-studies/temp-analysis.spthy
+  processing time: 0.060922s
+  injectivity_check (all-traces): verified (9 steps)
+
+------------------------------------------------------------------------------
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/features//injectivity/injectivity.spthy
+
+  output:          case-studies/temp-analysis.spthy
+  processing time: 0.060922s
+  injectivity_check (all-traces): verified (9 steps)
+
+==============================================================================
+*/

--- a/case-studies-regression/features/injectivity/injectivity_analyzed.spthy
+++ b/case-studies-regression/features/injectivity/injectivity_analyzed.spthy
@@ -63,7 +63,8 @@ qed
 
 /* All well-formedness checks were successful. */
 
-end\n/* Output
+end
+/* Output
 maude tool: 'maude'
  checking version: 2.7.1. OK.
  checking installation: OK.

--- a/examples/features/injectivity/injectivity.spthy
+++ b/examples/features/injectivity/injectivity.spthy
@@ -1,0 +1,23 @@
+theory injectivity begin
+
+rule Init:
+  [ Fr(~i) ]
+--[ Initiated(~i) ]->
+  [ Inj(~i) ]
+
+rule Copy:
+  [ Inj(i) ]
+--[ Copied(i) ]->
+  [ Inj(i) ]
+
+rule Remove:
+  [ Inj(i) ]
+--[ Removed(i) ]->
+  []
+
+lemma injectivity_check[use_induction]: all-traces
+  "¬(Ex id #i #j #k.
+        Initiated(id) @ i & Removed(id) @ j & Copied(id) @ k
+        & #i < #j & #j < #k)"
+
+end

--- a/examples/features/injectivity/injectivity.spthy
+++ b/examples/features/injectivity/injectivity.spthy
@@ -1,3 +1,15 @@
+/*
+   Protocol:    Injectivity test
+   Modeler:     Nick Moore
+   Date:        May 2017
+
+   Status:      working
+
+   A simple toy example that requires the injectivity constraint-reduction rule
+   to terminate.
+
+*/
+
 theory injectivity begin
 
 rule Init:


### PR DESCRIPTION
During the development of invariant rules, we introduced a bug into tamarin that prevented the injectivity constraint-reduction rule from being used. This adds a protocol that requires the injectivity constraint-reduction rule to terminate, to enable this kind of error to be more quickly identified.