### PR TITLE
Fix an issue with vim syntax highlighting

### DIFF
--- a/etc/spthy.vim
+++ b/etc/spthy.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     DH-proto-proof Security Protocol Theory Files
 " Maintainer:   Nick Moore <nicholas.moore@cs.ox.ac.uk>
-" Last Change:  2017 06 07
+" Last Change:  2018 04 10
 " based on Claudio Fleiner's <claudio@fleiner.com> spthy syntax highlighting
 " file.
 
@@ -66,7 +66,7 @@ syn match spthyDecl             ":"
 syn match spthyDecl             "{\*"
 syn match spthyDecl             "\*}"
 syn match spthyDecl             "\""
-syn match spthyDecl             "\d\+\."
+syn match spthyDecl             "[a-zA-Z\-_]\@<!\d\+\."
 
 syn match spthyTransfer         "->"
 syn match spthyTransfer         "<-"


### PR DESCRIPTION
In the current version of the vim syntax file, numbers are highlighted if they are followed by a dot, even when they are a substring of an identifier (e.g. in `All #i1 #i2.`, the string `2.` is highlighted in vim's typedef style). This might cause the false impression that variable names are not allowed to contain numbers.

The new regex contains a negative lookahead, such that the sequence is only highlighted if the number is not a substring of another symbol.

It is not clear to me what kind of expressions the rule was originally intended to match. I was unable to find an instance inside the examples directory that was not in a name or comment. Maybe this is deprecated? If not, the intended functionality should be left intact by this change.

/cc @kelnage, as he is listed as the maintainer of the file.