### PR TITLE
Display the name of the originating rule for action and premise goals

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -394,9 +394,14 @@ rankProofMethods ranking ctxt sys = do
       Nothing    -> []
   where
     contradiction c                    = (Contradiction (Just c), "")
+
+    sourceRule goal = case goalRule sys goal of
+        Just ru -> " (from rule " ++ getRuleName ru ++ ")"
+        Nothing -> ""
+
     solveGoalMethod (goal, (nr, usefulness)) =
       ( SolveGoal goal
-      , "nr. " ++ show nr ++ case usefulness of
+      , "nr. " ++ show nr ++ sourceRule goal ++ case usefulness of
                                Useful                -> ""
                                LoopBreaker           -> " (loop breaker)"
                                ProbablyConstructible -> " (probably constructible)"


### PR DESCRIPTION
When pretty printing a premise or action goal, whenever possible annotate the comment that follows goal number with the name of the rule that introduced the goal. This means users don't have to scour the dependency graph when determining which rule introduced a particular goal.

This was based upon requests from users who have been trying to verify large protocols that produce very large dependency graphs. There is a possibility that other tools that make use of the output format of goals by Tamarin may be affected by this change, but by putting it in the goal comment, we hope to reduce the effects of this change.