### PR TITLE
Update some links in the GUI front page

### DIFF
--- a/src/Web/Hamlet.hs
+++ b/src/Web/Hamlet.hs
@@ -371,22 +371,22 @@ introTpl = [whamlet|
         Core team:
         \ <a href="https://www.inf.ethz.ch/personal/basin/">David Basin</a>,
         \ <a href="https://www.cs.ox.ac.uk/people/cas.cremers/">Cas Cremers</a>,
-        \ <a href="http://www.jannikdreier.net">Jannik Dreier</a>,
+        \ <a href="https://www.jannikdreier.net">Jannik Dreier</a>,
         \ <a href="mailto:iridcode@gmail.com">Simon Meier</a>,
         \ <a href="https://people.inf.ethz.ch/rsasse/">Ralf Sasse</a>,
-        \ <a href="http://beschmi.net">Benedikt Schmidt</a><br>
+        \ <a href="https://beschmi.net">Benedikt Schmidt</a><br>
         Tamarin is a collaborative effort: see the <a href="http://tamarin-prover.github.io/manual/index.html">manual</a> for a more extensive overview of its development and additional contributors.
       <p>
         <span class="tamarin">Tamarin</span> was developed at the
         \ <a href="http://www.infsec.ethz.ch">Information Security Institute</a>,
-        \ <a href="http://www.ethz.ch">ETH Zurich</a>.
+        \ <a href="https://www.ethz.ch">ETH Zurich</a>.
         \ This program comes with ABSOLUTELY NO WARRANTY. It is free software, and
         \ you are welcome to redistribute it according to its
         \ <a href="/static/LICENSE" type="text/plain">LICENSE.</a>
       <p>
         More information about Tamarin and technical papers describing the underlying
         \ theory can be found on the
-        \ <a href="http://www.infsec.ethz.ch/research/software/tamarin"><span class="tamarin">Tamarin</span>
+        \ <a href="https://tamarin-prover.github.io"><span class="tamarin">Tamarin</span>
         \ webpage</a>.
   |]
 


### PR DESCRIPTION
Irritatingly, https://www.infsec.ethz.ch is broken (it serves up the ethz.ch cert which doesn't cover the subdomain), so I can't make that one HTTPS.