### PR TITLE
Issue #248: [aAbB] keys start first proof

### DIFF
--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -642,8 +642,7 @@ var mainDisplay = {
 
     /**
      * Apply a prover to the currently selected constraint system,
-     * or to the first sorry-step when not on selected constrain
-     * system.
+     * or to the first sorry-step when no constraint system is selected.
      * @param prover The CSS style of the link to the prover
      */
     applyProver: function(prover) {

--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -641,13 +641,28 @@ var mainDisplay = {
     },
 
     /**
-     * Apply a prover to the currently selected constraint system.
+     * Apply a prover to the currently selected constraint system,
+     * or to the first sorry-step when not on selected constrain
+     * system.
      * @param prover The CSS style of the link to the prover
      */
     applyProver: function(prover) {
         var auto = $("#ui-main-display").find("a.internal-link." + prover);
 
-        if(auto.length >= 1) $(auto.get(0)).click();
+        if(auto.length >= 1) {
+            $(auto.get(0)).click();
+        } else {
+            var firstStep = $("#proof").find("a.internal-link.sorry-step");
+
+            if(firstStep.length >= 1) {
+                $.when( $(firstStep.get(0)).click( ) ).done( function(  ) {
+                    setTimeout(function(){ 
+                        var autoP = $("#ui-main-display").find("a.internal-link." + prover );
+                        $(autoP.get(0)).click();
+                    }, 300);
+                });
+            }
+        }
     },
 
     /**


### PR DESCRIPTION
Changed the behaviour of [aAbB] keys to select the first 'sorry'
if currently no 'sorry' is selected, and then start the proof at
once.

Tested and working on recent stable releases of Chrome and Firefox.
Unfortunately due to the version of jQuery line 659 defines a time out
of 300 ms. For my laptop this is sufficient and not noticeable, I would be
interested to know if it is an appropriate time out for everyone else.

Addresses issue https://github.com/tamarin-prover/tamarin-prover/issues/248
