### PR TITLE
Fixed compile-time warnings

### DIFF
--- a/lib/term/src/Term/LTerm.hs
+++ b/lib/term/src/Term/LTerm.hs
@@ -120,6 +120,7 @@ import qualified Data.DList                       as D
 import           Data.Foldable                    hiding (concatMap, elem, notElem, any)
 import           Data.Data
 import qualified Data.Map                         as M
+import qualified Data.Map.Strict                  as M'
 import           Data.Monoid
 import qualified Data.Set                         as S
 -- import           Data.Traversable
@@ -587,7 +588,7 @@ avoidPrecise :: HasFrees t => t -> Precise.FreshState
 avoidPrecise =
     foldl' ins M.empty . frees
   where
-    ins m v = M.insertWith' max (lvarName v) (lvarIdx v + 1) m
+    ins m v = M'.insertWith max (lvarName v) (lvarIdx v + 1) m
 
 -- | @renamePrecise t@ replaces all variables in @t@ with fresh variables.
 --   If 'Control.Monad.PreciseFresh' is used with non-AC terms and identical

--- a/lib/term/src/Term/Maude/Types.hs
+++ b/lib/term/src/Term/Maude/Types.hs
@@ -78,7 +78,7 @@ lTermToMTerm sortOf =
 
 -- | Convert an 'MTerm' to an 'LNTerm' under the assumption that the bindings
 -- for the constants are already available.
-mTermToLNTerm :: (MonadBind MaudeLit (Lit c LVar) m, MonadFresh m, Show (Lit c LVar), Ord c, Show c)
+mTermToLNTerm :: (MonadBind MaudeLit (Lit c LVar) m, MonadFresh m, Ord c, Show c)
              => String -- ^ Name hint for freshly generated variables.
              -> MTerm  -- ^ The maude term to convert.
              -> m (VTerm c LVar)
@@ -121,7 +121,7 @@ runBackConversion back bindings =
 --   returned by Maude to a 'VFresh' substitution. It expects that the
 --   range of the maude substitution contains only fresh variables in its
 --   range and raises an error otherwise.
-msubstToLSubstVFresh :: (Ord c, Show (Lit c LVar), Show c)
+msubstToLSubstVFresh :: (Ord c, Show c)
                      => Map MaudeLit (Lit c LVar) -- ^ The binding map to use for constants.
                      -> MSubst -- ^ The maude substitution.
                      -> SubstVFresh c LVar
@@ -147,7 +147,7 @@ msubstToLSubstVFresh bindings substMaude
 --   returned by Maude to a 'VFree' substitution. It expects that the
 --   maude substitution contains no fresh variables in its range and raises an
 --   error otherwise.
-msubstToLSubstVFree ::  (Ord c, Show (Lit c LVar), Show c)
+msubstToLSubstVFree ::  (Ord c, Show c)
                     => Map MaudeLit (Lit c LVar) -> MSubst -> Subst c LVar
 msubstToLSubstVFree bindings substMaude
     | not $ null [i | (_,t) <- substMaude, FreshVar _ i <- lits t] =

--- a/lib/term/src/Term/Substitution/SubstVFree.hs
+++ b/lib/term/src/Term/Substitution/SubstVFree.hs
@@ -304,6 +304,6 @@ prettySubst ppVar ppLit =
         (fsep $ punctuate comma $ map ppVar $ S.toList vs) <> operator_ "}"
 
 -- | Pretty print a substitution with logical variables.
-prettyLNSubst :: (Show (Lit c LVar), Ord c, HighlightDocument d, Show c)
+prettyLNSubst :: (Ord c, HighlightDocument d, Show c)
               => LSubst c -> d
 prettyLNSubst = vcat . prettySubst (text . show) (text . show)

--- a/lib/term/src/Term/Substitution/SubstVFresh.hs
+++ b/lib/term/src/Term/Substitution/SubstVFresh.hs
@@ -216,7 +216,7 @@ prettySubstVFresh ppVar ppLit =
         (fsep $ punctuate comma $ map ppVar $ S.toList vs) <> operator_ "}"
 
 -- | Pretty print a substitution with logical variables.
-prettyLSubstVFresh :: (Show (Lit c LVar), Ord c, HighlightDocument d, Show c)
+prettyLSubstVFresh :: (Ord c, HighlightDocument d, Show c)
                    => LSubstVFresh c -> d
 prettyLSubstVFresh = vcat . prettySubstVFresh (text . show) (text . show)
 

--- a/lib/term/src/Term/Unification.hs
+++ b/lib/term/src/Term/Unification.hs
@@ -92,7 +92,7 @@ import           Debug.Trace.Ignore
 ----------------------------------------------------------------------
 
 -- | @unifyLTerm sortOf eqs@ returns a complete set of unifiers for @eqs@ modulo AC.
-unifyLTermFactored :: (IsConst c , Show (Lit c LVar))
+unifyLTermFactored :: (IsConst c)
                    => (c -> LSort)
                    -> [Equal (LTerm c)]
                    -> WithMaude (LSubst c, [SubstVFresh c LVar])
@@ -114,7 +114,7 @@ unifyLNTermFactored :: [Equal LNTerm]
 unifyLNTermFactored = unifyLTermFactored sortOfName
 
 -- | @unifyLNTerm eqs@ returns a complete set of unifiers for @eqs@ modulo AC.
-unifyLTerm :: (IsConst c , Show (Lit c LVar))
+unifyLTerm :: (IsConst c)
            => (c -> LSort)
            -> [Equal (LTerm c)]
            -> WithMaude [SubstVFresh c LVar]
@@ -138,7 +138,7 @@ flattenUnif (subst, substs) =
 ----------------------------------------------------------------------
 
 -- | @unifyLTermFactoredAC sortOf eqs@ returns a complete set of unifiers for @eqs@ for terms without AC symbols.
-unifyLTermFactoredNoAC :: (IsConst c , Show (Lit c LVar))
+unifyLTermFactoredNoAC :: (IsConst c)
                    => (c -> LSort)
                    -> [Equal (LTerm c)]
                    -> [(SubstVFresh c LVar)]
@@ -158,7 +158,7 @@ unifyLNTermFactoredNoAC :: [Equal LNTerm]
 unifyLNTermFactoredNoAC = unifyLTermFactoredNoAC sortOfName
 
 -- | @unifyLNTermNoAC eqs@ returns a complete set of unifiers for @eqs@  for terms without AC symbols.
-unifyLTermNoAC :: (IsConst c , Show (Lit c LVar))
+unifyLTermNoAC :: (IsConst c)
            => (c -> LSort)
            -> [Equal (LTerm c)]
            -> [SubstVFresh c LVar]

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -76,6 +76,7 @@ import           Prelude                                 hiding (id, (.))
 
 import qualified Data.Foldable                           as F
 import qualified Data.Map                                as M
+import qualified Data.Map.Strict                         as M'
 import qualified Data.Set                                as S
 import qualified Data.ByteString.Char8                   as BC
 import           Data.List                               (mapAccumL)
@@ -494,7 +495,7 @@ combineGoalStatus (GoalStatus solved1 age1 loops1)
 insertGoalStatus :: Goal -> GoalStatus -> Reduction ()
 insertGoalStatus goal status = do
     age <- getM sNextGoalNr
-    modM sGoals $ M.insertWith' combineGoalStatus goal (set gsNr age status)
+    modM sGoals $ M'.insertWith combineGoalStatus goal (set gsNr age status)
     sNextGoalNr =: succ age
 
 -- | Insert a 'Goal' and store its age.
@@ -616,7 +617,7 @@ substGoals = do
           | (isMsgVar m || isProduct m || isUnion m) && (apply subst m /= m) ->
               insertAction i (apply subst fa)
         _ -> do modM sGoals $
-                  M.insertWith' combineGoalStatus (apply subst goal) status
+                  M'.insertWith combineGoalStatus (apply subst goal) status
                 return Unchanged
 
     return (mconcat changes)

--- a/lib/utils/src/Utils/Misc.hs
+++ b/lib/utils/src/Utils/Misc.hs
@@ -30,9 +30,10 @@ import System.Environment
 import System.IO.Unsafe
 import Data.Maybe
 import Data.Set (Set)
-import qualified Data.Set as S
+import qualified Data.Set           as S
 import Data.Map ( Map )
-import qualified Data.Map as M
+import qualified Data.Map           as M
+import qualified Data.Map.Strict    as M'
 
 import Data.Digest.Pure.SHA      (bytestringDigest, sha256)
 import Blaze.ByteString.Builder  (toLazyByteString)
@@ -77,7 +78,7 @@ equivClasses :: (Ord a, Ord b) => [(a, b)] -> M.Map b (S.Set a)
 equivClasses = 
     foldl' insertEdge M.empty 
   where
-    insertEdge m (from,to) = M.insertWith' S.union to (S.singleton from) m
+    insertEdge m (from,to) = M'.insertWith S.union to (S.singleton from) m
 
 -- | The SHA-256 hash of a string in base64 notation.
 stringSHA256 :: String -> String

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -68,8 +68,6 @@ import qualified Data.Binary         as Bin
 import           Data.Binary.Orphans()
 
 import           Control.DeepSeq
-import           Control.Monad
--- import           Control.Monad
 import           GHC.Generics (Generic)
 
 import           Text.Hamlet


### PR DESCRIPTION
Two main things were causing warnings when compiled:

- `Data.Map.insertWIth'` is being deprecated in favour of `Data.Map.Strict.insertWith`. To solve this I imported `Data.Map.Strict` as `M'` in the relevant places and changed `M.insertWith'` to `M'.insertWith`
- A few places had the redundant class constraint `Show (Lit c LVar)`

And finally there was a redundant import in `Types.hs`.