### PR TITLE
Allow the case-studies make goal to be done in parallel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,9 @@ make case-studies
 diff -r case-studies case-studies-regression
 
 This first removes any existing case-study runs you may have, then runs all the case studies, and finally compares the resulting output to the stored expected output. It is expected that the runtime of the analyses changes every time (but on the order of 1% or so, possibly more depending on the machine you run it on). If that is the only change, everything is fine. If some proof steps get reordered, but the number of steps stays constant that is ok, but should be noted. If that number changes or runtimes change significantly that must be discussed in a pull request.
+
+If you are running the regression on a server you can run multiple case studies in parallel by adding the "-j #" parameter where # is the number of parallel runs. Note that your machine should have 16GB of memory per run, and each run uses 3 threads already. For example:
+
+make -j 6 case-studies
+
+to run 6 case studies in parallel.

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,6 @@ JKL3=JKL_TS3_2004_KI_wPFS.spthy JKL_TS3_2008_KI_wPFS.spthy
 UM=UM_wPFS.spthy UM_PFS.spthy
 
 
-TMPRES=case-studies/temp-analysis.spthy
-TMPOUT=case-studies/temp-output.spthy
-
 CSF12_CASE_STUDIES=$(JKL1) $(JKL2) $(KEA) $(NAXOS) $(UM) $(STS) $(SDH) $(KAS) $(DH2)
 CSF12_CS_TARGETS=$(subst .spthy,_analyzed.spthy,$(addprefix case-studies/csf12/,$(CSF12_CASE_STUDIES)))
 
@@ -110,14 +107,14 @@ case-studies/%_analyzed.spthy:	examples/%.spthy $(TAMARIN)
 	mkdir -p case-studies/post17
 	mkdir -p case-studies/regression/trace
 	# Use -N3, as the fourth core is used by the OS and the console
-	$(TAMARIN) $< --prove --stop-on-trace=dfs +RTS -N3 -RTS -o$(TMPRES) >$(TMPOUT)
+	$(TAMARIN) $< --prove --stop-on-trace=dfs +RTS -N3 -RTS -o$<.tmp >$<.out
 	# We only produce the target after the run, otherwise aborted
 	# runs already 'finish' the case.
-	echo "\n/* Output" >>$(TMPRES)
-	cat $(TMPOUT) >>$(TMPRES)
-	echo "*/" >>$(TMPRES)
-	mv $(TMPRES) $@
-	\rm -f $(TMPOUT)
+	printf "\n/* Output\n" >>$<.tmp
+	cat $<.out >>$<.tmp
+	echo "*/" >>$<.tmp
+	mv $<.tmp $@
+	\rm -f $<.out
 
 
 ## Observational Equivalence
@@ -130,14 +127,14 @@ case-studies/%_analyzed-diff.spthy:	examples/%.spthy $(TAMARIN)
 	mkdir -p case-studies/post17
 	mkdir -p case-studies/regression/diff
 	# Use -N3, as the fourth core is used by the OS and the console
-	$(TAMARIN) $< --prove --diff --stop-on-trace=dfs +RTS -N3 -RTS -o$(TMPRES) >$(TMPOUT)
+	$(TAMARIN) $< --prove --diff --stop-on-trace=dfs +RTS -N3 -RTS -o$<.tmp >$<.out
 	# We only produce the target after the run, otherwise aborted
 	# runs already 'finish' the case.
-	echo "\n/* Output" >>$(TMPRES)
-	cat $(TMPOUT) >>$(TMPRES)
-	echo "*/" >>$(TMPRES)
-	mv $(TMPRES) $@
-	\rm -f $(TMPOUT)
+	printf "\n/* Output\n" >>$<.tmp
+	cat $<.out >>$<.tmp
+	echo "*/" >>$<.tmp
+	mv $<.tmp $@
+	\rm -f $<.out
 
 # individual diff-based precomputed (no --prove) case studies
 case-studies/%_analyzed-diff-noprove.spthy:	examples/%.spthy $(TAMARIN)
@@ -145,14 +142,14 @@ case-studies/%_analyzed-diff-noprove.spthy:	examples/%.spthy $(TAMARIN)
 	mkdir -p case-studies/features/equivalence
 	mkdir -p case-studies/regression/diff
 	# Use -N3, as the fourth core is used by the OS and the console
-	$(TAMARIN) $< --diff --stop-on-trace=dfs +RTS -N3 -RTS -o$(TMPRES) >$(TMPOUT)
+	$(TAMARIN) $< --diff --stop-on-trace=dfs +RTS -N3 -RTS -o$<.tmp >$<.out
 	# We only produce the target after the run, otherwise aborted
 	# runs already 'finish' the case.
-	echo "\n/* Output" >>$(TMPRES)
-	cat $(TMPOUT) >>$(TMPRES)
-	echo "*/" >>$(TMPRES)
-	mv $(TMPRES) $@
-	\rm -f $(TMPOUT)
+	printf "\n/* Output\n" >>$<.tmp
+	cat $<.out >>$<.tmp
+	echo "*/" >>$<.tmp
+	mv $<.tmp $@
+	\rm -f $<.out
 
 CCS15_CASE_STUDIES=DDH.spthy  probEnc.spthy  rfid-feldhofer.spthy
 CCS15_CS_TARGETS=$(subst .spthy,_analyzed-diff.spthy,$(addprefix case-studies/ccs15/,$(CCS15_CASE_STUDIES)))
@@ -282,9 +279,6 @@ regression-case-studies:	$(REGRESSION_TARGETS)
 ## SAPIC
 ########
 
-TMPRESSAPIC=case-studies-sapic/temp-analysis.sapic
-TMPOUTSAPIC=case-studies-sapic/temp-output.spthy
-
 # sapic case studies
 case-studies-sapic/%.spthy:	examples/sapic/%.sapic $(SAPIC)
 	mkdir -p case-studies-sapic/basic
@@ -303,10 +297,10 @@ case-studies-sapic/%.spthy:	examples/sapic/%.sapic $(SAPIC)
 	mkdir -p case-studies-sapic/SCADA
 	mkdir -p case-studies-sapic/statVerifLeftRight
 	mkdir -p case-studies-sapic/Yubikey
-	$(SAPIC) $< $(TMPRESSAPIC) > $(TMPOUTSAPIC)
-	cat $(TMPOUTSAPIC) >>$(TMPRESSAPIC)
-	mv $(TMPRESSAPIC) $@
-	\rm -f $(TMPOUTSAPIC)
+	$(SAPIC) $< $<.tmp > $<.out
+	cat $<.out >>$<.tmp
+	mv $<.tmp $@
+	\rm -f $<.out
 
 SAPIC_CASE_STUDIES=basic/channels1.sapic basic/channels2.sapic basic/channels3.sapic basic/design-choices.sapic basic/exclusive-secrets.sapic basic/no-replication.sapic basic/replication.sapic  basic/running-example.sapic \
 encWrapDecUnwrap/encwrapdecunwrap-nolocks.sapic encWrapDecUnwrap/encwrapdecunwrap.sapic \
@@ -347,14 +341,14 @@ case-studies/%_analyzed-sapic.spthy:	case-studies-sapic-regression/%.spthy $(TAM
 	mkdir -p case-studies/sapic/SCADA
 	mkdir -p case-studies/sapic/fairexchange-mini
 	# Use -N3, as the fourth core is used by the OS and the console
-	$(TAMARIN) $< --prove --stop-on-trace=dfs +RTS -N3 -RTS -o$(TMPRES) >$(TMPOUT)
+	$(TAMARIN) $< --prove --stop-on-trace=dfs +RTS -N3 -RTS -o$<.tmp >$<.out
 	# We only produce the target after the run, otherwise aborted
 	# runs already 'finish' the case.
-	echo "\n/* Output" >>$(TMPRES)
-	cat $(TMPOUT) >>$(TMPRES)
-	echo "*/" >>$(TMPRES)
-	mv $(TMPRES) $(subst case-studies,case-studies/sapic,$@)
-	\rm -f $(TMPOUT)
+	printf "\n/* Output\n" >>$<.tmp
+	cat $<.out >>$<.tmp
+	echo "*/" >>$<.tmp
+	mv $<.tmp $(subst case-studies,case-studies/sapic,$@)
+	\rm -f $<.out
 
 SAPIC_TAMARIN_CASE_STUDIES=basic/no-replication.spthy basic/replication.spthy basic/channels1.spthy basic/channels2.spthy basic/channels3.spthy basic/design-choices.spthy basic/exclusive-secrets.spthy basic/running-example.spthy \
 statVerifLeftRight/stateverif_left_right.spthy \

--- a/case-studies-regression/Tutorial_analyzed.spthy
+++ b/case-studies-regression/Tutorial_analyzed.spthy
@@ -236,8 +236,8 @@ analyzing: examples/Tutorial.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/Tutorial.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.187935s
+  output:          examples/Tutorial.spthy.tmp
+  processing time: 0.201014s
   Client_session_key_secrecy (all-traces): verified (5 steps)
   Client_auth (all-traces): verified (11 steps)
   Client_auth_injective (all-traces): verified (15 steps)
@@ -250,8 +250,8 @@ summary of summaries:
 
 analyzed: examples/Tutorial.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.187935s
+  output:          examples/Tutorial.spthy.tmp
+  processing time: 0.201014s
   Client_session_key_secrecy (all-traces): verified (5 steps)
   Client_auth (all-traces): verified (11 steps)
   Client_auth_injective (all-traces): verified (15 steps)

--- a/case-studies-regression/ake/bilinear/Chen_Kudla_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/Chen_Kudla_analyzed.spthy
@@ -2588,8 +2588,8 @@ analyzing: examples/ake/bilinear/Chen_Kudla.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/Chen_Kudla.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 70.459248s
+  output:          examples/ake/bilinear/Chen_Kudla.spthy.tmp
+  processing time: 64.288951s
   key_agreement_reachable (exists-trace): verified (13 steps)
   key_secrecy_ephemeral_no_WPFS (all-traces): verified (679 steps)
 
@@ -2600,8 +2600,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/Chen_Kudla.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 70.459248s
+  output:          examples/ake/bilinear/Chen_Kudla.spthy.tmp
+  processing time: 64.288951s
   key_agreement_reachable (exists-trace): verified (13 steps)
   key_secrecy_ephemeral_no_WPFS (all-traces): verified (679 steps)
 

--- a/case-studies-regression/ake/bilinear/Chen_Kudla_eCK_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/Chen_Kudla_eCK_analyzed.spthy
@@ -517,8 +517,8 @@ analyzing: examples/ake/bilinear/Chen_Kudla_eCK.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/Chen_Kudla_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 54.093998s
+  output:          examples/ake/bilinear/Chen_Kudla_eCK.spthy.tmp
+  processing time: 50.205268s
   key_secrecy_eCK_like (all-traces): falsified - found trace (24 steps)
 
 ------------------------------------------------------------------------------
@@ -528,8 +528,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/Chen_Kudla_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 54.093998s
+  output:          examples/ake/bilinear/Chen_Kudla_eCK.spthy.tmp
+  processing time: 50.205268s
   key_secrecy_eCK_like (all-traces): falsified - found trace (24 steps)
 
 ==============================================================================

--- a/case-studies-regression/ake/bilinear/Joux_EphkRev_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/Joux_EphkRev_analyzed.spthy
@@ -1039,8 +1039,8 @@ analyzing: examples/ake/bilinear/Joux_EphkRev.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/Joux_EphkRev.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 143.389774s
+  output:          examples/ake/bilinear/Joux_EphkRev.spthy.tmp
+  processing time: 97.045018s
   session_key_establish (exists-trace): verified (28 steps)
   Session_Key_Secrecy_PFS (all-traces): falsified - found trace (14 steps)
 
@@ -1051,8 +1051,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/Joux_EphkRev.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 143.389774s
+  output:          examples/ake/bilinear/Joux_EphkRev.spthy.tmp
+  processing time: 97.045018s
   session_key_establish (exists-trace): verified (28 steps)
   Session_Key_Secrecy_PFS (all-traces): falsified - found trace (14 steps)
 

--- a/case-studies-regression/ake/bilinear/Joux_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/Joux_analyzed.spthy
@@ -1055,8 +1055,8 @@ analyzing: examples/ake/bilinear/Joux.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/Joux.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 138.470619s
+  output:          examples/ake/bilinear/Joux.spthy.tmp
+  processing time: 95.276704s
   session_key_establish (exists-trace): verified (28 steps)
   Session_Key_Secrecy_PFS (all-traces): verified (22 steps)
 
@@ -1067,8 +1067,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/Joux.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 138.470619s
+  output:          examples/ake/bilinear/Joux.spthy.tmp
+  processing time: 95.276704s
   session_key_establish (exists-trace): verified (28 steps)
   Session_Key_Secrecy_PFS (all-traces): verified (22 steps)
 

--- a/case-studies-regression/ake/bilinear/RYY_PFS_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/RYY_PFS_analyzed.spthy
@@ -396,8 +396,8 @@ analyzing: examples/ake/bilinear/RYY_PFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/RYY_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 9.148186s
+  output:          examples/ake/bilinear/RYY_PFS.spthy.tmp
+  processing time: 8.447581s
   key_agreement_reachable (exists-trace): verified (11 steps)
   key_secrecy_PFS (all-traces): falsified - found trace (12 steps)
 
@@ -408,8 +408,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/RYY_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 9.148186s
+  output:          examples/ake/bilinear/RYY_PFS.spthy.tmp
+  processing time: 8.447581s
   key_agreement_reachable (exists-trace): verified (11 steps)
   key_secrecy_PFS (all-traces): falsified - found trace (12 steps)
 

--- a/case-studies-regression/ake/bilinear/RYY_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/RYY_analyzed.spthy
@@ -526,8 +526,8 @@ analyzing: examples/ake/bilinear/RYY.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/RYY.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.974794s
+  output:          examples/ake/bilinear/RYY.spthy.tmp
+  processing time: 8.689988s
   key_agreement_reachable (exists-trace): verified (11 steps)
   key_secrecy_WPFS (all-traces): verified (53 steps)
 
@@ -538,8 +538,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/RYY.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.974794s
+  output:          examples/ake/bilinear/RYY.spthy.tmp
+  processing time: 8.689988s
   key_agreement_reachable (exists-trace): verified (11 steps)
   key_secrecy_WPFS (all-traces): verified (53 steps)
 

--- a/case-studies-regression/ake/bilinear/Scott_EphkRev_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/Scott_EphkRev_analyzed.spthy
@@ -306,8 +306,8 @@ analyzing: examples/ake/bilinear/Scott_EphkRev.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/Scott_EphkRev.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 25.199692s
+  output:          examples/ake/bilinear/Scott_EphkRev.spthy.tmp
+  processing time: 21.059035s
   key_agreement_reachable (exists-trace): verified (12 steps)
   key_secrecy (all-traces): falsified - found trace (15 steps)
 
@@ -318,8 +318,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/Scott_EphkRev.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 25.199692s
+  output:          examples/ake/bilinear/Scott_EphkRev.spthy.tmp
+  processing time: 21.059035s
   key_agreement_reachable (exists-trace): verified (12 steps)
   key_secrecy (all-traces): falsified - found trace (15 steps)
 

--- a/case-studies-regression/ake/bilinear/Scott_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/Scott_analyzed.spthy
@@ -1805,8 +1805,8 @@ analyzing: examples/ake/bilinear/Scott.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/Scott.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 20.481474s
+  output:          examples/ake/bilinear/Scott.spthy.tmp
+  processing time: 18.289524s
   key_agreement_reachable (exists-trace): verified (10 steps)
   key_secrecy (all-traces): verified (518 steps)
 
@@ -1817,8 +1817,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/Scott.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 20.481474s
+  output:          examples/ake/bilinear/Scott.spthy.tmp
+  processing time: 18.289524s
   key_agreement_reachable (exists-trace): verified (10 steps)
   key_secrecy (all-traces): verified (518 steps)
 

--- a/case-studies-regression/ake/bilinear/TAK1_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/TAK1_analyzed.spthy
@@ -2649,8 +2649,8 @@ analyzing: examples/ake/bilinear/TAK1.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/TAK1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 76.677435s
+  output:          examples/ake/bilinear/TAK1.spthy.tmp
+  processing time: 61.357324s
   session_key_establish (exists-trace): verified (17 steps)
   Session_Key_Secrecy (all-traces): verified (725 steps)
 
@@ -2661,8 +2661,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/TAK1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 76.677435s
+  output:          examples/ake/bilinear/TAK1.spthy.tmp
+  processing time: 61.357324s
   session_key_establish (exists-trace): verified (17 steps)
   Session_Key_Secrecy (all-traces): verified (725 steps)
 

--- a/case-studies-regression/ake/bilinear/TAK1_eCK_like_analyzed.spthy
+++ b/case-studies-regression/ake/bilinear/TAK1_eCK_like_analyzed.spthy
@@ -527,8 +527,8 @@ analyzing: examples/ake/bilinear/TAK1_eCK_like.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/bilinear/TAK1_eCK_like.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 110.696628s
+  output:          examples/ake/bilinear/TAK1_eCK_like.spthy.tmp
+  processing time: 84.550096s
   session_key_establish (exists-trace): verified (17 steps)
   Session_Key_Secrecy (all-traces): falsified - found trace (21 steps)
 
@@ -539,8 +539,8 @@ summary of summaries:
 
 analyzed: examples/ake/bilinear/TAK1_eCK_like.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 110.696628s
+  output:          examples/ake/bilinear/TAK1_eCK_like.spthy.tmp
+  processing time: 84.550096s
   session_key_establish (exists-trace): verified (17 steps)
   Session_Key_Secrecy (all-traces): falsified - found trace (21 steps)
 

--- a/case-studies-regression/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching_analyzed.spthy
+++ b/case-studies-regression/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching_analyzed.spthy
@@ -4907,8 +4907,8 @@ analyzing: examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 135.021883s
+  output:          examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching.spthy.tmp
+  processing time: 109.273425s
   execution_match_same_key_NAXOS (exists-trace): verified (13 steps)
   eCK_key_secrecy (all-traces): verified (809 steps)
 
@@ -4919,8 +4919,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 135.021883s
+  output:          examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_keyreg_partially_matching.spthy.tmp
+  processing time: 109.273425s
   execution_match_same_key_NAXOS (exists-trace): verified (13 steps)
   eCK_key_secrecy (all-traces): verified (809 steps)
 

--- a/case-studies-regression/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching_analyzed.spthy
+++ b/case-studies-regression/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching_analyzed.spthy
@@ -4862,8 +4862,8 @@ analyzing: examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 90.209764s
+  output:          examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching.spthy.tmp
+  processing time: 77.131084s
   execution_match_same_key_NAXOS (exists-trace): verified (13 steps)
   eCK_key_secrecy (all-traces): verified (797 steps)
 
@@ -4874,8 +4874,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 90.209764s
+  output:          examples/ake/dh/DHKEA_NAXOS_C_eCK_PFS_partially_matching.spthy.tmp
+  processing time: 77.131084s
   execution_match_same_key_NAXOS (exists-trace): verified (13 steps)
   eCK_key_secrecy (all-traces): verified (797 steps)
 

--- a/case-studies-regression/ake/dh/NAXOS_eCK_PFS_analyzed.spthy
+++ b/case-studies-regression/ake/dh/NAXOS_eCK_PFS_analyzed.spthy
@@ -360,8 +360,8 @@ analyzing: examples/ake/dh/NAXOS_eCK_PFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/NAXOS_eCK_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.151221s
+  output:          examples/ake/dh/NAXOS_eCK_PFS.spthy.tmp
+  processing time: 3.753625s
   eCK_PFS_key_secrecy (all-traces): falsified - found trace (15 steps)
 
 ------------------------------------------------------------------------------
@@ -371,8 +371,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/NAXOS_eCK_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.151221s
+  output:          examples/ake/dh/NAXOS_eCK_PFS.spthy.tmp
+  processing time: 3.753625s
   eCK_PFS_key_secrecy (all-traces): falsified - found trace (15 steps)
 
 ==============================================================================

--- a/case-studies-regression/ake/dh/NAXOS_eCK_analyzed.spthy
+++ b/case-studies-regression/ake/dh/NAXOS_eCK_analyzed.spthy
@@ -734,8 +734,8 @@ analyzing: examples/ake/dh/NAXOS_eCK.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/NAXOS_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.827021s
+  output:          examples/ake/dh/NAXOS_eCK.spthy.tmp
+  processing time: 4.302532s
   eCK_key_secrecy (all-traces): verified (136 steps)
 
 ------------------------------------------------------------------------------
@@ -745,8 +745,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/NAXOS_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.827021s
+  output:          examples/ake/dh/NAXOS_eCK.spthy.tmp
+  processing time: 4.302532s
   eCK_key_secrecy (all-traces): verified (136 steps)
 
 ==============================================================================

--- a/case-studies-regression/ake/dh/UM_one_pass_attack_analyzed.spthy
+++ b/case-studies-regression/ake/dh/UM_one_pass_attack_analyzed.spthy
@@ -333,8 +333,8 @@ analyzing: examples/ake/dh/UM_one_pass_attack.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/UM_one_pass_attack.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.085468s
+  output:          examples/ake/dh/UM_one_pass_attack.spthy.tmp
+  processing time: 3.457524s
   key_agreement_reachable (exists-trace): verified (10 steps)
   CK_secure (all-traces): falsified - found trace (19 steps)
 
@@ -345,8 +345,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/UM_one_pass_attack.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.085468s
+  output:          examples/ake/dh/UM_one_pass_attack.spthy.tmp
+  processing time: 3.457524s
   key_agreement_reachable (exists-trace): verified (10 steps)
   CK_secure (all-traces): falsified - found trace (19 steps)
 

--- a/case-studies-regression/ake/dh/UM_one_pass_fix_analyzed.spthy
+++ b/case-studies-regression/ake/dh/UM_one_pass_fix_analyzed.spthy
@@ -789,8 +789,8 @@ analyzing: examples/ake/dh/UM_one_pass_fix.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/UM_one_pass_fix.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 2.547105s
+  output:          examples/ake/dh/UM_one_pass_fix.spthy.tmp
+  processing time: 2.429539s
   key_agreement_reachable (exists-trace): verified (10 steps)
   CK_secure (all-traces): verified (170 steps)
 
@@ -801,8 +801,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/UM_one_pass_fix.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 2.547105s
+  output:          examples/ake/dh/UM_one_pass_fix.spthy.tmp
+  processing time: 2.429539s
   key_agreement_reachable (exists-trace): verified (10 steps)
   CK_secure (all-traces): verified (170 steps)
 

--- a/case-studies-regression/ake/dh/UM_three_pass_analyzed.spthy
+++ b/case-studies-regression/ake/dh/UM_three_pass_analyzed.spthy
@@ -2638,6 +2638,54 @@ solve( (∃ #l matchingComm.
                           case R_Complete_case_1
                           solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
                             case R_Activate
+                            solve( !KU( second(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                  'g'^~ey>))
+                                   ) @ #vk )
+                              case Corrupt_SessionKey_case_1
+                              by contradiction /* cyclic */
+                            next
+                              case Corrupt_SessionKey_case_2
+                              by contradiction /* cyclic */
+                            next
+                              case Corrupt_SessionKey_case_3
+                              by contradiction /* cyclic */
+                            next
+                              case Corrupt_SessionKey_case_4
+                              by contradiction /* cyclic */
+                            next
+                              case Reveal_SessionKey_case_1
+                              by contradiction /* from formulas */
+                            next
+                              case Reveal_SessionKey_case_2
+                              by contradiction /* from formulas */
+                            next
+                              case Reveal_SessionKey_case_3
+                              by contradiction /* from formulas */
+                            next
+                              case Reveal_SessionKey_case_4
+                              by contradiction /* from formulas */
+                            next
+                              case c_second
+                              solve( !KU( h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)
+                                     ) @ #vk.6 )
+                                case c_h
+                                solve( !KU( 'g'^(~ex*~ey) ) @ #vk.9 )
+                                  case I_Activate
+                                  by solve( !KU( ~ey ) @ #vk.16 )
+                                next
+                                  case R_Activate
+                                  by solve( !KU( ~ex ) @ #vk.16 )
+                                next
+                                  case cexp
+                                  by solve( !KU( ~ex ) @ #vk.18 )
+                                qed
+                              qed
+                            qed
+                          qed
+                        next
+                          case R_Complete_case_2
+                          solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
+                            case R_Activate
                             solve( (∀ rest.
                                      ((rest+'g'^~ex) =
                                       (<'1', 'g'^~ex>+
@@ -2730,54 +2778,6 @@ solve( (∃ #l matchingComm.
                                     case cexp
                                     by solve( !KU( ~ex ) @ #vk.17 )
                                   qed
-                                qed
-                              qed
-                            qed
-                          qed
-                        next
-                          case R_Complete_case_2
-                          solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
-                            case R_Activate
-                            solve( !KU( second(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                  'g'^~ey>))
-                                   ) @ #vk )
-                              case Corrupt_SessionKey_case_1
-                              by contradiction /* cyclic */
-                            next
-                              case Corrupt_SessionKey_case_2
-                              by contradiction /* cyclic */
-                            next
-                              case Corrupt_SessionKey_case_3
-                              by contradiction /* cyclic */
-                            next
-                              case Corrupt_SessionKey_case_4
-                              by contradiction /* cyclic */
-                            next
-                              case Reveal_SessionKey_case_1
-                              by contradiction /* from formulas */
-                            next
-                              case Reveal_SessionKey_case_2
-                              by contradiction /* from formulas */
-                            next
-                              case Reveal_SessionKey_case_3
-                              by contradiction /* from formulas */
-                            next
-                              case Reveal_SessionKey_case_4
-                              by contradiction /* from formulas */
-                            next
-                              case c_second
-                              solve( !KU( h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)
-                                     ) @ #vk.6 )
-                                case c_h
-                                solve( !KU( 'g'^(~ex*~ey) ) @ #vk.9 )
-                                  case I_Activate
-                                  by solve( !KU( ~ey ) @ #vk.16 )
-                                next
-                                  case R_Activate
-                                  by solve( !KU( ~ex ) @ #vk.16 )
-                                next
-                                  case cexp
-                                  by solve( !KU( ~ex ) @ #vk.18 )
                                 qed
                               qed
                             qed
@@ -5687,6 +5687,159 @@ next
                   case case_1
                   solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
                     case R_Activate
+                    solve( !Ltk( $B, ~x ) ▶₂ #v )
+                      case Register_key_honest
+                      solve( !Pk( $A, 'g'^~ea ) ▶₃ #v )
+                        case Register_key_honest
+                        by solve( SidUpdated( <'UM3', $B, $A, 
+                                               (<'1', 'g'^~ex>+
+                                                <'2', 'g'^~ey, 
+                                                 MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                              'g'^~ey>)),
+                                                     <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
+                                                >+
+                                                <'3', 
+                                                 MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                              'g'^~ey>)),
+                                                     <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
+                                                >
+                                               )
+                                              >
+                                  ) @ #v.1 )
+                      qed
+                    qed
+                  qed
+                next
+                  case case_2
+                  solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
+                    case R_Activate
+                    solve( !Ltk( $B, ~x ) ▶₂ #v )
+                      case Register_key_honest
+                      solve( !Pk( $A, 'g'^~ea ) ▶₃ #v )
+                        case Register_key_honest
+                        solve( !KU( second(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                              'g'^~ey>))
+                               ) @ #vk.2 )
+                          case Corrupt_SessionKey_case_1
+                          by contradiction /* cyclic */
+                        next
+                          case Corrupt_SessionKey_case_2
+                          by contradiction /* cyclic */
+                        next
+                          case Corrupt_SessionKey_case_3
+                          by contradiction /* cyclic */
+                        next
+                          case Corrupt_SessionKey_case_4
+                          by contradiction /* cyclic */
+                        next
+                          case Reveal_SessionKey_case_1
+                          by contradiction /* from formulas */
+                        next
+                          case Reveal_SessionKey_case_2
+                          by contradiction /* from formulas */
+                        next
+                          case Reveal_SessionKey_case_3
+                          by contradiction /* from formulas */
+                        next
+                          case Reveal_SessionKey_case_4
+                          by contradiction /* from formulas */
+                        next
+                          case c_second
+                          solve( !KU( h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)
+                                 ) @ #vk.6 )
+                            case c_h
+                            solve( !KU( 'g'^(~ex*~ey) ) @ #vk.9 )
+                              case I_Activate
+                              by solve( !KU( ~ey ) @ #vk.16 )
+                            next
+                              case R_Activate
+                              by solve( !KU( ~ex ) @ #vk.16 )
+                            next
+                              case cexp
+                              by solve( !KU( ~ex ) @ #vk.18 )
+                            qed
+                          qed
+                        qed
+                      qed
+                    qed
+                  qed
+                qed
+              next
+                case R_Complete_case_2
+                solve( (∃ #v.
+                         (SidUpdated( <'UM3', $B, $A, 
+                                       (<'1', 'g'^~ex>+
+                                        <'2', 'g'^~ey, 
+                                         MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey
+                                                     >)),
+                                             <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
+                                        >+
+                                        <'3', 
+                                         MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey
+                                                     >)),
+                                             <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
+                                        >
+                                       )
+                                      >
+                          ) @ #v))  ∥
+                       ((∀ #k.
+                          (SessionKeyReveal( <'UM3', $B, $A, 
+                                              (<'1', 'g'^~ex>+
+                                               <'2', 'g'^~ey, 
+                                                MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                             'g'^~ey>)),
+                                                    <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
+                                               >+
+                                               <'3', 
+                                                MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                             'g'^~ey>)),
+                                                    <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
+                                               >
+                                              )
+                                             >
+                           ) @ #k)
+                         ⇒
+                          ⊥) ∧
+                        (∀ #k.
+                          (Corrupt( $B ) @ #k)
+                         ⇒
+                          ∃ #l.
+                           (Expire( <'UM3', $B, $A, 
+                                     (<'1', 'g'^~ex>+
+                                      <'2', 'g'^~ey, 
+                                       MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)),
+                                           <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
+                                      >+
+                                      <'3', 
+                                       MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)),
+                                           <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
+                                      >
+                                     )
+                                    >
+                            ) @ #l)
+                          ∧
+                           #l < #k) ∧
+                        (∀ #k.
+                          (SessionStateReveal( <'UM3', $B, $A, 
+                                                (<'1', 'g'^~ex>+
+                                                 <'2', 'g'^~ey, 
+                                                  MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                               'g'^~ey>)),
+                                                      <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
+                                                 >+
+                                                 <'3', 
+                                                  MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
+                                                               'g'^~ey>)),
+                                                      <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
+                                                 >
+                                                )
+                                               >
+                           ) @ #k)
+                         ⇒
+                          (∀ #l. (Corrupt( $A ) @ #l) ⇒ ⊥) ∧ (∀ #l. (Corrupt( $B ) @ #l) ⇒ ⊥))) )
+                  case case_1
+                  solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
+                    case R_Activate
                     solve( !Ltk( $B, ~ea ) ▶₂ #v )
                       case Register_key_honest
                       solve( (∀ rest.
@@ -5879,159 +6032,6 @@ next
                                 case cexp
                                 by solve( !KU( ~ex ) @ #vk.17 )
                               qed
-                            qed
-                          qed
-                        qed
-                      qed
-                    qed
-                  qed
-                qed
-              next
-                case R_Complete_case_2
-                solve( (∃ #v.
-                         (SidUpdated( <'UM3', $B, $A, 
-                                       (<'1', 'g'^~ex>+
-                                        <'2', 'g'^~ey, 
-                                         MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey
-                                                     >)),
-                                             <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
-                                        >+
-                                        <'3', 
-                                         MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey
-                                                     >)),
-                                             <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
-                                        >
-                                       )
-                                      >
-                          ) @ #v))  ∥
-                       ((∀ #k.
-                          (SessionKeyReveal( <'UM3', $B, $A, 
-                                              (<'1', 'g'^~ex>+
-                                               <'2', 'g'^~ey, 
-                                                MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                             'g'^~ey>)),
-                                                    <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
-                                               >+
-                                               <'3', 
-                                                MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                             'g'^~ey>)),
-                                                    <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
-                                               >
-                                              )
-                                             >
-                           ) @ #k)
-                         ⇒
-                          ⊥) ∧
-                        (∀ #k.
-                          (Corrupt( $B ) @ #k)
-                         ⇒
-                          ∃ #l.
-                           (Expire( <'UM3', $B, $A, 
-                                     (<'1', 'g'^~ex>+
-                                      <'2', 'g'^~ey, 
-                                       MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)),
-                                           <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
-                                      >+
-                                      <'3', 
-                                       MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)),
-                                           <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
-                                      >
-                                     )
-                                    >
-                            ) @ #l)
-                          ∧
-                           #l < #k) ∧
-                        (∀ #k.
-                          (SessionStateReveal( <'UM3', $B, $A, 
-                                                (<'1', 'g'^~ex>+
-                                                 <'2', 'g'^~ey, 
-                                                  MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                               'g'^~ey>)),
-                                                      <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
-                                                 >+
-                                                 <'3', 
-                                                  MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                               'g'^~ey>)),
-                                                      <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
-                                                 >
-                                                )
-                                               >
-                           ) @ #k)
-                         ⇒
-                          (∀ #l. (Corrupt( $A ) @ #l) ⇒ ⊥) ∧ (∀ #l. (Corrupt( $B ) @ #l) ⇒ ⊥))) )
-                  case case_1
-                  solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
-                    case R_Activate
-                    solve( !Ltk( $B, ~x ) ▶₂ #v )
-                      case Register_key_honest
-                      solve( !Pk( $A, 'g'^~ea ) ▶₃ #v )
-                        case Register_key_honest
-                        by solve( SidUpdated( <'UM3', $B, $A, 
-                                               (<'1', 'g'^~ex>+
-                                                <'2', 'g'^~ey, 
-                                                 MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                              'g'^~ey>)),
-                                                     <'I', $A, $B, 'g'^~ex, 'g'^~ey>)
-                                                >+
-                                                <'3', 
-                                                 MAC(first(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                                              'g'^~ey>)),
-                                                     <'R', $B, $A, 'g'^~ey, 'g'^~ex>)
-                                                >
-                                               )
-                                              >
-                                  ) @ #v.1 )
-                      qed
-                    qed
-                  qed
-                next
-                  case case_2
-                  solve( R_Act( ~ey, $B, $A, 'g'^~ex ) ▶₀ #v )
-                    case R_Activate
-                    solve( !Ltk( $B, ~x ) ▶₂ #v )
-                      case Register_key_honest
-                      solve( !Pk( $A, 'g'^~ea ) ▶₃ #v )
-                        case Register_key_honest
-                        solve( !KU( second(h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 
-                                              'g'^~ey>))
-                               ) @ #vk.2 )
-                          case Corrupt_SessionKey_case_1
-                          by contradiction /* cyclic */
-                        next
-                          case Corrupt_SessionKey_case_2
-                          by contradiction /* cyclic */
-                        next
-                          case Corrupt_SessionKey_case_3
-                          by contradiction /* cyclic */
-                        next
-                          case Corrupt_SessionKey_case_4
-                          by contradiction /* cyclic */
-                        next
-                          case Reveal_SessionKey_case_1
-                          by contradiction /* from formulas */
-                        next
-                          case Reveal_SessionKey_case_2
-                          by contradiction /* from formulas */
-                        next
-                          case Reveal_SessionKey_case_3
-                          by contradiction /* from formulas */
-                        next
-                          case Reveal_SessionKey_case_4
-                          by contradiction /* from formulas */
-                        next
-                          case c_second
-                          solve( !KU( h(<'g'^(~ex*~ey), 'g'^(~ea*~x), $A, $B, 'g'^~ex, 'g'^~ey>)
-                                 ) @ #vk.6 )
-                            case c_h
-                            solve( !KU( 'g'^(~ex*~ey) ) @ #vk.9 )
-                              case I_Activate
-                              by solve( !KU( ~ey ) @ #vk.16 )
-                            next
-                              case R_Activate
-                              by solve( !KU( ~ex ) @ #vk.16 )
-                            next
-                              case cexp
-                              by solve( !KU( ~ex ) @ #vk.18 )
                             qed
                           qed
                         qed
@@ -13336,8 +13336,8 @@ analyzing: examples/ake/dh/UM_three_pass.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/UM_three_pass.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 149.129579s
+  output:          examples/ake/dh/UM_three_pass.spthy.tmp
+  processing time: 129.436318s
   key_agreement_reachable (exists-trace): verified (14 steps)
   CK_secure_UM3 (all-traces): verified (1170 steps)
 
@@ -13348,8 +13348,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/UM_three_pass.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 149.129579s
+  output:          examples/ake/dh/UM_three_pass.spthy.tmp
+  processing time: 129.436318s
   key_agreement_reachable (exists-trace): verified (14 steps)
   CK_secure_UM3 (all-traces): verified (1170 steps)
 

--- a/case-studies-regression/ake/dh/UM_three_pass_combined_analyzed.spthy
+++ b/case-studies-regression/ake/dh/UM_three_pass_combined_analyzed.spthy
@@ -840,8 +840,8 @@ analyzing: examples/ake/dh/UM_three_pass_combined.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/UM_three_pass_combined.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 30.717862s
+  output:          examples/ake/dh/UM_three_pass_combined.spthy.tmp
+  processing time: 29.11613s
   key_agreement_reachable (exists-trace): verified (14 steps)
   CK_secure_UM3 (all-traces): falsified - found trace (13 steps)
 
@@ -852,8 +852,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/UM_three_pass_combined.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 30.717862s
+  output:          examples/ake/dh/UM_three_pass_combined.spthy.tmp
+  processing time: 29.11613s
   key_agreement_reachable (exists-trace): verified (14 steps)
   CK_secure_UM3 (all-traces): falsified - found trace (13 steps)
 

--- a/case-studies-regression/ake/dh/UM_three_pass_combined_fixed_analyzed.spthy
+++ b/case-studies-regression/ake/dh/UM_three_pass_combined_fixed_analyzed.spthy
@@ -5133,8 +5133,8 @@ analyzing: examples/ake/dh/UM_three_pass_combined_fixed.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ake/dh/UM_three_pass_combined_fixed.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 32.713609s
+  output:          examples/ake/dh/UM_three_pass_combined_fixed.spthy.tmp
+  processing time: 42.209823s
   key_agreement_reachable (exists-trace): verified (14 steps)
   CK_secure_UM3 (all-traces): verified (417 steps)
   CK_secure (all-traces): verified (142 steps)
@@ -5146,8 +5146,8 @@ summary of summaries:
 
 analyzed: examples/ake/dh/UM_three_pass_combined_fixed.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 32.713609s
+  output:          examples/ake/dh/UM_three_pass_combined_fixed.spthy.tmp
+  processing time: 42.209823s
   key_agreement_reachable (exists-trace): verified (14 steps)
   CK_secure_UM3 (all-traces): verified (417 steps)
   CK_secure (all-traces): verified (142 steps)

--- a/case-studies-regression/cav13/DH_example_analyzed.spthy
+++ b/case-studies-regression/cav13/DH_example_analyzed.spthy
@@ -131,8 +131,8 @@ analyzing: examples/cav13/DH_example.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/cav13/DH_example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.209813s
+  output:          examples/cav13/DH_example.spthy.tmp
+  processing time: 0.169248s
   Accept_Secret (all-traces): verified (9 steps)
   Accept_Secret_Counter (all-traces): falsified - found trace (7 steps)
 
@@ -143,8 +143,8 @@ summary of summaries:
 
 analyzed: examples/cav13/DH_example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.209813s
+  output:          examples/cav13/DH_example.spthy.tmp
+  processing time: 0.169248s
   Accept_Secret (all-traces): verified (9 steps)
   Accept_Secret_Counter (all-traces): falsified - found trace (7 steps)
 

--- a/case-studies-regression/ccs15/Attack_TPM_Envelope_analyzed-diff-noprove.spthy
+++ b/case-studies-regression/ccs15/Attack_TPM_Envelope_analyzed-diff-noprove.spthy
@@ -404,8 +404,8 @@ analyzing: examples/ccs15/Attack_TPM_Envelope.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ccs15/Attack_TPM_Envelope.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.646986s
+  output:          examples/ccs15/Attack_TPM_Envelope.spthy.tmp
+  processing time: 0.317167s
   RHS :  types (all-traces): analysis incomplete (1 steps)
   LHS :  types (all-traces): analysis incomplete (1 steps)
   RHS :  PCR_Write_charn (all-traces): analysis incomplete (1 steps)
@@ -423,8 +423,8 @@ summary of summaries:
 
 analyzed: examples/ccs15/Attack_TPM_Envelope.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.646986s
+  output:          examples/ccs15/Attack_TPM_Envelope.spthy.tmp
+  processing time: 0.317167s
   RHS :  types (all-traces): analysis incomplete (1 steps)
   LHS :  types (all-traces): analysis incomplete (1 steps)
   RHS :  PCR_Write_charn (all-traces): analysis incomplete (1 steps)

--- a/case-studies-regression/ccs15/DDH_analyzed-diff.spthy
+++ b/case-studies-regression/ccs15/DDH_analyzed-diff.spthy
@@ -7565,8 +7565,8 @@ analyzing: examples/ccs15/DDH.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ccs15/DDH.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 15.323139s
+  output:          examples/ccs15/DDH.spthy.tmp
+  processing time: 9.255837s
   DiffLemma:  Observational_equivalence : verified (2522 steps)
 
 ------------------------------------------------------------------------------
@@ -7576,8 +7576,8 @@ summary of summaries:
 
 analyzed: examples/ccs15/DDH.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 15.323139s
+  output:          examples/ccs15/DDH.spthy.tmp
+  processing time: 9.255837s
   DiffLemma:  Observational_equivalence : verified (2522 steps)
 
 ==============================================================================

--- a/case-studies-regression/ccs15/probEnc_analyzed-diff.spthy
+++ b/case-studies-regression/ccs15/probEnc_analyzed-diff.spthy
@@ -229,8 +229,8 @@ analyzing: examples/ccs15/probEnc.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ccs15/probEnc.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.288819s
+  output:          examples/ccs15/probEnc.spthy.tmp
+  processing time: 0.158516s
   DiffLemma:  Observational_equivalence : verified (75 steps)
 
 ------------------------------------------------------------------------------
@@ -240,8 +240,8 @@ summary of summaries:
 
 analyzed: examples/ccs15/probEnc.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.288819s
+  output:          examples/ccs15/probEnc.spthy.tmp
+  processing time: 0.158516s
   DiffLemma:  Observational_equivalence : verified (75 steps)
 
 ==============================================================================

--- a/case-studies-regression/ccs15/rfid-feldhofer_analyzed-diff.spthy
+++ b/case-studies-regression/ccs15/rfid-feldhofer_analyzed-diff.spthy
@@ -1502,8 +1502,8 @@ analyzing: examples/ccs15/rfid-feldhofer.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/ccs15/rfid-feldhofer.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.965048s
+  output:          examples/ccs15/rfid-feldhofer.spthy.tmp
+  processing time: 2.704139s
   RHS :  types (all-traces): verified (26 steps)
   LHS :  types (all-traces): verified (26 steps)
   RHS :  executable (exists-trace): verified (6 steps)
@@ -1521,8 +1521,8 @@ summary of summaries:
 
 analyzed: examples/ccs15/rfid-feldhofer.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.965048s
+  output:          examples/ccs15/rfid-feldhofer.spthy.tmp
+  processing time: 2.704139s
   RHS :  types (all-traces): verified (26 steps)
   LHS :  types (all-traces): verified (26 steps)
   RHS :  executable (exists-trace): verified (6 steps)

--- a/case-studies-regression/classic/NSLPK3_analyzed.spthy
+++ b/case-studies-regression/classic/NSLPK3_analyzed.spthy
@@ -722,8 +722,8 @@ analyzing: examples/classic/NSLPK3.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/classic/NSLPK3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.786462s
+  output:          examples/classic/NSLPK3.spthy.tmp
+  processing time: 1.608408s
   types (all-traces): verified (33 steps)
   nonce_secrecy (all-traces): verified (54 steps)
   injective_agree (all-traces): verified (92 steps)
@@ -736,8 +736,8 @@ summary of summaries:
 
 analyzed: examples/classic/NSLPK3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.786462s
+  output:          examples/classic/NSLPK3.spthy.tmp
+  processing time: 1.608408s
   types (all-traces): verified (33 steps)
   nonce_secrecy (all-traces): verified (54 steps)
   injective_agree (all-traces): verified (92 steps)

--- a/case-studies-regression/classic/NSLPK3_untagged_analyzed.spthy
+++ b/case-studies-regression/classic/NSLPK3_untagged_analyzed.spthy
@@ -706,8 +706,8 @@ analyzing: examples/classic/NSLPK3_untagged.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/classic/NSLPK3_untagged.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.438568s
+  output:          examples/classic/NSLPK3_untagged.spthy.tmp
+  processing time: 2.77605s
   types (all-traces): verified (37 steps)
   nonce_secrecy (all-traces): verified (133 steps)
   session_key_setup_possible (exists-trace): verified (9 steps)
@@ -719,8 +719,8 @@ summary of summaries:
 
 analyzed: examples/classic/NSLPK3_untagged.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.438568s
+  output:          examples/classic/NSLPK3_untagged.spthy.tmp
+  processing time: 2.77605s
   types (all-traces): verified (37 steps)
   nonce_secrecy (all-traces): verified (133 steps)
   session_key_setup_possible (exists-trace): verified (9 steps)

--- a/case-studies-regression/classic/NSPK3_analyzed.spthy
+++ b/case-studies-regression/classic/NSPK3_analyzed.spthy
@@ -368,8 +368,8 @@ analyzing: examples/classic/NSPK3.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/classic/NSPK3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 2.39073s
+  output:          examples/classic/NSPK3.spthy.tmp
+  processing time: 2.176622s
   types (all-traces): verified (33 steps)
   nonce_secrecy (all-traces): falsified - found trace (16 steps)
   injective_agree (all-traces): falsified - found trace (14 steps)
@@ -382,8 +382,8 @@ summary of summaries:
 
 analyzed: examples/classic/NSPK3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 2.39073s
+  output:          examples/classic/NSPK3.spthy.tmp
+  processing time: 2.176622s
   types (all-traces): verified (33 steps)
   nonce_secrecy (all-traces): falsified - found trace (16 steps)
   injective_agree (all-traces): falsified - found trace (14 steps)

--- a/case-studies-regression/classic/TLS_Handshake_analyzed.spthy
+++ b/case-studies-regression/classic/TLS_Handshake_analyzed.spthy
@@ -741,8 +741,8 @@ analyzing: examples/classic/TLS_Handshake.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/classic/TLS_Handshake.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.795252s
+  output:          examples/classic/TLS_Handshake.spthy.tmp
+  processing time: 3.356718s
   session_key_secrecy (all-traces): verified (95 steps)
   injective_agree (all-traces): verified (44 steps)
   session_key_setup_possible (exists-trace): verified (11 steps)
@@ -754,8 +754,8 @@ summary of summaries:
 
 analyzed: examples/classic/TLS_Handshake.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.795252s
+  output:          examples/classic/TLS_Handshake.spthy.tmp
+  processing time: 3.356718s
   session_key_secrecy (all-traces): verified (95 steps)
   injective_agree (all-traces): verified (44 steps)
   session_key_setup_possible (exists-trace): verified (11 steps)

--- a/case-studies-regression/csf12/DH2_original_analyzed.spthy
+++ b/case-studies-regression/csf12/DH2_original_analyzed.spthy
@@ -1827,8 +1827,8 @@ analyzing: examples/csf12/DH2_original.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/DH2_original.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 28.367522s
+  output:          examples/csf12/DH2_original.spthy.tmp
+  processing time: 25.10122s
   KAS_key_secrecy (all-traces): verified (503 steps)
 
 ------------------------------------------------------------------------------
@@ -1838,8 +1838,8 @@ summary of summaries:
 
 analyzed: examples/csf12/DH2_original.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 28.367522s
+  output:          examples/csf12/DH2_original.spthy.tmp
+  processing time: 25.10122s
   KAS_key_secrecy (all-traces): verified (503 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/JKL_TS1_2004_KI_analyzed.spthy
+++ b/case-studies-regression/csf12/JKL_TS1_2004_KI_analyzed.spthy
@@ -176,8 +176,8 @@ analyzing: examples/csf12/JKL_TS1_2004_KI.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/JKL_TS1_2004_KI.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.28082s
+  output:          examples/csf12/JKL_TS1_2004_KI.spthy.tmp
+  processing time: 0.283932s
   JKL2008_1_initiator_key (all-traces): falsified - found trace (7 steps)
   JKL2008_1_responder_key (all-traces): falsified - found trace (7 steps)
 
@@ -188,8 +188,8 @@ summary of summaries:
 
 analyzed: examples/csf12/JKL_TS1_2004_KI.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.28082s
+  output:          examples/csf12/JKL_TS1_2004_KI.spthy.tmp
+  processing time: 0.283932s
   JKL2008_1_initiator_key (all-traces): falsified - found trace (7 steps)
   JKL2008_1_responder_key (all-traces): falsified - found trace (7 steps)
 

--- a/case-studies-regression/csf12/JKL_TS1_2008_KI_analyzed.spthy
+++ b/case-studies-regression/csf12/JKL_TS1_2008_KI_analyzed.spthy
@@ -221,8 +221,8 @@ analyzing: examples/csf12/JKL_TS1_2008_KI.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/JKL_TS1_2008_KI.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.258105s
+  output:          examples/csf12/JKL_TS1_2008_KI.spthy.tmp
+  processing time: 0.29514s
   JKL2008_1_initiator_key (all-traces): verified (15 steps)
   JKL2008_1_responder_key (all-traces): verified (15 steps)
 
@@ -233,8 +233,8 @@ summary of summaries:
 
 analyzed: examples/csf12/JKL_TS1_2008_KI.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.258105s
+  output:          examples/csf12/JKL_TS1_2008_KI.spthy.tmp
+  processing time: 0.29514s
   JKL2008_1_initiator_key (all-traces): verified (15 steps)
   JKL2008_1_responder_key (all-traces): verified (15 steps)
 

--- a/case-studies-regression/csf12/JKL_TS2_2004_KI_wPFS_analyzed.spthy
+++ b/case-studies-regression/csf12/JKL_TS2_2004_KI_wPFS_analyzed.spthy
@@ -251,8 +251,8 @@ analyzing: examples/csf12/JKL_TS2_2004_KI_wPFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/JKL_TS2_2004_KI_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.477881s
+  output:          examples/csf12/JKL_TS2_2004_KI_wPFS.spthy.tmp
+  processing time: 0.457404s
   JKL2008_2_initiator_key (all-traces): falsified - found trace (7 steps)
   JKL2008_2_responder_key (all-traces): falsified - found trace (7 steps)
 
@@ -263,8 +263,8 @@ summary of summaries:
 
 analyzed: examples/csf12/JKL_TS2_2004_KI_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.477881s
+  output:          examples/csf12/JKL_TS2_2004_KI_wPFS.spthy.tmp
+  processing time: 0.457404s
   JKL2008_2_initiator_key (all-traces): falsified - found trace (7 steps)
   JKL2008_2_responder_key (all-traces): falsified - found trace (7 steps)
 

--- a/case-studies-regression/csf12/JKL_TS2_2008_KI_wPFS_analyzed.spthy
+++ b/case-studies-regression/csf12/JKL_TS2_2008_KI_wPFS_analyzed.spthy
@@ -445,8 +445,8 @@ analyzing: examples/csf12/JKL_TS2_2008_KI_wPFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/JKL_TS2_2008_KI_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.143515s
+  output:          examples/csf12/JKL_TS2_2008_KI_wPFS.spthy.tmp
+  processing time: 1.074591s
   JKL2008_2_initiator_key (all-traces): verified (40 steps)
   JKL2008_2_responder_key (all-traces): verified (37 steps)
 
@@ -457,8 +457,8 @@ summary of summaries:
 
 analyzed: examples/csf12/JKL_TS2_2008_KI_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.143515s
+  output:          examples/csf12/JKL_TS2_2008_KI_wPFS.spthy.tmp
+  processing time: 1.074591s
   JKL2008_2_initiator_key (all-traces): verified (40 steps)
   JKL2008_2_responder_key (all-traces): verified (37 steps)
 

--- a/case-studies-regression/csf12/KAS1_analyzed.spthy
+++ b/case-studies-regression/csf12/KAS1_analyzed.spthy
@@ -258,8 +258,8 @@ analyzing: examples/csf12/KAS1.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/KAS1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.734528s
+  output:          examples/csf12/KAS1.spthy.tmp
+  processing time: 0.673945s
   KAS1_key_secrecy (all-traces): verified (38 steps)
 
 ------------------------------------------------------------------------------
@@ -269,8 +269,8 @@ summary of summaries:
 
 analyzed: examples/csf12/KAS1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.734528s
+  output:          examples/csf12/KAS1.spthy.tmp
+  processing time: 0.673945s
   KAS1_key_secrecy (all-traces): verified (38 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/KAS2_eCK_analyzed.spthy
+++ b/case-studies-regression/csf12/KAS2_eCK_analyzed.spthy
@@ -242,8 +242,8 @@ analyzing: examples/csf12/KAS2_eCK.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/KAS2_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.011161s
+  output:          examples/csf12/KAS2_eCK.spthy.tmp
+  processing time: 3.112278s
   eCK_key_secrecy (all-traces): falsified - found trace (16 steps)
 
 ------------------------------------------------------------------------------
@@ -253,8 +253,8 @@ summary of summaries:
 
 analyzed: examples/csf12/KAS2_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.011161s
+  output:          examples/csf12/KAS2_eCK.spthy.tmp
+  processing time: 3.112278s
   eCK_key_secrecy (all-traces): falsified - found trace (16 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/KAS2_original_analyzed.spthy
+++ b/case-studies-regression/csf12/KAS2_original_analyzed.spthy
@@ -1044,8 +1044,8 @@ analyzing: examples/csf12/KAS2_original.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/KAS2_original.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 5.773157s
+  output:          examples/csf12/KAS2_original.spthy.tmp
+  processing time: 5.84085s
   KAS_key_secrecy (all-traces): verified (254 steps)
 
 ------------------------------------------------------------------------------
@@ -1055,8 +1055,8 @@ summary of summaries:
 
 analyzed: examples/csf12/KAS2_original.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 5.773157s
+  output:          examples/csf12/KAS2_original.spthy.tmp
+  processing time: 5.84085s
   KAS_key_secrecy (all-traces): verified (254 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/KEA_plus_KI_KCI_analyzed.spthy
+++ b/case-studies-regression/csf12/KEA_plus_KI_KCI_analyzed.spthy
@@ -287,8 +287,8 @@ analyzing: examples/csf12/KEA_plus_KI_KCI.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/KEA_plus_KI_KCI.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.589454s
+  output:          examples/csf12/KEA_plus_KI_KCI.spthy.tmp
+  processing time: 0.53658s
   keaplus_initiator_key (all-traces): verified (13 steps)
   keaplus_responder_key (all-traces): verified (13 steps)
 
@@ -299,8 +299,8 @@ summary of summaries:
 
 analyzed: examples/csf12/KEA_plus_KI_KCI.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.589454s
+  output:          examples/csf12/KEA_plus_KI_KCI.spthy.tmp
+  processing time: 0.53658s
   keaplus_initiator_key (all-traces): verified (13 steps)
   keaplus_responder_key (all-traces): verified (13 steps)
 

--- a/case-studies-regression/csf12/KEA_plus_KI_KCI_wPFS_analyzed.spthy
+++ b/case-studies-regression/csf12/KEA_plus_KI_KCI_wPFS_analyzed.spthy
@@ -283,8 +283,8 @@ analyzing: examples/csf12/KEA_plus_KI_KCI_wPFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/KEA_plus_KI_KCI_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.305033s
+  output:          examples/csf12/KEA_plus_KI_KCI_wPFS.spthy.tmp
+  processing time: 1.04381s
   keaplus_initiator_key (all-traces): falsified - found trace (11 steps)
   keaplus_responder_key (all-traces): falsified - found trace (11 steps)
 
@@ -295,8 +295,8 @@ summary of summaries:
 
 analyzed: examples/csf12/KEA_plus_KI_KCI_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.305033s
+  output:          examples/csf12/KEA_plus_KI_KCI_wPFS.spthy.tmp
+  processing time: 1.04381s
   keaplus_initiator_key (all-traces): falsified - found trace (11 steps)
   keaplus_responder_key (all-traces): falsified - found trace (11 steps)
 

--- a/case-studies-regression/csf12/NAXOS_eCK_PFS_analyzed.spthy
+++ b/case-studies-regression/csf12/NAXOS_eCK_PFS_analyzed.spthy
@@ -359,8 +359,8 @@ analyzing: examples/csf12/NAXOS_eCK_PFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/NAXOS_eCK_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.001276s
+  output:          examples/csf12/NAXOS_eCK_PFS.spthy.tmp
+  processing time: 4.050978s
   eCK_PFS_key_secrecy (all-traces): falsified - found trace (13 steps)
 
 ------------------------------------------------------------------------------
@@ -370,8 +370,8 @@ summary of summaries:
 
 analyzed: examples/csf12/NAXOS_eCK_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.001276s
+  output:          examples/csf12/NAXOS_eCK_PFS.spthy.tmp
+  processing time: 4.050978s
   eCK_PFS_key_secrecy (all-traces): falsified - found trace (13 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/NAXOS_eCK_analyzed.spthy
+++ b/case-studies-regression/csf12/NAXOS_eCK_analyzed.spthy
@@ -733,8 +733,8 @@ analyzing: examples/csf12/NAXOS_eCK.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/NAXOS_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.285299s
+  output:          examples/csf12/NAXOS_eCK.spthy.tmp
+  processing time: 4.397394s
   eCK_key_secrecy (all-traces): verified (134 steps)
 
 ------------------------------------------------------------------------------
@@ -744,8 +744,8 @@ summary of summaries:
 
 analyzed: examples/csf12/NAXOS_eCK.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.285299s
+  output:          examples/csf12/NAXOS_eCK.spthy.tmp
+  processing time: 4.397394s
   eCK_key_secrecy (all-traces): verified (134 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/STS_MAC_analyzed.spthy
+++ b/case-studies-regression/csf12/STS_MAC_analyzed.spthy
@@ -318,8 +318,8 @@ analyzing: examples/csf12/STS_MAC.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/STS_MAC.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 2.941517s
+  output:          examples/csf12/STS_MAC.spthy.tmp
+  processing time: 2.875225s
   KI_Perfect_Forward_Secrecy_I (all-traces): falsified - found trace (12 steps)
   KI_Perfect_Forward_Secrecy_R (all-traces): falsified - found trace (12 steps)
 
@@ -330,8 +330,8 @@ summary of summaries:
 
 analyzed: examples/csf12/STS_MAC.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 2.941517s
+  output:          examples/csf12/STS_MAC.spthy.tmp
+  processing time: 2.875225s
   KI_Perfect_Forward_Secrecy_I (all-traces): falsified - found trace (12 steps)
   KI_Perfect_Forward_Secrecy_R (all-traces): falsified - found trace (12 steps)
 

--- a/case-studies-regression/csf12/STS_MAC_fix1_analyzed.spthy
+++ b/case-studies-regression/csf12/STS_MAC_fix1_analyzed.spthy
@@ -1098,8 +1098,8 @@ analyzing: examples/csf12/STS_MAC_fix1.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/STS_MAC_fix1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 7.65816s
+  output:          examples/csf12/STS_MAC_fix1.spthy.tmp
+  processing time: 7.374955s
   KI_Perfect_Forward_Secrecy_I (all-traces): verified (109 steps)
   KI_Perfect_Forward_Secrecy_R (all-traces): verified (160 steps)
 
@@ -1110,8 +1110,8 @@ summary of summaries:
 
 analyzed: examples/csf12/STS_MAC_fix1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 7.65816s
+  output:          examples/csf12/STS_MAC_fix1.spthy.tmp
+  processing time: 7.374955s
   KI_Perfect_Forward_Secrecy_I (all-traces): verified (109 steps)
   KI_Perfect_Forward_Secrecy_R (all-traces): verified (160 steps)
 

--- a/case-studies-regression/csf12/STS_MAC_fix2_analyzed.spthy
+++ b/case-studies-regression/csf12/STS_MAC_fix2_analyzed.spthy
@@ -420,8 +420,8 @@ analyzing: examples/csf12/STS_MAC_fix2.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/STS_MAC_fix2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.512141s
+  output:          examples/csf12/STS_MAC_fix2.spthy.tmp
+  processing time: 1.395327s
   KI_Perfect_Forward_Secrecy_I (all-traces): verified (26 steps)
   KI_Perfect_Forward_Secrecy_R (all-traces): verified (28 steps)
 
@@ -432,8 +432,8 @@ summary of summaries:
 
 analyzed: examples/csf12/STS_MAC_fix2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.512141s
+  output:          examples/csf12/STS_MAC_fix2.spthy.tmp
+  processing time: 1.395327s
   KI_Perfect_Forward_Secrecy_I (all-traces): verified (26 steps)
   KI_Perfect_Forward_Secrecy_R (all-traces): verified (28 steps)
 

--- a/case-studies-regression/csf12/SignedDH_PFS_analyzed.spthy
+++ b/case-studies-regression/csf12/SignedDH_PFS_analyzed.spthy
@@ -216,8 +216,8 @@ analyzing: examples/csf12/SignedDH_PFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/SignedDH_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.55644s
+  output:          examples/csf12/SignedDH_PFS.spthy.tmp
+  processing time: 0.517611s
   Perfect_Forward_Secrecy (all-traces): verified (23 steps)
 
 ------------------------------------------------------------------------------
@@ -227,8 +227,8 @@ summary of summaries:
 
 analyzed: examples/csf12/SignedDH_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.55644s
+  output:          examples/csf12/SignedDH_PFS.spthy.tmp
+  processing time: 0.517611s
   Perfect_Forward_Secrecy (all-traces): verified (23 steps)
 
 ==============================================================================

--- a/case-studies-regression/csf12/UM_PFS_analyzed.spthy
+++ b/case-studies-regression/csf12/UM_PFS_analyzed.spthy
@@ -217,8 +217,8 @@ analyzing: examples/csf12/UM_PFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/UM_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.114374s
+  output:          examples/csf12/UM_PFS.spthy.tmp
+  processing time: 0.920552s
   wPFS_initiator_key (all-traces): falsified - found trace (10 steps)
   wPFS_responder_key (all-traces): falsified - found trace (10 steps)
 
@@ -229,8 +229,8 @@ summary of summaries:
 
 analyzed: examples/csf12/UM_PFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.114374s
+  output:          examples/csf12/UM_PFS.spthy.tmp
+  processing time: 0.920552s
   wPFS_initiator_key (all-traces): falsified - found trace (10 steps)
   wPFS_responder_key (all-traces): falsified - found trace (10 steps)
 

--- a/case-studies-regression/csf12/UM_wPFS_analyzed.spthy
+++ b/case-studies-regression/csf12/UM_wPFS_analyzed.spthy
@@ -416,8 +416,8 @@ analyzing: examples/csf12/UM_wPFS.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/csf12/UM_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.039146s
+  output:          examples/csf12/UM_wPFS.spthy.tmp
+  processing time: 0.995833s
   wPFS_initiator_key (all-traces): verified (40 steps)
   wPFS_responder_key (all-traces): verified (37 steps)
 
@@ -428,8 +428,8 @@ summary of summaries:
 
 analyzed: examples/csf12/UM_wPFS.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.039146s
+  output:          examples/csf12/UM_wPFS.spthy.tmp
+  processing time: 0.995833s
   wPFS_initiator_key (all-traces): verified (40 steps)
   wPFS_responder_key (all-traces): verified (37 steps)
 

--- a/case-studies-regression/features/equivalence/AxiomDiffTest1_analyzed-diff.spthy
+++ b/case-studies-regression/features/equivalence/AxiomDiffTest1_analyzed-diff.spthy
@@ -38,8 +38,8 @@ analyzing: examples/features/equivalence/AxiomDiffTest1.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features/equivalence/AxiomDiffTest1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.088387s
+  output:          examples/features/equivalence/AxiomDiffTest1.spthy.tmp
+  processing time: 0.06689s
   DiffLemma:  Observational_equivalence : falsified - found trace (4 steps)
 
 ------------------------------------------------------------------------------
@@ -49,8 +49,8 @@ summary of summaries:
 
 analyzed: examples/features/equivalence/AxiomDiffTest1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.088387s
+  output:          examples/features/equivalence/AxiomDiffTest1.spthy.tmp
+  processing time: 0.06689s
   DiffLemma:  Observational_equivalence : falsified - found trace (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/equivalence/AxiomDiffTest2_analyzed-diff.spthy
+++ b/case-studies-regression/features/equivalence/AxiomDiffTest2_analyzed-diff.spthy
@@ -48,8 +48,8 @@ analyzing: examples/features/equivalence/AxiomDiffTest2.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features/equivalence/AxiomDiffTest2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.087076s
+  output:          examples/features/equivalence/AxiomDiffTest2.spthy.tmp
+  processing time: 0.077409s
   DiffLemma:  Observational_equivalence : falsified - found trace (5 steps)
 
 ------------------------------------------------------------------------------
@@ -59,8 +59,8 @@ summary of summaries:
 
 analyzed: examples/features/equivalence/AxiomDiffTest2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.087076s
+  output:          examples/features/equivalence/AxiomDiffTest2.spthy.tmp
+  processing time: 0.077409s
   DiffLemma:  Observational_equivalence : falsified - found trace (5 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/equivalence/AxiomDiffTest3_analyzed-diff.spthy
+++ b/case-studies-regression/features/equivalence/AxiomDiffTest3_analyzed-diff.spthy
@@ -38,8 +38,8 @@ analyzing: examples/features/equivalence/AxiomDiffTest3.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features/equivalence/AxiomDiffTest3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.085515s
+  output:          examples/features/equivalence/AxiomDiffTest3.spthy.tmp
+  processing time: 0.064058s
   DiffLemma:  Observational_equivalence : falsified - found trace (4 steps)
 
 ------------------------------------------------------------------------------
@@ -49,8 +49,8 @@ summary of summaries:
 
 analyzed: examples/features/equivalence/AxiomDiffTest3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.085515s
+  output:          examples/features/equivalence/AxiomDiffTest3.spthy.tmp
+  processing time: 0.064058s
   DiffLemma:  Observational_equivalence : falsified - found trace (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/equivalence/AxiomDiffTest4_analyzed-diff.spthy
+++ b/case-studies-regression/features/equivalence/AxiomDiffTest4_analyzed-diff.spthy
@@ -44,8 +44,8 @@ analyzing: examples/features/equivalence/AxiomDiffTest4.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features/equivalence/AxiomDiffTest4.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.091158s
+  output:          examples/features/equivalence/AxiomDiffTest4.spthy.tmp
+  processing time: 0.107413s
   DiffLemma:  Observational_equivalence : falsified - found trace (6 steps)
 
 ------------------------------------------------------------------------------
@@ -55,8 +55,8 @@ summary of summaries:
 
 analyzed: examples/features/equivalence/AxiomDiffTest4.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.091158s
+  output:          examples/features/equivalence/AxiomDiffTest4.spthy.tmp
+  processing time: 0.107413s
   DiffLemma:  Observational_equivalence : falsified - found trace (6 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/equivalence/N5N6DiffTest_analyzed-diff.spthy
+++ b/case-studies-regression/features/equivalence/N5N6DiffTest_analyzed-diff.spthy
@@ -46,8 +46,8 @@ analyzing: examples/features/equivalence/N5N6DiffTest.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features/equivalence/N5N6DiffTest.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.078244s
+  output:          examples/features/equivalence/N5N6DiffTest.spthy.tmp
+  processing time: 0.07534s
   DiffLemma:  Observational_equivalence : falsified - found trace (8 steps)
 
 ------------------------------------------------------------------------------
@@ -57,8 +57,8 @@ summary of summaries:
 
 analyzed: examples/features/equivalence/N5N6DiffTest.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.078244s
+  output:          examples/features/equivalence/N5N6DiffTest.spthy.tmp
+  processing time: 0.07534s
   DiffLemma:  Observational_equivalence : falsified - found trace (8 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/injectivity/injectivity_analyzed.spthy
+++ b/case-studies-regression/features/injectivity/injectivity_analyzed.spthy
@@ -77,8 +77,8 @@ analyzing: examples/features//injectivity/injectivity.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features//injectivity/injectivity.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.060922s
+  output:          examples/features//injectivity/injectivity.spthy.tmp
+  processing time: 0.057379s
   injectivity_check (all-traces): verified (9 steps)
 
 ------------------------------------------------------------------------------
@@ -88,8 +88,8 @@ summary of summaries:
 
 analyzed: examples/features//injectivity/injectivity.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.060922s
+  output:          examples/features//injectivity/injectivity.spthy.tmp
+  processing time: 0.057379s
   injectivity_check (all-traces): verified (9 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/multiset/counter_analyzed.spthy
+++ b/case-studies-regression/features/multiset/counter_analyzed.spthy
@@ -526,8 +526,8 @@ analyzing: examples/features//multiset/counter.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features//multiset/counter.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.901957s
+  output:          examples/features//multiset/counter.spthy.tmp
+  processing time: 1.353469s
   counters_linear_order (all-traces): verified (52 steps)
   counter_start (all-traces): verified (8 steps)
   counter_increases (all-traces): verified (58 steps)
@@ -540,8 +540,8 @@ summary of summaries:
 
 analyzed: examples/features//multiset/counter.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.901957s
+  output:          examples/features//multiset/counter.spthy.tmp
+  processing time: 1.353469s
   counters_linear_order (all-traces): verified (52 steps)
   counter_start (all-traces): verified (8 steps)
   counter_increases (all-traces): verified (58 steps)

--- a/case-studies-regression/features/private_function_symbols/NAXOS_eCK_PFS_private_analyzed.spthy
+++ b/case-studies-regression/features/private_function_symbols/NAXOS_eCK_PFS_private_analyzed.spthy
@@ -350,8 +350,8 @@ analyzing: examples/features//private_function_symbols/NAXOS_eCK_PFS_private.spt
 ------------------------------------------------------------------------------
 analyzed: examples/features//private_function_symbols/NAXOS_eCK_PFS_private.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.436299s
+  output:          examples/features//private_function_symbols/NAXOS_eCK_PFS_private.spthy.tmp
+  processing time: 2.577677s
   eCK_PFS_key_secrecy (all-traces): falsified - found trace (14 steps)
 
 ------------------------------------------------------------------------------
@@ -361,8 +361,8 @@ summary of summaries:
 
 analyzed: examples/features//private_function_symbols/NAXOS_eCK_PFS_private.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.436299s
+  output:          examples/features//private_function_symbols/NAXOS_eCK_PFS_private.spthy.tmp
+  processing time: 2.577677s
   eCK_PFS_key_secrecy (all-traces): falsified - found trace (14 steps)
 
 ==============================================================================

--- a/case-studies-regression/features/private_function_symbols/NAXOS_eCK_private_analyzed.spthy
+++ b/case-studies-regression/features/private_function_symbols/NAXOS_eCK_private_analyzed.spthy
@@ -589,8 +589,8 @@ analyzing: examples/features//private_function_symbols/NAXOS_eCK_private.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/features//private_function_symbols/NAXOS_eCK_private.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.129169s
+  output:          examples/features//private_function_symbols/NAXOS_eCK_private.spthy.tmp
+  processing time: 2.424008s
   eCK_key_secrecy (all-traces): verified (89 steps)
 
 ------------------------------------------------------------------------------
@@ -600,8 +600,8 @@ summary of summaries:
 
 analyzed: examples/features//private_function_symbols/NAXOS_eCK_private.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.129169s
+  output:          examples/features//private_function_symbols/NAXOS_eCK_private.spthy.tmp
+  processing time: 2.424008s
   eCK_key_secrecy (all-traces): verified (89 steps)
 
 ==============================================================================

--- a/case-studies-regression/loops/JCS12_Typing_Example_analyzed.spthy
+++ b/case-studies-regression/loops/JCS12_Typing_Example_analyzed.spthy
@@ -281,8 +281,8 @@ analyzing: examples/loops/JCS12_Typing_Example.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/JCS12_Typing_Example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.244078s
+  output:          examples/loops/JCS12_Typing_Example.spthy.tmp
+  processing time: 0.212699s
   typing_assertion (all-traces): verified (16 steps)
   Client_session_key_secrecy_raw (all-traces): verified (8 steps)
   Client_session_key_secrecy (all-traces): verified (4 steps)
@@ -295,8 +295,8 @@ summary of summaries:
 
 analyzed: examples/loops/JCS12_Typing_Example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.244078s
+  output:          examples/loops/JCS12_Typing_Example.spthy.tmp
+  processing time: 0.212699s
   typing_assertion (all-traces): verified (16 steps)
   Client_session_key_secrecy_raw (all-traces): verified (8 steps)
   Client_session_key_secrecy (all-traces): verified (4 steps)

--- a/case-studies-regression/loops/Minimal_Create_Use_Destroy_analyzed.spthy
+++ b/case-studies-regression/loops/Minimal_Create_Use_Destroy_analyzed.spthy
@@ -185,8 +185,8 @@ analyzing: examples/loops/Minimal_Create_Use_Destroy.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/Minimal_Create_Use_Destroy.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.183624s
+  output:          examples/loops/Minimal_Create_Use_Destroy.spthy.tmp
+  processing time: 0.159806s
   Use_charn (all-traces): verified (8 steps)
   Destroy_charn (all-traces): verified (28 steps)
 
@@ -197,8 +197,8 @@ summary of summaries:
 
 analyzed: examples/loops/Minimal_Create_Use_Destroy.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.183624s
+  output:          examples/loops/Minimal_Create_Use_Destroy.spthy.tmp
+  processing time: 0.159806s
   Use_charn (all-traces): verified (8 steps)
   Destroy_charn (all-traces): verified (28 steps)
 

--- a/case-studies-regression/loops/Minimal_Crypto_API_analyzed.spthy
+++ b/case-studies-regression/loops/Minimal_Crypto_API_analyzed.spthy
@@ -79,8 +79,8 @@ analyzing: examples/loops/Minimal_Crypto_API.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/Minimal_Crypto_API.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.087879s
+  output:          examples/loops/Minimal_Crypto_API.spthy.tmp
+  processing time: 0.080635s
   NewKey_invariant (all-traces): verified (8 steps)
   NewKey_secrecy (all-traces): verified (2 steps)
 
@@ -91,8 +91,8 @@ summary of summaries:
 
 analyzed: examples/loops/Minimal_Crypto_API.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.087879s
+  output:          examples/loops/Minimal_Crypto_API.spthy.tmp
+  processing time: 0.080635s
   NewKey_invariant (all-traces): verified (8 steps)
   NewKey_secrecy (all-traces): verified (2 steps)
 

--- a/case-studies-regression/loops/Minimal_KeyRenegotiation_analyzed.spthy
+++ b/case-studies-regression/loops/Minimal_KeyRenegotiation_analyzed.spthy
@@ -137,8 +137,8 @@ analyzing: examples/loops/Minimal_KeyRenegotiation.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/Minimal_KeyRenegotiation.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.092227s
+  output:          examples/loops/Minimal_KeyRenegotiation.spthy.tmp
+  processing time: 0.101173s
   Secret_reachable (exists-trace): verified (5 steps)
   secrecy (all-traces): verified (23 steps)
 
@@ -149,8 +149,8 @@ summary of summaries:
 
 analyzed: examples/loops/Minimal_KeyRenegotiation.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.092227s
+  output:          examples/loops/Minimal_KeyRenegotiation.spthy.tmp
+  processing time: 0.101173s
   Secret_reachable (exists-trace): verified (5 steps)
   secrecy (all-traces): verified (23 steps)
 

--- a/case-studies-regression/loops/Minimal_Loop_Example_analyzed.spthy
+++ b/case-studies-regression/loops/Minimal_Loop_Example_analyzed.spthy
@@ -171,8 +171,8 @@ analyzing: examples/loops/Minimal_Loop_Example.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/Minimal_Loop_Example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.083678s
+  output:          examples/loops/Minimal_Loop_Example.spthy.tmp
+  processing time: 0.094496s
   Start_before_Loop (all-traces): verified (8 steps)
   Start_before_Stop (all-traces): verified (4 steps)
   Loop_before_Stop (all-traces): verified (9 steps)
@@ -186,8 +186,8 @@ summary of summaries:
 
 analyzed: examples/loops/Minimal_Loop_Example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.083678s
+  output:          examples/loops/Minimal_Loop_Example.spthy.tmp
+  processing time: 0.094496s
   Start_before_Loop (all-traces): verified (8 steps)
   Start_before_Stop (all-traces): verified (4 steps)
   Loop_before_Stop (all-traces): verified (9 steps)

--- a/case-studies-regression/loops/Minimal_Typing_Example_analyzed.spthy
+++ b/case-studies-regression/loops/Minimal_Typing_Example_analyzed.spthy
@@ -153,8 +153,8 @@ analyzing: examples/loops/Minimal_Typing_Example.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/Minimal_Typing_Example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.13527s
+  output:          examples/loops/Minimal_Typing_Example.spthy.tmp
+  processing time: 0.142752s
   sources_assertion (all-traces): verified (13 steps)
   Responder_secrecy (all-traces): verified (8 steps)
   Public_part_public (exists-trace): verified (5 steps)
@@ -166,8 +166,8 @@ summary of summaries:
 
 analyzed: examples/loops/Minimal_Typing_Example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.13527s
+  output:          examples/loops/Minimal_Typing_Example.spthy.tmp
+  processing time: 0.142752s
   sources_assertion (all-traces): verified (13 steps)
   Responder_secrecy (all-traces): verified (8 steps)
   Public_part_public (exists-trace): verified (5 steps)

--- a/case-studies-regression/loops/RFID_Simple_analyzed.spthy
+++ b/case-studies-regression/loops/RFID_Simple_analyzed.spthy
@@ -518,8 +518,8 @@ analyzing: examples/loops/RFID_Simple.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/RFID_Simple.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.623295s
+  output:          examples/loops/RFID_Simple.spthy.tmp
+  processing time: 0.506054s
   types (all-traces): verified (86 steps)
   Device_ToBob (all-traces): verified (12 steps)
   Device_Init_Use_Set (all-traces): verified (18 steps)
@@ -532,8 +532,8 @@ summary of summaries:
 
 analyzed: examples/loops/RFID_Simple.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.623295s
+  output:          examples/loops/RFID_Simple.spthy.tmp
+  processing time: 0.506054s
   types (all-traces): verified (86 steps)
   Device_ToBob (all-traces): verified (12 steps)
   Device_Init_Use_Set (all-traces): verified (18 steps)

--- a/case-studies-regression/loops/TESLA_Scheme1_analyzed.spthy
+++ b/case-studies-regression/loops/TESLA_Scheme1_analyzed.spthy
@@ -782,8 +782,8 @@ analyzing: examples/loops/TESLA_Scheme1.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/TESLA_Scheme1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.251911s
+  output:          examples/loops/TESLA_Scheme1.spthy.tmp
+  processing time: 3.64113s
   authentic (all-traces): verified (158 steps)
   authentic_reachable (exists-trace): verified (13 steps)
 
@@ -794,8 +794,8 @@ summary of summaries:
 
 analyzed: examples/loops/TESLA_Scheme1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.251911s
+  output:          examples/loops/TESLA_Scheme1.spthy.tmp
+  processing time: 3.64113s
   authentic (all-traces): verified (158 steps)
   authentic_reachable (exists-trace): verified (13 steps)
 

--- a/case-studies-regression/loops/Typing_and_Destructors_analyzed.spthy
+++ b/case-studies-regression/loops/Typing_and_Destructors_analyzed.spthy
@@ -287,8 +287,8 @@ analyzing: examples/loops/Typing_and_Destructors.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/loops/Typing_and_Destructors.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.236983s
+  output:          examples/loops/Typing_and_Destructors.spthy.tmp
+  processing time: 0.235312s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -303,8 +303,8 @@ summary of summaries:
 
 analyzed: examples/loops/Typing_and_Destructors.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.236983s
+  output:          examples/loops/Typing_and_Destructors.spthy.tmp
+  processing time: 0.235312s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/post17/chaum_anonymity_analyzed-diff.spthy
+++ b/case-studies-regression/post17/chaum_anonymity_analyzed-diff.spthy
@@ -2292,8 +2292,8 @@ analyzing: examples/post17/chaum_anonymity.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/chaum_anonymity.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.841516s
+  output:          examples/post17/chaum_anonymity.spthy.tmp
+  processing time: 7.279314s
   RHS :  exec (exists-trace): verified (9 steps)
   LHS :  exec (exists-trace): verified (9 steps)
   DiffLemma:  Observational_equivalence : verified (739 steps)
@@ -2305,8 +2305,8 @@ summary of summaries:
 
 analyzed: examples/post17/chaum_anonymity.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.841516s
+  output:          examples/post17/chaum_anonymity.spthy.tmp
+  processing time: 7.279314s
   RHS :  exec (exists-trace): verified (9 steps)
   LHS :  exec (exists-trace): verified (9 steps)
   DiffLemma:  Observational_equivalence : verified (739 steps)

--- a/case-studies-regression/post17/chaum_unforgeability_analyzed.spthy
+++ b/case-studies-regression/post17/chaum_unforgeability_analyzed.spthy
@@ -129,8 +129,8 @@ analyzing: examples/post17/chaum_unforgeability.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/chaum_unforgeability.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.131091s
+  output:          examples/post17/chaum_unforgeability.spthy.tmp
+  processing time: 0.123252s
   exec (exists-trace): verified (6 steps)
   unforgeability (all-traces): verified (10 steps)
 
@@ -141,8 +141,8 @@ summary of summaries:
 
 analyzed: examples/post17/chaum_unforgeability.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.131091s
+  output:          examples/post17/chaum_unforgeability.spthy.tmp
+  processing time: 0.123252s
   exec (exists-trace): verified (6 steps)
   unforgeability (all-traces): verified (10 steps)
 

--- a/case-studies-regression/post17/chaum_untraceability_analyzed-diff.spthy
+++ b/case-studies-regression/post17/chaum_untraceability_analyzed-diff.spthy
@@ -8703,8 +8703,8 @@ analyzing: examples/post17/chaum_untraceability.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/chaum_untraceability.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 89.246139s
+  output:          examples/post17/chaum_untraceability.spthy.tmp
+  processing time: 66.280516s
   RHS :  exec (exists-trace): verified (15 steps)
   LHS :  exec (exists-trace): verified (15 steps)
   DiffLemma:  Observational_equivalence : verified (2863 steps)
@@ -8716,8 +8716,8 @@ summary of summaries:
 
 analyzed: examples/post17/chaum_untraceability.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 89.246139s
+  output:          examples/post17/chaum_untraceability.spthy.tmp
+  processing time: 66.280516s
   RHS :  exec (exists-trace): verified (15 steps)
   LHS :  exec (exists-trace): verified (15 steps)
   DiffLemma:  Observational_equivalence : verified (2863 steps)

--- a/case-studies-regression/post17/denning_sacco_symmetric_cbc_analyzed.spthy
+++ b/case-studies-regression/post17/denning_sacco_symmetric_cbc_analyzed.spthy
@@ -128,8 +128,8 @@ analyzing: examples/post17/denning_sacco_symmetric_cbc.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/denning_sacco_symmetric_cbc.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.27455s
+  output:          examples/post17/denning_sacco_symmetric_cbc.spthy.tmp
+  processing time: 0.265573s
   executable (exists-trace): verified (8 steps)
   sessionsmatch (all-traces): falsified - found trace (4 steps)
 
@@ -140,8 +140,8 @@ summary of summaries:
 
 analyzed: examples/post17/denning_sacco_symmetric_cbc.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.27455s
+  output:          examples/post17/denning_sacco_symmetric_cbc.spthy.tmp
+  processing time: 0.265573s
   executable (exists-trace): verified (8 steps)
   sessionsmatch (all-traces): falsified - found trace (4 steps)
 

--- a/case-studies-regression/post17/foo_eligibility_analyzed.spthy
+++ b/case-studies-regression/post17/foo_eligibility_analyzed.spthy
@@ -326,8 +326,8 @@ analyzing: examples/post17/foo_eligibility.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/foo_eligibility.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 12.772496s
+  output:          examples/post17/foo_eligibility.spthy.tmp
+  processing time: 9.544289s
   types (all-traces): verified (44 steps)
   exec (exists-trace): verified (9 steps)
   eligibility (all-traces): verified (11 steps)
@@ -339,8 +339,8 @@ summary of summaries:
 
 analyzed: examples/post17/foo_eligibility.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 12.772496s
+  output:          examples/post17/foo_eligibility.spthy.tmp
+  processing time: 9.544289s
   types (all-traces): verified (44 steps)
   exec (exists-trace): verified (9 steps)
   eligibility (all-traces): verified (11 steps)

--- a/case-studies-regression/post17/foo_vote_privacy_analyzed-diff.spthy
+++ b/case-studies-regression/post17/foo_vote_privacy_analyzed-diff.spthy
@@ -21898,8 +21898,8 @@ analyzing: examples/post17/foo_vote_privacy.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/foo_vote_privacy.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 311.165358s
+  output:          examples/post17/foo_vote_privacy.spthy.tmp
+  processing time: 250.063279s
   RHS :  exec (exists-trace): verified (12 steps)
   LHS :  exec (exists-trace): verified (12 steps)
   DiffLemma:  Observational_equivalence : verified (7204 steps)
@@ -21911,8 +21911,8 @@ summary of summaries:
 
 analyzed: examples/post17/foo_vote_privacy.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 311.165358s
+  output:          examples/post17/foo_vote_privacy.spthy.tmp
+  processing time: 250.063279s
   RHS :  exec (exists-trace): verified (12 steps)
   LHS :  exec (exists-trace): verified (12 steps)
   DiffLemma:  Observational_equivalence : verified (7204 steps)

--- a/case-studies-regression/post17/needham_schroeder_symmetric_cbc_analyzed.spthy
+++ b/case-studies-regression/post17/needham_schroeder_symmetric_cbc_analyzed.spthy
@@ -124,8 +124,8 @@ analyzing: examples/post17/needham_schroeder_symmetric_cbc.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/needham_schroeder_symmetric_cbc.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 13.093644s
+  output:          examples/post17/needham_schroeder_symmetric_cbc.spthy.tmp
+  processing time: 10.061849s
   secrecy (all-traces): falsified - found trace (8 steps)
 
 ------------------------------------------------------------------------------
@@ -135,8 +135,8 @@ summary of summaries:
 
 analyzed: examples/post17/needham_schroeder_symmetric_cbc.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 13.093644s
+  output:          examples/post17/needham_schroeder_symmetric_cbc.spthy.tmp
+  processing time: 10.061849s
   secrecy (all-traces): falsified - found trace (8 steps)
 
 ==============================================================================

--- a/case-studies-regression/post17/okamoto_eligibility_analyzed.spthy
+++ b/case-studies-regression/post17/okamoto_eligibility_analyzed.spthy
@@ -213,8 +213,8 @@ analyzing: examples/post17/okamoto_eligibility.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/okamoto_eligibility.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.928402s
+  output:          examples/post17/okamoto_eligibility.spthy.tmp
+  processing time: 6.859009s
   types (all-traces): verified (23 steps)
   exec (exists-trace): verified (6 steps)
   eligibility (all-traces): verified (5 steps)
@@ -226,8 +226,8 @@ summary of summaries:
 
 analyzed: examples/post17/okamoto_eligibility.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.928402s
+  output:          examples/post17/okamoto_eligibility.spthy.tmp
+  processing time: 6.859009s
   types (all-traces): verified (23 steps)
   exec (exists-trace): verified (6 steps)
   eligibility (all-traces): verified (5 steps)

--- a/case-studies-regression/post17/okamoto_vote_privacy_analyzed-diff.spthy
+++ b/case-studies-regression/post17/okamoto_vote_privacy_analyzed-diff.spthy
@@ -11374,8 +11374,8 @@ analyzing: examples/post17/okamoto_vote_privacy.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/post17/okamoto_vote_privacy.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 97.630701s
+  output:          examples/post17/okamoto_vote_privacy.spthy.tmp
+  processing time: 88.201952s
   RHS :  exec (exists-trace): verified (12 steps)
   LHS :  exec (exists-trace): verified (12 steps)
   DiffLemma:  Observational_equivalence : verified (3701 steps)
@@ -11387,8 +11387,8 @@ summary of summaries:
 
 analyzed: examples/post17/okamoto_vote_privacy.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 97.630701s
+  output:          examples/post17/okamoto_vote_privacy.spthy.tmp
+  processing time: 88.201952s
   RHS :  exec (exists-trace): verified (12 steps)
   LHS :  exec (exists-trace): verified (12 steps)
   DiffLemma:  Observational_equivalence : verified (3701 steps)

--- a/case-studies-regression/regression/diff/issue223_analyzed-diff.spthy
+++ b/case-studies-regression/regression/diff/issue223_analyzed-diff.spthy
@@ -3245,8 +3245,8 @@ analyzing: examples/regression/diff/issue223.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/regression/diff/issue223.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.794911s
+  output:          examples/regression/diff/issue223.spthy.tmp
+  processing time: 4.269948s
   DiffLemma:  Observational_equivalence : verified (1082 steps)
 
 ------------------------------------------------------------------------------
@@ -3256,8 +3256,8 @@ summary of summaries:
 
 analyzed: examples/regression/diff/issue223.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.794911s
+  output:          examples/regression/diff/issue223.spthy.tmp
+  processing time: 4.269948s
   DiffLemma:  Observational_equivalence : verified (1082 steps)
 
 ==============================================================================

--- a/case-studies-regression/related_work/AIF_Moedersheim_CCS10/Keyserver_analyzed.spthy
+++ b/case-studies-regression/related_work/AIF_Moedersheim_CCS10/Keyserver_analyzed.spthy
@@ -145,8 +145,8 @@ analyzing: examples/related_work/AIF_Moedersheim_CCS10/Keyserver.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/AIF_Moedersheim_CCS10/Keyserver.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.11461s
+  output:          examples/related_work/AIF_Moedersheim_CCS10/Keyserver.spthy.tmp
+  processing time: 0.111047s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (6 steps)
 
 ------------------------------------------------------------------------------
@@ -156,8 +156,8 @@ summary of summaries:
 
 analyzed: examples/related_work/AIF_Moedersheim_CCS10/Keyserver.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.11461s
+  output:          examples/related_work/AIF_Moedersheim_CCS10/Keyserver.spthy.tmp
+  processing time: 0.111047s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (6 steps)
 
 ==============================================================================

--- a/case-studies-regression/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signing_analyzed.spthy
+++ b/case-studies-regression/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signing_analyzed.spthy
@@ -390,8 +390,8 @@ analyzing: examples/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signi
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signing.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.581899s
+  output:          examples/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signing.spthy.tmp
+  processing time: 0.506528s
   aborted_and_resolved_exclusive (all-traces): verified (7 steps)
   aborted_contract_reachable (exists-trace): verified (8 steps)
   resolved1_contract_reachable (exists-trace): verified (9 steps)
@@ -404,8 +404,8 @@ summary of summaries:
 
 analyzed: examples/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signing.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.581899s
+  output:          examples/related_work/StatVerif_ARR_CSF11/StatVerif_GM_Contract_Signing.spthy.tmp
+  processing time: 0.506528s
   aborted_and_resolved_exclusive (all-traces): verified (7 steps)
   aborted_contract_reachable (exists-trace): verified (8 steps)
   resolved1_contract_reachable (exists-trace): verified (9 steps)

--- a/case-studies-regression/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device_analyzed.spthy
+++ b/case-studies-regression/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device_analyzed.spthy
@@ -282,8 +282,8 @@ analyzing: examples/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device.s
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.381496s
+  output:          examples/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device.spthy.tmp
+  processing time: 0.341013s
   types (all-traces): verified (32 steps)
   reachability_left (exists-trace): verified (5 steps)
   reachability_right (exists-trace): verified (5 steps)
@@ -296,8 +296,8 @@ summary of summaries:
 
 analyzed: examples/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.381496s
+  output:          examples/related_work/StatVerif_ARR_CSF11/StatVerif_Security_Device.spthy.tmp
+  processing time: 0.341013s
   types (all-traces): verified (32 steps)
   reachability_left (exists-trace): verified (5 steps)
   reachability_right (exists-trace): verified (5 steps)

--- a/case-studies-regression/related_work/TPM_DKRS_CSF11/Envelope_analyzed.spthy
+++ b/case-studies-regression/related_work/TPM_DKRS_CSF11/Envelope_analyzed.spthy
@@ -6139,8 +6139,8 @@ analyzing: examples/related_work/TPM_DKRS_CSF11/Envelope.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/TPM_DKRS_CSF11/Envelope.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 36.23544s
+  output:          examples/related_work/TPM_DKRS_CSF11/Envelope.spthy.tmp
+  processing time: 28.441925s
   types (all-traces): verified (13 steps)
   PCR_Write_charn (all-traces): verified (60 steps)
   Secret_and_Denied_exclusive (all-traces): verified (1799 steps)
@@ -6152,8 +6152,8 @@ summary of summaries:
 
 analyzed: examples/related_work/TPM_DKRS_CSF11/Envelope.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 36.23544s
+  output:          examples/related_work/TPM_DKRS_CSF11/Envelope.spthy.tmp
+  processing time: 28.441925s
   types (all-traces): verified (13 steps)
   PCR_Write_charn (all-traces): verified (60 steps)
   Secret_and_Denied_exclusive (all-traces): verified (1799 steps)

--- a/case-studies-regression/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets_analyzed.spthy
+++ b/case-studies-regression/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets_analyzed.spthy
@@ -612,8 +612,8 @@ analyzing: examples/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.255598s
+  output:          examples/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets.spthy.tmp
+  processing time: 1.871315s
   types (all-traces): verified (16 steps)
   Unbind_PCR_charn (all-traces): verified (26 steps)
   exclusive_secrets (all-traces): verified (96 steps)
@@ -627,8 +627,8 @@ summary of summaries:
 
 analyzed: examples/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 3.255598s
+  output:          examples/related_work/TPM_DKRS_CSF11/TPM_Exclusive_Secrets.spthy.tmp
+  processing time: 1.871315s
   types (all-traces): verified (16 steps)
   Unbind_PCR_charn (all-traces): verified (26 steps)
   exclusive_secrets (all-traces): verified (96 steps)

--- a/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_analyzed.spthy
+++ b/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_analyzed.spthy
@@ -4675,8 +4675,8 @@ analyzing: examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 20.513897s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy.tmp
+  processing time: 19.326991s
   Login_reachable (exists-trace): verified (12 steps)
   one_count_foreach_login (all-traces): verified (210 steps)
   slightly_weaker_invariant (all-traces): verified (1241 steps)
@@ -4691,8 +4691,8 @@ summary of summaries:
 
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 20.513897s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy.tmp
+  processing time: 19.326991s
   Login_reachable (exists-trace): verified (12 steps)
   one_count_foreach_login (all-traces): verified (210 steps)
   slightly_weaker_invariant (all-traces): verified (1241 steps)

--- a/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_analyzed.spthy
+++ b/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_analyzed.spthy
@@ -7936,8 +7936,8 @@ analyzing: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 39.02468s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy.tmp
+  processing time: 27.979641s
   adv_can_guess_counter (all-traces): verified (24 steps)
   otp_decode_does_not_help_adv_use_induction (all-traces): verified (275 steps)
   k2_is_secret_use_induction (all-traces): verified (132 steps)
@@ -7951,8 +7951,8 @@ summary of summaries:
 
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 39.02468s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy.tmp
+  processing time: 27.979641s
   adv_can_guess_counter (all-traces): verified (24 steps)
   otp_decode_does_not_help_adv_use_induction (all-traces): verified (275 steps)
   k2_is_secret_use_induction (all-traces): verified (132 steps)

--- a/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset_analyzed.spthy
+++ b/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset_analyzed.spthy
@@ -1700,8 +1700,8 @@ analyzing: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multise
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.044546s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy.tmp
+  processing time: 6.322358s
   transitivity (all-traces): verified (2 steps)
   adv_can_guess_counter (all-traces): verified (13 steps)
   otp_decode_does_not_help_adv_use_induction (all-traces): verified (72 steps)
@@ -1720,8 +1720,8 @@ summary of summaries:
 
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 8.044546s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy.tmp
+  processing time: 6.322358s
   transitivity (all-traces): verified (2 steps)
   adv_can_guess_counter (all-traces): verified (13 steps)
   otp_decode_does_not_help_adv_use_induction (all-traces): verified (72 steps)

--- a/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_multiset_analyzed.spthy
+++ b/case-studies-regression/related_work/YubiSecure_KS_STM12/Yubikey_multiset_analyzed.spthy
@@ -1655,8 +1655,8 @@ analyzing: examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy
 ------------------------------------------------------------------------------
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 22.568882s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy.tmp
+  processing time: 19.481737s
   transitivity (all-traces): verified (2 steps)
   Login_reachable (exists-trace): verified (8 steps)
   one_count_foreach_login (all-traces): verified (11 steps)
@@ -1672,8 +1672,8 @@ summary of summaries:
 
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 22.568882s
+  output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy.tmp
+  processing time: 19.481737s
   transitivity (all-traces): verified (2 steps)
   Login_reachable (exists-trace): verified (8 steps)
   one_count_foreach_login (all-traces): verified (11 steps)

--- a/case-studies-regression/sapic/GJM-contract/contract_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/GJM-contract/contract_analyzed-sapic.spthy
@@ -1173,8 +1173,8 @@ analyzing: case-studies-sapic-regression/GJM-contract/contract.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/GJM-contract/contract.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 26.69363s
+  output:          case-studies-sapic-regression/GJM-contract/contract.spthy.tmp
+  processing time: 29.048005s
   WARNING: 5 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -1189,8 +1189,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/GJM-contract/contract.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 26.69363s
+  output:          case-studies-sapic-regression/GJM-contract/contract.spthy.tmp
+  processing time: 29.048005s
   WARNING: 5 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/NSL/nsl-no_as-untagged_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/NSL/nsl-no_as-untagged_analyzed-sapic.spthy
@@ -457,8 +457,8 @@ analyzing: case-studies-sapic-regression/NSL/nsl-no_as-untagged.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/NSL/nsl-no_as-untagged.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.545357s
+  output:          case-studies-sapic-regression/NSL/nsl-no_as-untagged.spthy.tmp
+  processing time: 2.166657s
   source (all-traces): verified (34 steps)
   secrecy (all-traces): verified (21 steps)
 
@@ -469,8 +469,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/NSL/nsl-no_as-untagged.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.545357s
+  output:          case-studies-sapic-regression/NSL/nsl-no_as-untagged.spthy.tmp
+  processing time: 2.166657s
   source (all-traces): verified (34 steps)
   secrecy (all-traces): verified (21 steps)
 

--- a/case-studies-regression/sapic/SCADA/opc_ua_secure_conversation_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/SCADA/opc_ua_secure_conversation_analyzed-sapic.spthy
@@ -3390,8 +3390,8 @@ analyzing: case-studies-sapic-regression/SCADA/opc_ua_secure_conversation.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/SCADA/opc_ua_secure_conversation.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 15.620886s
+  output:          case-studies-sapic-regression/SCADA/opc_ua_secure_conversation.spthy.tmp
+  processing time: 20.114353s
   Executable (exists-trace): verified (52 steps)
   all_received_were_sent (all-traces): verified (16 steps)
   all_received_were_sent_injective (all-traces): verified (156 steps)
@@ -3406,8 +3406,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/SCADA/opc_ua_secure_conversation.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 15.620886s
+  output:          case-studies-sapic-regression/SCADA/opc_ua_secure_conversation.spthy.tmp
+  processing time: 20.114353s
   Executable (exists-trace): verified (52 steps)
   all_received_were_sent (all-traces): verified (16 steps)
   all_received_were_sent_injective (all-traces): verified (156 steps)

--- a/case-studies-regression/sapic/basic/channels1_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/channels1_analyzed-sapic.spthy
@@ -134,8 +134,8 @@ analyzing: case-studies-sapic-regression/basic/channels1.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/channels1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.160774s
+  output:          case-studies-sapic-regression/basic/channels1.spthy.tmp
+  processing time: 0.262404s
   secret (all-traces): verified (4 steps)
   received (exists-trace): verified (3 steps)
 
@@ -146,8 +146,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/channels1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.160774s
+  output:          case-studies-sapic-regression/basic/channels1.spthy.tmp
+  processing time: 0.262404s
   secret (all-traces): verified (4 steps)
   received (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/basic/channels2_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/channels2_analyzed-sapic.spthy
@@ -83,8 +83,8 @@ analyzing: case-studies-sapic-regression/basic/channels2.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/channels2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.04781s
+  output:          case-studies-sapic-regression/basic/channels2.spthy.tmp
+  processing time: 0.07947s
   received (all-traces): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -94,8 +94,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/channels2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.04781s
+  output:          case-studies-sapic-regression/basic/channels2.spthy.tmp
+  processing time: 0.07947s
   received (all-traces): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/basic/channels3_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/channels3_analyzed-sapic.spthy
@@ -113,8 +113,8 @@ analyzing: case-studies-sapic-regression/basic/channels3.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/channels3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.064968s
+  output:          case-studies-sapic-regression/basic/channels3.spthy.tmp
+  processing time: 0.108403s
   not_secret (exists-trace): verified (3 steps)
   internal_comm (exists-trace): verified (3 steps)
 
@@ -125,8 +125,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/channels3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.064968s
+  output:          case-studies-sapic-regression/basic/channels3.spthy.tmp
+  processing time: 0.108403s
   not_secret (exists-trace): verified (3 steps)
   internal_comm (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/basic/design-choices_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/design-choices_analyzed-sapic.spthy
@@ -472,8 +472,8 @@ analyzing: case-studies-sapic-regression/basic/design-choices.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/design-choices.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.54655s
+  output:          case-studies-sapic-regression/basic/design-choices.spthy.tmp
+  processing time: 0.651604s
   WARNING: 3 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -486,8 +486,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/design-choices.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.54655s
+  output:          case-studies-sapic-regression/basic/design-choices.spthy.tmp
+  processing time: 0.651604s
   WARNING: 3 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/basic/exclusive-secrets_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/exclusive-secrets_analyzed-sapic.spthy
@@ -291,8 +291,8 @@ analyzing: case-studies-sapic-regression/basic/exclusive-secrets.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/exclusive-secrets.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.29476s
+  output:          case-studies-sapic-regression/basic/exclusive-secrets.spthy.tmp
+  processing time: 0.387667s
   WARNING: 3 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -308,8 +308,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/exclusive-secrets.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.29476s
+  output:          case-studies-sapic-regression/basic/exclusive-secrets.spthy.tmp
+  processing time: 0.387667s
   WARNING: 3 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/basic/no-replication_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/no-replication_analyzed-sapic.spthy
@@ -70,8 +70,8 @@ analyzing: case-studies-sapic-regression/basic/no-replication.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/no-replication.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.040237s
+  output:          case-studies-sapic-regression/basic/no-replication.spthy.tmp
+  processing time: 0.071051s
   onlyOneSecret (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -81,8 +81,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/no-replication.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.040237s
+  output:          case-studies-sapic-regression/basic/no-replication.spthy.tmp
+  processing time: 0.071051s
   onlyOneSecret (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/basic/replication_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/replication_analyzed-sapic.spthy
@@ -80,8 +80,8 @@ analyzing: case-studies-sapic-regression/basic/replication.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/replication.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.049389s
+  output:          case-studies-sapic-regression/basic/replication.spthy.tmp
+  processing time: 0.074914s
   onlyOneSecret (all-traces): falsified - found trace (4 steps)
 
 ------------------------------------------------------------------------------
@@ -91,8 +91,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/replication.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.049389s
+  output:          case-studies-sapic-regression/basic/replication.spthy.tmp
+  processing time: 0.074914s
   onlyOneSecret (all-traces): falsified - found trace (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/basic/running-example_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/basic/running-example_analyzed-sapic.spthy
@@ -754,8 +754,8 @@ analyzing: case-studies-sapic-regression/basic/running-example.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/basic/running-example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.766599s
+  output:          case-studies-sapic-regression/basic/running-example.spthy.tmp
+  processing time: 2.131695s
   WARNING: 9 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -772,8 +772,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/basic/running-example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.766599s
+  output:          case-studies-sapic-regression/basic/running-example.spthy.tmp
+  processing time: 2.131695s
   WARNING: 9 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini10_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini10_analyzed-sapic.spthy
@@ -119,8 +119,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini10.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini10.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.052362s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini10.spthy.tmp
+  processing time: 0.079056s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -134,8 +134,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini10.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.052362s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini10.spthy.tmp
+  processing time: 0.079056s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini1_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini1_analyzed-sapic.spthy
@@ -145,8 +145,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini1.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.093329s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini1.spthy.tmp
+  processing time: 0.151292s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (7 steps)
 
@@ -157,8 +157,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini1.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.093329s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini1.spthy.tmp
+  processing time: 0.151292s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (7 steps)
 

--- a/case-studies-regression/sapic/fairexchange-mini/mini2_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini2_analyzed-sapic.spthy
@@ -159,8 +159,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini2.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.097713s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini2.spthy.tmp
+  processing time: 0.147611s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -174,8 +174,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.097713s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini2.spthy.tmp
+  processing time: 0.147611s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini3_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini3_analyzed-sapic.spthy
@@ -194,8 +194,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini3.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.091407s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini3.spthy.tmp
+  processing time: 0.130166s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -211,8 +211,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.091407s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini3.spthy.tmp
+  processing time: 0.130166s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini4_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini4_analyzed-sapic.spthy
@@ -145,8 +145,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini4.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini4.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.077091s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini4.spthy.tmp
+  processing time: 0.12814s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (7 steps)
 
@@ -157,8 +157,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini4.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.077091s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini4.spthy.tmp
+  processing time: 0.12814s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (7 steps)
 

--- a/case-studies-regression/sapic/fairexchange-mini/mini5_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini5_analyzed-sapic.spthy
@@ -294,8 +294,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini5.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini5.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.303038s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini5.spthy.tmp
+  processing time: 0.443059s
   WARNING: 5 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -310,8 +310,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini5.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.303038s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini5.spthy.tmp
+  processing time: 0.443059s
   WARNING: 5 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini6_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini6_analyzed-sapic.spthy
@@ -193,8 +193,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini6.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini6.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.144735s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini6.spthy.tmp
+  processing time: 0.180537s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -208,8 +208,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini6.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.144735s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini6.spthy.tmp
+  processing time: 0.180537s
   WARNING: 1 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini7_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini7_analyzed-sapic.spthy
@@ -246,8 +246,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini7.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini7.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.124997s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini7.spthy.tmp
+  processing time: 0.193387s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -264,8 +264,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini7.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.124997s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini7.spthy.tmp
+  processing time: 0.193387s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini8_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini8_analyzed-sapic.spthy
@@ -123,8 +123,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini8.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini8.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.048571s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini8.spthy.tmp
+  processing time: 0.073992s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -138,8 +138,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini8.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.048571s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini8.spthy.tmp
+  processing time: 0.073992s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/mini9_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/mini9_analyzed-sapic.spthy
@@ -218,8 +218,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/mini9.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini9.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.179572s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini9.spthy.tmp
+  processing time: 0.258873s
   A_possible (exists-trace): verified (14 steps)
   B_possible (exists-trace): verified (7 steps)
   A_or_B (all-traces): verified (4 steps)
@@ -231,8 +231,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/mini9.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.179572s
+  output:          case-studies-sapic-regression/fairexchange-mini/mini9.spthy.tmp
+  processing time: 0.258873s
   A_possible (exists-trace): verified (14 steps)
   B_possible (exists-trace): verified (7 steps)
   A_or_B (all-traces): verified (4 steps)

--- a/case-studies-regression/sapic/fairexchange-mini/ndc-nested-2_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/ndc-nested-2_analyzed-sapic.spthy
@@ -244,8 +244,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/ndc-nested-2.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.099311s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-2.spthy.tmp
+  processing time: 0.132486s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -261,8 +261,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-2.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.099311s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-2.spthy.tmp
+  processing time: 0.132486s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/ndc-nested-3_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/ndc-nested-3_analyzed-sapic.spthy
@@ -208,8 +208,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/ndc-nested-3.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.082062s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-3.spthy.tmp
+  processing time: 0.131322s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -225,8 +225,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-3.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.082062s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-3.spthy.tmp
+  processing time: 0.131322s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/ndc-nested-4_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/ndc-nested-4_analyzed-sapic.spthy
@@ -208,8 +208,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/ndc-nested-4.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-4.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.081549s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-4.spthy.tmp
+  processing time: 0.102821s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -225,8 +225,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-4.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.081549s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-4.spthy.tmp
+  processing time: 0.102821s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/ndc-nested-5_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/ndc-nested-5_analyzed-sapic.spthy
@@ -317,8 +317,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/ndc-nested-5.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-5.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.160484s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-5.spthy.tmp
+  processing time: 0.229841s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -336,8 +336,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested-5.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.160484s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested-5.spthy.tmp
+  processing time: 0.229841s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/ndc-nested_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/ndc-nested_analyzed-sapic.spthy
@@ -373,8 +373,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/ndc-nested.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.144668s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested.spthy.tmp
+  processing time: 0.202714s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -394,8 +394,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-nested.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.144668s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-nested.spthy.tmp
+  processing time: 0.202714s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/fairexchange-mini/ndc-two-replications_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/fairexchange-mini/ndc-two-replications_analyzed-sapic.spthy
@@ -180,8 +180,8 @@ analyzing: case-studies-sapic-regression/fairexchange-mini/ndc-two-replications.
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-two-replications.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.062598s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-two-replications.spthy.tmp
+  processing time: 0.098708s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -198,8 +198,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/fairexchange-mini/ndc-two-replications.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.062598s
+  output:          case-studies-sapic-regression/fairexchange-mini/ndc-two-replications.spthy.tmp
+  processing time: 0.098708s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/locations/AC_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/locations/AC_analyzed-sapic.spthy
@@ -986,8 +986,8 @@ analyzing: case-studies-sapic-regression/locations/AC.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/locations/AC.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.109618s
+  output:          case-studies-sapic-regression/locations/AC.spthy.tmp
+  processing time: 5.21833s
   WARNING: 6 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -1000,8 +1000,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/locations/AC.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.109618s
+  output:          case-studies-sapic-regression/locations/AC.spthy.tmp
+  processing time: 5.21833s
   WARNING: 6 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/locations/AKE_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/locations/AKE_analyzed-sapic.spthy
@@ -286,8 +286,8 @@ analyzing: case-studies-sapic-regression/locations/AKE.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/locations/AKE.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.448132s
+  output:          case-studies-sapic-regression/locations/AKE.spthy.tmp
+  processing time: 0.60973s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -301,8 +301,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/locations/AKE.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.448132s
+  output:          case-studies-sapic-regression/locations/AKE.spthy.tmp
+  processing time: 0.60973s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/locations/licensing_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/locations/licensing_analyzed-sapic.spthy
@@ -811,8 +811,8 @@ analyzing: case-studies-sapic-regression/locations/licensing.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/locations/licensing.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.210888s
+  output:          case-studies-sapic-regression/locations/licensing.spthy.tmp
+  processing time: 5.210468s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -827,8 +827,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/locations/licensing.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 4.210888s
+  output:          case-studies-sapic-regression/locations/licensing.spthy.tmp
+  processing time: 5.210468s
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/predicates/decwrap_destr_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/predicates/decwrap_destr_analyzed-sapic.spthy
@@ -1096,8 +1096,8 @@ analyzing: case-studies-sapic-regression/predicates/decwrap_destr.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/predicates/decwrap_destr.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.865814s
+  output:          case-studies-sapic-regression/predicates/decwrap_destr.spthy.tmp
+  processing time: 2.165315s
   WARNING: 7 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -1114,8 +1114,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/predicates/decwrap_destr.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 1.865814s
+  output:          case-studies-sapic-regression/predicates/decwrap_destr.spthy.tmp
+  processing time: 2.165315s
   WARNING: 7 wellformedness check failed!
            The analysis results might be wrong!
   

--- a/case-studies-regression/sapic/predicates/simple_example_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/predicates/simple_example_analyzed-sapic.spthy
@@ -84,8 +84,8 @@ analyzing: case-studies-sapic-regression/predicates/simple_example.spthy
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/predicates/simple_example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.035999s
+  output:          case-studies-sapic-regression/predicates/simple_example.spthy.tmp
+  processing time: 0.064203s
   bogus_exists (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -95,8 +95,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/predicates/simple_example.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 0.035999s
+  output:          case-studies-sapic-regression/predicates/simple_example.spthy.tmp
+  processing time: 0.064203s
   bogus_exists (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/statVerifLeftRight/stateverif_left_right_analyzed-sapic.spthy
+++ b/case-studies-regression/sapic/statVerifLeftRight/stateverif_left_right_analyzed-sapic.spthy
@@ -2179,8 +2179,8 @@ analyzing: case-studies-sapic-regression/statVerifLeftRight/stateverif_left_righ
 ------------------------------------------------------------------------------
 analyzed: case-studies-sapic-regression/statVerifLeftRight/stateverif_left_right.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 10.252461s
+  output:          case-studies-sapic-regression/statVerifLeftRight/stateverif_left_right.spthy.tmp
+  processing time: 12.22144s
   WARNING: 4 wellformedness check failed!
            The analysis results might be wrong!
   
@@ -2196,8 +2196,8 @@ summary of summaries:
 
 analyzed: case-studies-sapic-regression/statVerifLeftRight/stateverif_left_right.spthy
 
-  output:          case-studies/temp-analysis.spthy
-  processing time: 10.252461s
+  output:          case-studies-sapic-regression/statVerifLeftRight/stateverif_left_right.spthy.tmp
+  processing time: 12.22144s
   WARNING: 4 wellformedness check failed!
            The analysis results might be wrong!
   


### PR DESCRIPTION
Move the temporary files generated during the execution of the case-studies make goal to a file dependent on the case-study theory file path (this commit uses `/path/to/theory/file.tmp` and `/path/to/theory/file.out` - other suggestions would be welcome).

This change allows case-studies to be verified in parallel (i.e. with the `-j` flag on make). On our server orac, this significantly speeds up the process - in our testing, using `make -j 6 case-studies` cuts down the (wall-clock) time taken from 34 minutes without parallelisation to 16 minutes. It does slightly increase the time taken by some of the individual verifications, but I believe the overall reduction is more helpful to us since it will allow us to test all the case-studies more regularly.

Also includes a change to using `printf` to allow the newlines to be output correctly, rather than `echo "\n"` which prints a literal `\n` (and the `-e` flag from GNU coreutils echo is not supported everywhere).