### PR TITLE
Updated `i` heuristic

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -338,7 +338,7 @@ data GoalRanking =
   | UsefulGoalNrRanking
   | SmartRanking Bool
   | SmartDiffRanking
-  | InjRanking
+  | InjRanking Bool
   deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | The name/explanation of a 'GoalRanking'.
@@ -351,12 +351,11 @@ goalRankingName ranking =
         SapicRanking                 -> "heuristics adapted to the output of the SAPIC tool"
         SapicLivenessRanking         -> "heuristics adapted to the output of the SAPIC tool for liveness properties"
         SapicPKCS11Ranking           -> "heuristics adapted to a model of PKCS#11 translated using the SAPIC tool"
-        SmartRanking useLoopBreakers -> smart useLoopBreakers
+        SmartRanking useLoopBreakers -> "the 'smart' heuristic" ++ loopStatus useLoopBreakers
         SmartDiffRanking             -> "the 'smart' heuristic (for diff proofs)"
-        InjRanking                   -> "heuristics adapted to stateful injective protocols"
+        InjRanking useLoopBreakers   -> "heuristics adapted to stateful injective protocols" ++ loopStatus useLoopBreakers
    where
-     smart b = "the 'smart' heuristic (loop breakers " ++
-               (if b then "allowed" else "delayed") ++ ")."
+     loopStatus b = " (loop breakers " ++ (if b then "allowed" else "delayed") ++ ")"
 
 -- | Use a 'GoalRanking' to sort a list of 'AnnotatedGoal's stemming from the
 -- given constraint 'System'.
@@ -369,9 +368,9 @@ rankGoals ctxt ranking = case ranking of
     SapicRanking -> sapicRanking ctxt
     SapicLivenessRanking -> sapicLivenessRanking ctxt
     SapicPKCS11Ranking -> sapicPKCS11Ranking ctxt
-    SmartRanking useLoopsBreakers -> smartRanking ctxt useLoopsBreakers
+    SmartRanking useLoopBreakers -> smartRanking ctxt useLoopBreakers
     SmartDiffRanking -> smartDiffRanking ctxt
-    InjRanking      -> injRanking ctxt
+    InjRanking useLoopBreakers -> injRanking ctxt useLoopBreakers
 
 -- | Use a 'GoalRanking' to generate the ranked, list of possible
 -- 'ProofMethod's and their corresponding results in this 'ProofContext' and
@@ -974,10 +973,11 @@ sapicPKCS11Ranking ctxt sys =
 -- | A ranking function tailored for automatic verification of stateful
 -- protocols which can make heavy use of injectivity properties
 injRanking :: ProofContext
+            -> Bool
             -> System
             -> [AnnotatedGoal] -> [AnnotatedGoal]
-injRanking ctxt sys =
-    (sortOnUsefulness . unmark . sortDecisionTree solveLast . sortDecisionTree solveFirst . goalNrRanking)
+injRanking ctxt allowLoopBreakers sys =
+    (sortOnUsefulness . unmark . sortDecisionTree [solveLast] . sortDecisionTree solveFirst . goalNrRanking)
   where
     oneCaseOnly = catMaybes . map getMsgOneCase . L.get pcSources $ ctxt
 
@@ -990,17 +990,19 @@ injRanking ctxt sys =
 
     tagUsefulness Useful                = 0 :: Int
     tagUsefulness ProbablyConstructible = 1
-    tagUsefulness LoopBreaker           = 0
+    tagUsefulness LoopBreaker           = 1
     tagUsefulness CurrentlyDeducible    = 2
 
-    unmark = map unmarkPremiseG
+    unmark | allowLoopBreakers = map unmarkPremiseG
+           | otherwise         = id
+
     unmarkPremiseG (goal@(PremiseG _ _), (nr, _)) = (goal, (nr, Useful))
     unmarkPremiseG annGoal                        = annGoal
 
-    solveLast =
-       [  isNonLastProtoFact . fst
-        , isNotKnowsLastNameGoal . fst]
-       -- move the Last proto facts (L_) to the end.
+    -- move the Last proto facts (L_) and large splits to the end.
+    solveLast goaltuple = (isNoLargeSplitGoal $ fst goaltuple)
+                            && (isNonLastProtoFact $ fst goaltuple)
+                            && (isNotKnowsLastNameGoal $ fst goaltuple)
 
     solveFirst =
         [ isImmediateGoal . fst         -- Goals with the I_ prefix
@@ -1011,9 +1013,6 @@ injRanking ctxt sys =
         -- equation splits
 
     smallSplitGoalSize = 3
-
-    isProtoFactGoal (PremiseG _ _, (_, _))  = True
-    isProtoFactGoal _                       = False
 
     msgPremise (ActionG _ fa) = do (UpK, m) <- kFactView fa; return m
     msgPremise _              = Nothing
@@ -1031,11 +1030,18 @@ injRanking ctxt sys =
                                     || (isPrivateKnowsGoal $ fst goaltuple)
                                     || (isSplitGoalSmall $ fst goaltuple)
                                     || (isMsgOneCaseGoal $ fst goaltuple)
+                                    || (isNonLoopBreakerProtoFactGoal goaltuple)
 
     isLowPriorityGoal goaltuple = (isDoubleExpGoal $ fst goaltuple)
-                                || (isNoLargeSplitGoal $ fst goaltuple)
                                 || (isSignatureGoal $ fst goaltuple)
                                 || (isProtoFactGoal goaltuple)
+
+    isNonLoopBreakerProtoFactGoal (PremiseG _ fa, (_, Useful)) = not (isKFact fa)
+    isNonLoopBreakerProtoFactGoal _                            = False
+
+    isProtoFactGoal (PremiseG _ fa, (_, _)) = not (isKFact fa)
+    isProtoFactGoal _                       = False
+
     -- Detect 'I_' (immediate) fact and term prefix for heuristics
     isImmediateGoal (PremiseG _ (Fact (ProtoFact _ ('I':'_':_) _) _)) = True
     isImmediateGoal (ActionG  _ (Fact (ProtoFact _ ('I':'_':_) _) _)) = True

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -977,7 +977,7 @@ injRanking :: ProofContext
             -> System
             -> [AnnotatedGoal] -> [AnnotatedGoal]
 injRanking ctxt allowLoopBreakers sys =
-    (sortOnUsefulness . unmark . sortDecisionTree [solveLast] . sortDecisionTree solveFirst . goalNrRanking)
+    (sortOnUsefulness . unmark . sortDecisionTree [notSolveLast] . sortDecisionTree solveFirst . goalNrRanking)
   where
     oneCaseOnly = catMaybes . map getMsgOneCase . L.get pcSources $ ctxt
 
@@ -999,8 +999,9 @@ injRanking ctxt allowLoopBreakers sys =
     unmarkPremiseG (goal@(PremiseG _ _), (nr, _)) = (goal, (nr, Useful))
     unmarkPremiseG annGoal                        = annGoal
 
-    -- move the Last proto facts (L_) and large splits to the end.
-    solveLast goaltuple = (isNoLargeSplitGoal $ fst goaltuple)
+    -- move the Last proto facts (L_) and large splits to the end by
+    -- putting all goals that shouldn't be solved last in front
+    notSolveLast goaltuple = (isNoLargeSplitGoal $ fst goaltuple)
                             && (isNonLastProtoFact $ fst goaltuple)
                             && (isNotKnowsLastNameGoal $ fst goaltuple)
 
@@ -1116,7 +1117,7 @@ smartRanking :: ProofContext
              -> System
              -> [AnnotatedGoal] -> [AnnotatedGoal]
 smartRanking ctxt allowPremiseGLoopBreakers sys =
-    sortOnUsefulness . unmark . sortDecisionTree solveLast . sortDecisionTree solveFirst . goalNrRanking
+    sortOnUsefulness . unmark . sortDecisionTree notSolveLast . sortDecisionTree solveFirst . goalNrRanking
   where
     oneCaseOnly = catMaybes . map getMsgOneCase . L.get pcSources $ ctxt
 
@@ -1138,9 +1139,9 @@ smartRanking ctxt allowPremiseGLoopBreakers sys =
     unmarkPremiseG (goal@(PremiseG _ _), (nr, _)) = (goal, (nr, Useful))
     unmarkPremiseG annGoal                        = annGoal
 
-    solveLast = 
+    notSolveLast =
        [ isNonLastProtoFact . fst ]
-       -- move the Last proto facts (L_) to the end.
+       -- move the Last proto facts (L_) to the end by sorting all other goals in front
 
     solveFirst =
         [ isChainGoal . fst

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -85,7 +85,7 @@ theoryLoadFlags =
   , flagOpt "5" ["bound", "b"] (updateArg "bound") "INT"
       "Bound the depth of the proofs"
 
-  , flagOpt "s" ["heuristic"] (updateArg "heuristic") "(s|S|o|p|P|l|c|C|i)+"
+  , flagOpt "s" ["heuristic"] (updateArg "heuristic") "(s|S|o|p|P|l|c|C|i|I)+"
       "Sequence of goal rankings to use (default 's')"
 
   , flagOpt "summary" ["partial-evaluation"] (updateArg "partialEvaluation")
@@ -306,7 +306,8 @@ constructAutoProver as =
     ranking 'P' = SapicPKCS11Ranking
     ranking 'c' = UsefulGoalNrRanking
     ranking 'C' = GoalNrRanking
-    ranking 'i' = InjRanking
+    ranking 'i' = InjRanking False
+    ranking 'I' = InjRanking True
     ranking r   = error $ render $ fsep $ map text $ words $
       "Unknown goal ranking '" ++ [r] ++ "'. Use one of the following:\
       \ 's' for the smart ranking without loop breakers,\
@@ -315,7 +316,8 @@ constructAutoProver as =
       \ 'p' for the smart ranking optimized for translations coming from SAPIC (http://sapic.gforge.inria.fr),\
       \ 'l' for the smart ranking optimized for translations coming from SAPIC proving liveness properties,\
       \ 'P' for the smart ranking optimized for a specific model of PKCS11, translated using SAPIC,\
-      \ 'i' for the smart ranking modified for the proof of injective detection protocols,\
+      \ 'i' for the ranking modified for the proof of stateful injective protocols without loop breakers,\
+      \ 'I' for the ranking modified for the proof of stateful injective protocols with loop breakers,\
       \ 'c' for the creation order and useful goals first,\
       \ and 'C' for the creation order."
 


### PR DESCRIPTION
-Fixed a bug with how split goals were sorted that improves performance on diffie-hellman protocols, and added support for a loop breaker/non-loop breaker mode to make it consistent with other heuristics.

One thing to note: the comments around `isNoLargeSplitGoal` in the smart heuristic would seem to imply the intention is to prioritize small split goals, but what it actually does is match any goal except large split goals, more along the lines of the `solveLast` conditions (as implied by the name, I suppose). Not sure if that is intentional, but I had copied that code from the smart heuristic without looking at it closely and that caused this issue--effectively every goal was being considered the same priority as double exponent goals.