### PR TITLE
Fact annotations

### DIFF
--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -298,7 +298,7 @@ closeProtoRule hnd ruE = ClosedProtoRule ruE (variantsProtoRule hnd ruE)
 -- | Close an intruder rule; i.e., compute maximum number of consecutive applications and variants
 --   Should be parallelized like the variant computation for protocol rules (JD)
 closeIntrRule :: MaudeHandle -> IntrRuleAC -> [IntrRuleAC]
-closeIntrRule hnd (Rule (DestrRule name (-1) subterm constant) prems@((Fact KDFact [t]):_) concs@[Fact KDFact [rhs]] acts nvs) =
+closeIntrRule hnd (Rule (DestrRule name (-1) subterm constant) prems@((Fact KDFact _ [t]):_) concs@[Fact KDFact _ [rhs]] acts nvs) =
   if subterm then [ru] else variantsIntruder hnd id False ru
     where
       ru = (Rule (DestrRule name (if runMaude (unifiableLNTerms rhs t)

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns  #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE ViewPatterns     #-}
+{-# LANGUAGE FlexibleContexts #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -154,7 +155,7 @@ openGoals sys = do
         -- We cannot deduce a message from a last node.
         guard (not $ isLast sys j)
         let derivedMsgs = concatMap toplevelTerms $
-                [ t | Fact OutFact [t] <- get rConcs ru] <|>
+                [ t | Fact OutFact _ [t] <- get rConcs ru] <|>
                 [ t | Just (DnK, t)    <- kFactView <$> get rConcs ru]
         -- m is deducible from j without an immediate contradiction
         -- if it is a derived message of 'ru' and the dependency does
@@ -217,11 +218,11 @@ solveGoal goal = do
 solveAction :: [RuleAC]          -- ^ All rules labelled with an action
             -> (NodeId, LNFact)  -- ^ The action we are looking for.
             -> Reduction String  -- ^ A sensible case name.
-solveAction rules (i, fa) = do
+solveAction rules (i, fa@(Fact _ ann _)) = do
     mayRu <- M.lookup i <$> getM sNodes
     showRuleCaseName <$> case mayRu of
         Nothing -> case fa of
-            (Fact KUFact [m@(viewTerm2 -> FXor ts)]) -> do
+            (Fact KUFact _ [m@(viewTerm2 -> FXor ts)]) -> do
                    partitions <- disjunctionOfList $ twoPartitions ts
                    case partitions of
                        (_, []) -> do
@@ -236,7 +237,7 @@ solveAction rules (i, fa) = do
                             modM sNodes (M.insert i ru)
                             mapM_ requiresKU [a, b] *> return ru
             _                                        -> do
-                   ru  <- labelNodeId i rules Nothing
+                   ru  <- labelNodeId i (annotatePrems <$> rules) Nothing
                    act <- disjunctionOfList $ get rActs ru
                    void (solveFactEqs SplitNow [Equal fa act])
                    return ru
@@ -245,9 +246,15 @@ solveAction rules (i, fa) = do
                           act <- disjunctionOfList $ get rActs ru
                           void (solveFactEqs SplitNow [Equal fa act])
                       return ru
-
-    where
-      requiresKU t = do
+  where
+    -- If the fact in the action goal has annotations, then consider annotated
+    -- versions of intruder rules (this allows high or low priority intruder knowledge
+    -- goals to propagate to intruder knowledge of subterms)
+    annotatePrems ru@(Rule ri ps cs as nvs) =
+        if not (S.null ann) && isIntruderRule ru then
+            Rule ri (annotateFact ann <$> ps) cs (annotateFact ann <$> as) nvs
+            else ru
+    requiresKU t = do
         j <- freshLVar "vk" LSortNode
         let faKU = kuFact t
         insertLess j i

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -294,7 +294,7 @@ execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ sho
       $ L.set dsProofType (Just RuleEquivalence) sys
       
     formula :: String -> LNFormula
-    formula rulename = Qua Ex ("i", LSortNode) (Ato (Action (LIT (Var (Bound 0))) (Fact {factTag = ProtoFact Linear ("Diff" ++ rulename) 0, factTerms = []})))
+    formula rulename = Qua Ex ("i", LSortNode) (Ato (Action (LIT (Var (Bound 0))) (Fact (ProtoFact Linear ("Diff" ++ rulename) 0) S.empty [])))
     
     ruleEquivalenceCase :: M.Map CaseName DiffSystem -> RuleAC -> M.Map CaseName DiffSystem
     ruleEquivalenceCase m rule = M.insert ("Rule_" ++ (getRuleName rule) ++ "") (ruleEquivalenceSystem (getRuleNameDiff rule)) m
@@ -576,39 +576,39 @@ sapicRanking ctxt sys =
        not (isKFact fa) && not (isAuthOutFact fa)
     isNonLoopBreakerProtoFactGoal _                            = False
 
-    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _) = True
+    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _ _) = True
     isAuthOutFact  _                                 = False
 
-    isStateFact (PremiseG _ (Fact (ProtoFact _ n _) _)) = isPrefixOf "State_" n
+    isStateFact (PremiseG _ (Fact (ProtoFact _ n _) _ _)) = isPrefixOf "State_" n
     isStateFact  _                                 = False
 
-    isUnlockAction (ActionG _ (Fact (ProtoFact _ "Unlock" _) _)) = True
+    isUnlockAction (ActionG _ (Fact (ProtoFact _ "Unlock" _) _ _)) = True
     isUnlockAction  _                                 = False
 
-    isFirstInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _)  (t:_)) ) = 
+    isFirstInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ (t:_)) ) =
         case t of
             (viewTerm2 -> FPair (viewTerm2 -> Lit2( Con (Name PubName a)))  _) -> isPrefixOf "F_" (show a)
             _ -> False
     isFirstInsertAction _ = False
 
-    isLastInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _)  (t:_)) ) = 
+    isLastInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ (t:_)) ) = 
         case t of
             (viewTerm2 -> FPair (viewTerm2 -> Lit2( Con (Name PubName a)))  _) -> not( isPrefixOf "L_" (show a))
             _ -> False
     isLastInsertAction _ = False
 
-    isNotInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _)) = False
+    isNotInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ _)) = False
     isNotInsertAction  _                                 = True
 
     isStandardActionGoalButNotInsert g = 
        (isStandardActionGoal g) &&  (isNotInsertAction g)
 
 
-    isLastProtoFact (PremiseG _ (Fact (ProtoFact _ ('L':'_':_) _) _)) = True
-    isLastProtoFact _                                                 = False
+    isLastProtoFact (PremiseG _ fa) = isSolveLastFact fa
+    isLastProtoFact _               = False
 
-    isFirstProtoFact (PremiseG _ (Fact (ProtoFact _ ('F':'_':_) _) _)) = True
-    isFirstProtoFact _                                                 = False
+    isFirstProtoFact (PremiseG _ fa) = isSolveFirstFact fa
+    isFirstProtoFact _               = False
 
     isNotAuthOut (PremiseG _ fa) = not (isAuthOutFact fa)
     isNotAuthOut _               = False
@@ -740,48 +740,48 @@ sapicLivenessRanking ctxt sys =
        not (isKFact fa) && not (isAuthOutFact fa)
     isNonLoopBreakerProtoFactGoal _                            = False
 
-    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _) = True
+    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _ _) = True
     isAuthOutFact  _                                 = False
 
-    isMID_Receiver (PremiseG _ (Fact (ProtoFact _ "MID_Receiver" _) _)) = True
+    isMID_Receiver (PremiseG _ (Fact (ProtoFact _ "MID_Receiver" _) _ _)) = True
     isMID_Receiver  _                                 = False
 
-    isMID_Sender (PremiseG _ (Fact (ProtoFact _ "MID_Sender" _) _)) = True
+    isMID_Sender (PremiseG _ (Fact (ProtoFact _ "MID_Sender" _) _ _)) = True
     isMID_Sender  _                                 = False
 
-    isStateFact (PremiseG _ (Fact (ProtoFact _ n _) _)) = isPrefixOf "State_" n
+    isStateFact (PremiseG _ (Fact (ProtoFact _ n _) _ _)) = isPrefixOf "State_" n
     isStateFact  _                                 = False
 
-    isUnlockAction (ActionG _ (Fact (ProtoFact _ "Unlock" _) _)) = True
+    isUnlockAction (ActionG _ (Fact (ProtoFact _ "Unlock" _) _ _)) = True
     isUnlockAction  _                                 = False
 
-    isFirstInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _)  (t:_)) ) = 
+    isFirstInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ (t:_)) ) = 
         case t of
             (viewTerm2 -> FPair (viewTerm2 -> Lit2( Con (Name PubName a)))  _) -> isPrefixOf "F_" (show a)
             _ -> False
     isFirstInsertAction _ = False
 
-    isLastInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _)  (t:_)) ) = 
+    isLastInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ (t:_)) ) = 
         case t of
             (viewTerm2 -> FPair (viewTerm2 -> Lit2( Con (Name PubName a)))  _) -> not( isPrefixOf "L_" (show a))
             _ -> False
     isLastInsertAction _ = False
 
-    isNotInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _)) = False
+    isNotInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ _)) = False
     isNotInsertAction  _                                 = True
 
-    isNotReceiveAction (ActionG _ (Fact (ProtoFact _ "Receive" _) _)) = False
+    isNotReceiveAction (ActionG _ (Fact (ProtoFact _ "Receive" _) _ _)) = False
     isNotReceiveAction  _                                 = True
 
     isStandardActionGoalButNotInsertOrReceive g = 
        (isStandardActionGoal g) && (isNotInsertAction g) && (isNotReceiveAction g)
 
 
-    isLastProtoFact (PremiseG _ (Fact (ProtoFact _ ('L':'_':_) _) _)) = True
-    isLastProtoFact _                                                 = False
+    isLastProtoFact (PremiseG _ fa) = isSolveLastFact fa
+    isLastProtoFact _               = False
 
-    isFirstProtoFact (PremiseG _ (Fact (ProtoFact _ ('F':'_':_) _) _)) = True
-    isFirstProtoFact _                                                 = False
+    isFirstProtoFact (PremiseG _ fa) = isSolveFirstFact fa
+    isFirstProtoFact _               = False
 
     isNotAuthOut (PremiseG _ fa) = not (isAuthOutFact fa)
     isNotAuthOut _               = False
@@ -919,33 +919,33 @@ sapicPKCS11Ranking ctxt sys =
        not (isKFact fa) && not (isAuthOutFact fa)
     isNonLoopBreakerProtoFactGoal _                            = False
 
-    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _) = True
+    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _ _) = True
     isAuthOutFact  _                                 = False
 
-    isStateFact (PremiseG _ (Fact (ProtoFact _ n _) _)) = isPrefixOf "State_" n
+    isStateFact (PremiseG _ (Fact (ProtoFact _ n _) _ _)) = isPrefixOf "State_" n
     isStateFact  _                                 = False
 
-    isUnlockAction (ActionG _ (Fact (ProtoFact _ "Unlock" _) _)) = True
+    isUnlockAction (ActionG _ (Fact (ProtoFact _ "Unlock" _) _ _)) = True
     isUnlockAction  _                                 = False
 
-    isInsertTemplateAction (ActionG _ (Fact (ProtoFact _ "Insert" _)  (t:_)) ) = 
+    isInsertTemplateAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ (t:_)) ) = 
         case t of
             (viewTerm2 -> FPair (viewTerm2 -> Lit2( Con (Name PubName a)))  _) -> isPrefixOf "template" (show a)
             _ -> False
     isInsertTemplateAction _ = False
 
-    isNotInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _)) = False
+    isNotInsertAction (ActionG _ (Fact (ProtoFact _ "Insert" _) _ _)) = False
     isNotInsertAction  _                                 = True
 
     isStandardActionGoalButNotInsert g = 
        (isStandardActionGoal g) &&  (isNotInsertAction g)
 
 
-    isLastProtoFact (PremiseG _ (Fact (ProtoFact _ ('L':'_':_) _) _)) = True
-    isLastProtoFact _                                                 = False
+    isLastProtoFact (PremiseG _ fa) = isSolveLastFact fa
+    isLastProtoFact _               = False
 
-    isFirstProtoFact (PremiseG _ (Fact (ProtoFact _ ('F':'_':_) _) _)) = True
-    isFirstProtoFact _                                                 = False
+    isFirstProtoFact (PremiseG _ fa) = isSolveFirstFact fa
+    isFirstProtoFact _               = False
 
     isNotAuthOut (PremiseG _ fa) = not (isAuthOutFact fa)
     isNotAuthOut _               = False
@@ -1031,7 +1031,7 @@ injRanking ctxt allowLoopBreakers sys =
     -- move the Last proto facts (L_) and large splits to the end by
     -- putting all goals that shouldn't be solved last in front
     notSolveLast goaltuple = (isNoLargeSplitGoal $ fst goaltuple)
-                            && (isNonLastProtoFact $ fst goaltuple)
+                            && (isNonSolveLastGoal $ fst goaltuple)
                             && (isNotKnowsLastNameGoal $ fst goaltuple)
 
     solveFirst =
@@ -1051,7 +1051,7 @@ injRanking ctxt allowLoopBreakers sys =
     -- within the same priority class, so one type of goal doesn't always win
     -- (assuming the same usefulness)
     isHighPriorityGoal goal = (isKnowsFirstNameGoal goal)
-                                || (isFirstProtoFact goal)
+                                || (isSolveFirstGoal goal)
                                 || (isChainGoal goal)
                                 || (isFreshKnowsGoal goal)
 
@@ -1073,19 +1073,17 @@ injRanking ctxt allowLoopBreakers sys =
     isProtoFactGoal _                       = False
 
     -- Detect 'I_' (immediate) fact and term prefix for heuristics
-    isImmediateGoal (PremiseG _ (Fact (ProtoFact _ ('I':'_':_) _) _)) = True
-    isImmediateGoal (ActionG  _ (Fact (ProtoFact _ ('I':'_':_) _) _)) = True
+    isImmediateGoal (PremiseG _ (Fact (ProtoFact _ ('I':'_':_) _) _ _)) = True
+    isImmediateGoal (ActionG  _ (Fact (ProtoFact _ ('I':'_':_) _) _ _)) = True
     isImmediateGoal goal = isKnowsImmediateNameGoal goal
 
-    -- Detect 'F_' (first) fact prefix for heuristics
-    isFirstProtoFact (PremiseG _ (Fact (ProtoFact _ ('F':'_':_) _) _)) = True
-    isFirstProtoFact (ActionG  _ (Fact (ProtoFact _ ('F':'_':_) _) _)) = True
-    isFirstProtoFact _                                                 = False
+    isNonSolveLastGoal (PremiseG _ fa) = not $ isSolveLastFact fa
+    isNonSolveLastGoal (ActionG  _ fa) = not $ isSolveLastFact fa
+    isNonSolveLastGoal _               = True
 
-    -- Detect 'L_' (last) fact prefix for heuristics
-    isNonLastProtoFact (PremiseG _ (Fact (ProtoFact _ ('L':'_':_) _) _)) = False
-    isNonLastProtoFact (ActionG  _ (Fact (ProtoFact _ ('L':'_':_) _) _)) = False
-    isNonLastProtoFact _                                                 = True
+    isSolveFirstGoal (PremiseG _ fa) = isSolveFirstFact fa
+    isSolveFirstGoal (ActionG  _ fa) = isSolveFirstFact fa
+    isSolveFirstGoal _               = False
 
     isLastName lv = isPrefixOf "L_" (lvarName lv)
     isFirstName lv = isPrefixOf "F_" (lvarName lv)
@@ -1132,7 +1130,7 @@ injRanking ctxt allowLoopBreakers sys =
     -- | @sortDecisionTree xs ps@ returns a reordering of @xs@
     -- such that the sublist satisfying @ps!!0@ occurs first,
     -- then the sublist satisfying @ps!!1@, and so on.
-    sortDecisionTree :: [a -> Bool] -> [a] -> [a]
+    sortDecisionTree :: (Show a) => [a -> Bool] -> [a] -> [a]
     sortDecisionTree []     xs = xs
     sortDecisionTree (p:ps) xs = sat ++ sortDecisionTree ps nonsat
       where (sat, nonsat) = partition p xs
@@ -1169,13 +1167,13 @@ smartRanking ctxt allowPremiseGLoopBreakers sys =
     unmarkPremiseG annGoal                        = annGoal
 
     notSolveLast =
-       [ isNonLastProtoFact . fst ]
+       [ isNonSolveLastGoal . fst ]
        -- move the Last proto facts (L_) to the end by sorting all other goals in front
 
     solveFirst =
         [ isChainGoal . fst
         , isDisjGoal . fst
-        , isFirstProtoFact . fst
+        , isSolveFirstGoal . fst
         , isNonLoopBreakerProtoFactGoal
         , isStandardActionGoal . fst
         , isNotAuthOut . fst
@@ -1199,7 +1197,7 @@ smartRanking ctxt allowPremiseGLoopBreakers sys =
       not (isKFact fa) && not (isAuthOutFact fa)
     isNonLoopBreakerProtoFactGoal _                            = False
 
-    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _) = True
+    isAuthOutFact (Fact (ProtoFact _ "AuthOut" _) _ _) = True
     isAuthOutFact  _                                 = False
 
     isNotAuthOut (PremiseG _ fa) = not (isAuthOutFact fa)
@@ -1208,13 +1206,13 @@ smartRanking ctxt allowPremiseGLoopBreakers sys =
     msgPremise (ActionG _ fa) = do (UpK, m) <- kFactView fa; return m
     msgPremise _              = Nothing
 
-    -- Detect 'F_' (first) fact prefix for heuristics
-    isFirstProtoFact (PremiseG _ (Fact (ProtoFact _ ('F':'_':_) _) _)) = True
-    isFirstProtoFact _                                                 = False
+    isNonSolveLastGoal (PremiseG _ fa) = not $ isSolveLastFact fa
+    isNonSolveLastGoal (ActionG  _ fa) = not $ isSolveLastFact fa
+    isNonSolveLastGoal _               = True
 
-    -- Detect 'L_' (last) fact prefix for heuristics
-    isNonLastProtoFact (PremiseG _ (Fact (ProtoFact _ ('L':'_':_) _) _)) = False
-    isNonLastProtoFact _                                                 = True
+    isSolveFirstGoal (PremiseG _ fa) = isSolveFirstFact fa
+    isSolveFirstGoal (ActionG _ fa)  = isSolveFirstFact fa
+    isSolveFirstGoal _               = False
 
     isFreshKnowsGoal goal = case msgPremise goal of
         Just (viewTerm -> Lit (Var lv)) | lvarSort lv == LSortFresh -> True
@@ -1279,7 +1277,7 @@ smartDiffRanking ctxt sys =
 
     -- | If all the fact terms are simple and different msg variables (i.e., not fresh or public), returns the list of all these variables. Otherwise returns Nothing. Currently identical to "isTrivialFact" from Model/Fact, but could eventually be relaxed there, but not here. 
     isTrivialMsgFact :: LNFact -> Maybe [LVar]
-    isTrivialMsgFact (Fact _ ts) = case ts of
+    isTrivialMsgFact (Fact _ _ ts) = case ts of
       []   -> Just []
       x:xs -> Prelude.foldl combine (getMsgVar x) (map getMsgVar xs)
       where

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -222,8 +222,8 @@ labelNodeId = \i rules parent -> do
     -- | Import a rule with all its variables renamed to fresh variables.
     importRule ru = someRuleACInst ru `evalBindT` noBindings
 
-    mkISendRuleAC m = return $ Rule (IntrInfo (ISendRule))
-                                    [kuFact m] [inFact m] [kLogFact m] []
+    mkISendRuleAC ann m = return $ Rule (IntrInfo (ISendRule))
+                                    [kuFactAnn ann m] [inFact m] [kLogFact m] []
 
 
     mkFreshRuleAC m = Rule (ProtoInfo (ProtoRuleACInstInfo FreshRule [] []))
@@ -233,15 +233,15 @@ labelNodeId = \i rules parent -> do
 
     exploitPrem i ru (v, fa) = case fa of
         -- CR-rule *DG2_2* specialized for *In* facts.
-        Fact InFact [m] -> do
+        Fact InFact ann [m] -> do
             j <- freshLVar "vf" LSortNode
-            ruKnows <- mkISendRuleAC m
+            ruKnows <- mkISendRuleAC ann m
             modM sNodes (M.insert j ruKnows)
             modM sEdges (S.insert $ Edge (j, ConcIdx 0) (i, v))
             exploitPrems j ruKnows
 
         -- CR-rule *DG2_2* specialized for *Fr* facts.
-        Fact FreshFact [m] -> do
+        Fact FreshFact _ [m] -> do
             j <- freshLVar "vf" LSortNode
             modM sNodes (M.insert j (mkFreshRuleAC m))
             unless (isFreshVar m) $ do
@@ -281,7 +281,7 @@ insertEdges edges = do
 -- FIXME: Ensure that intermediate products are also solved before stating
 -- that no rule is applicable.
 insertAction :: NodeId -> LNFact -> Reduction ChangeIndicator
-insertAction i fa = do
+insertAction i fa@(Fact _ ann _) = do
     present <- (goal `M.member`) <$> getM sGoals
     isdiff <- getM sDiffSystem
     nodePresent <- (i `M.member`) <$> getM sNodes
@@ -295,7 +295,7 @@ insertAction i fa = do
                           -- if the node is already present in the graph, do not insert it again. (This can be caused by substitutions applying and changing a goal.)
                           if not nodePresent
                              then do
-                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_pair")) ([(Fact KUFact [m1]),(Fact KUFact [m2])]) ([fa]) ([fa]) []))
+                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_pair")) ([(kuFactAnn ann m1),(kuFactAnn ann m2)]) ([fa]) ([fa]) []))
                                insertGoal goal False
                                markGoalAsSolved "pair" goal
                                requiresKU m1 *> requiresKU m2 *> return Changed
@@ -314,7 +314,7 @@ insertAction i fa = do
                           -- if the node is already present in the graph, do not insert it again. (This can be caused by substitutions applying and changing a goal.)
                           if not nodePresent
                              then do
-                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_inv")) ([(Fact KUFact [m])]) ([fa]) ([fa]) []))
+                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_inv")) ([(kuFactAnn ann m)]) ([fa]) ([fa]) []))
                                insertGoal goal False
                                markGoalAsSolved "inv" goal
                                requiresKU m *> return Changed
@@ -333,7 +333,7 @@ insertAction i fa = do
                           -- if the node is already present in the graph, do not insert it again. (This can be caused by substitutions applying and changing a goal.)
                           if not nodePresent
                              then do
-                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_mult")) (map (\x -> Fact KUFact [x]) ms) ([fa]) ([fa]) []))
+                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_mult")) (map (\x -> kuFactAnn ann x) ms) ([fa]) ([fa]) []))
                                insertGoal goal False
                                markGoalAsSolved "mult" goal
                                mapM_ requiresKU ms *> return Changed
@@ -353,7 +353,7 @@ insertAction i fa = do
                           -- if the node is already present in the graph, do not insert it again. (This can be caused by substitutions applying and changing a goal.)
                           if not nodePresent
                              then do
-                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_union")) (map (\x -> Fact KUFact [x]) ms) ([fa]) ([fa]) []))
+                               modM sNodes (M.insert i (Rule (IntrInfo (ConstrRule $ BC.pack "_union")) (map (\x -> kuFactAnn ann x) ms) ([fa]) ([fa]) []))
                                insertGoal goal False
                                markGoalAsSolved "union" goal
                                mapM_ requiresKU ms *> return Changed
@@ -375,7 +375,7 @@ insertAction i fa = do
     -- loop due to generating new KU-nodes that are merged immediately.
     requiresKU t = do
       j <- freshLVar "vk" LSortNode
-      let faKU = kuFact t
+      let faKU = kuFactAnn ann t
       insertLess j i
       void (insertAction j faKU)
 

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -267,9 +267,9 @@ solveUniqueActions = do
     -- proof-context, e.g., in the 'ClassifiedRules'.
     let uniqueActions = [ x | [x] <- group (sort ruleActions) ]
         ruleActions   = [ (tag, length ts)
-                        | ru <- rules, Fact tag ts <- get rActs ru ]
+                        | ru <- rules, Fact tag _ ts <- get rActs ru ]
 
-        isUnique (Fact tag ts) =
+        isUnique (Fact tag _ ts) =
            (tag, length ts) `elem` uniqueActions
            -- multiset union leads to case-splits because there
            -- are multiple unifiers

--- a/lib/theory/src/Theory/Constraint/Solver/Sources.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Sources.hs
@@ -137,7 +137,7 @@ solveAllSafeGoals ths' =
         ActionG _ fa  -> not (isKUFact fa)
         -- we do not solve KD goals for Xor facts as insertAction inserts
         -- these goals directly. This prevents loops in the precomputations
-        PremiseG _ fa -> not (isKUFact fa) && not (isKDXorFact fa)
+        PremiseG _ fa -> not (isKUFact fa) && not (isKDXorFact fa) && not (isNoSourcesFact fa)
         DisjG _       -> doSplit
         -- Uncomment to get more extensive case splitting
         SplitG _      -> doSplit --extensiveSplitting &&

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -1368,7 +1368,7 @@ prettyGoals solved sys = vsep $ do
         -- We cannot deduce a message from a last node.
         guard (not $ isLast sys j)
         let derivedMsgs = concatMap toplevelTerms $
-                [ t | Fact OutFact [t] <- L.get rConcs ru] <|>
+                [ t | Fact OutFact _ [t] <- L.get rConcs ru] <|>
                 [ t | Just (DnK, t)    <- kFactView <$> L.get rConcs ru]
         -- m is deducible from j without an immediate contradiction
         -- if it is a derived message of 'ru' and the dependency does

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -136,7 +136,7 @@ dotNode v = dotOnce dsNodes v $ do
         nameAndActs =
             ruleInfo (prettyProtoRuleName . get praciName) prettyIntrRuleACInfo (get rInfo ru) <->
             brackets (vcat $ punctuate comma $ map prettyLNFact $ filter isNotDiffAnnotation $ get rActs ru)
-        isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0, factTerms = []})
+        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
 
 -- | An edge from a rule node to its premises or conclusions.
 dotIntraRuleEdge :: D.NodeId -> D.NodeId -> SeDot ()
@@ -372,7 +372,7 @@ dotNodeCompact boringStyle v = dotOnce dsNodes v $ do
             (brackets $ vcat $ punctuate comma $
                 map prettyLNFact $ filter isNotDiffAnnotation $ get rActs ru)
 
-        isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0, factTerms = []})
+        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
 
         renderRow annDocs =
           zipWith (\(ann, _) lbl -> (ann, lbl)) annDocs $

--- a/lib/theory/src/Theory/Constraint/System/Guarded.hs
+++ b/lib/theory/src/Theory/Constraint/System/Guarded.hs
@@ -163,7 +163,7 @@ guardFactTags =
     foldGuarded mempty (mconcat . getDisj) (mconcat . getConj) getTags
   where
     getTags _qua _ss atos inner =
-        mconcat [ D.singleton tag | Action _ (Fact tag _) <- atos ] <> inner
+        mconcat [ D.singleton tag | Action _ (Fact tag _ _) <- atos ] <> inner
 
 
 -- | Atoms that are allowed as guards.

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -43,6 +43,7 @@ module Theory.Model.Fact (
   , isTrivialFact
   , isSolveFirstFact
   , isSolveLastFact
+  , isNoSourcesFact
 
   , DirTag(..)
   , kuFact
@@ -134,7 +135,7 @@ data FactTag = ProtoFact Multiplicity String Int
 -- | Annotations are properties thhat might be used elsewhere (e.g. in
 --   dot rendering, or for sorting by heuristics) but do not affect
 --   the semantics of the fact
-data FactAnnotation = SolveFirst | SolveLast
+data FactAnnotation = SolveFirst | SolveLast | NoSources
     deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
 
 -- | Facts.
@@ -350,6 +351,10 @@ isSolveFirstFact (Fact tag ann _) = SolveFirst `S.member` ann || (isPrefixOf "F_
 isSolveLastFact :: Fact t -> Bool
 isSolveLastFact (Fact tag ann _)  = SolveLast `S.member` ann  || (isPrefixOf "L_" $ factTagName tag)
 
+-- | Whether the fact should not have its source solved
+isNoSourcesFact :: Fact t -> Bool
+isNoSourcesFact (Fact _ ann _) = NoSources `S.member` ann
+
 ------------------------------------------------------------------------------
 -- NFact
 ------------------------------------------------------------------------------
@@ -455,6 +460,7 @@ showFactAnnotation :: FactAnnotation -> String
 showFactAnnotation an = case an of
     SolveFirst     -> "+"
     SolveLast      -> "-"
+    NoSources      -> "no_precomp"
 
 -- | Pretty print a fact.
 prettyFact :: Document d => (t -> d) -> Fact t -> d

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -18,6 +18,7 @@ module Theory.Model.Fact (
     Fact(..)
   , Multiplicity(..)
   , FactTag(..)
+  , FactAnnotation(..)
 
   , matchFact
   , normFact
@@ -38,11 +39,16 @@ module Theory.Model.Fact (
   , getRightFact
   , getFactVariables
   , getFactTerms
+  , getFactAnnotations
   , isTrivialFact
+  , isSolveFirstFact
+  , isSolveLastFact
 
   , DirTag(..)
   , kuFact
+  , kuFactAnn
   , kdFact
+  , kdFactAnn
   , termFact
   , kFactView
   , dedFactView
@@ -59,9 +65,12 @@ module Theory.Model.Fact (
   , freshFact
   , outFact
   , inFact
+  , inFactAnn
   , kLogFact
   , dedLogFact
   , protoFact
+  , protoFactAnn
+  , annotateFact
 
   -- * NFact
   , NFact
@@ -91,6 +100,7 @@ import           Data.Data
 import           Data.Maybe             (isJust)
 -- import           Data.Monoid
 -- import           Data.Traversable       (Traversable(..))
+import           Data.List              (isPrefixOf)
 import qualified Data.Set               as S
 
 import           Term.Unification
@@ -120,29 +130,44 @@ data FactTag = ProtoFact Multiplicity String Int
                           -- to simplify computations. should never occur in a graph.
     deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
 
+
+-- | Annotations are properties thhat might be used elsewhere (e.g. in
+--   dot rendering, or for sorting by heuristics) but do not affect
+--   the semantics of the fact
+data FactAnnotation = SolveFirst | SolveLast
+    deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
+
 -- | Facts.
 data Fact t = Fact
-    { factTag   :: FactTag
-    , factTerms :: [t]
+    { factTag         :: FactTag
+    , factAnnotations :: S.Set FactAnnotation
+    , factTerms       :: [t]
     }
-    deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
+    deriving( Show, Typeable, Data, Generic, NFData, Binary )
 
 
 -- Instances
 ------------
 
+-- Ignore annotations in equality and ord testing
+instance Eq t => Eq (Fact t) where
+    (==) (Fact tag _ ts) (Fact tag' _ ts') = (tag == tag') && (ts == ts')
+
+instance Ord t => Ord (Fact t) where
+    compare (Fact tag _ ts) (Fact tag' _ ts') = compare tag tag' <> compare ts ts'
+
 instance Functor Fact where
-    fmap f (Fact tag ts) = Fact tag (fmap f ts)
+    fmap f (Fact tag an ts) = Fact tag an (fmap f ts)
 
 instance Foldable Fact where
-    foldMap f (Fact _ ts) = foldMap f ts
+    foldMap f (Fact _ _ ts) = foldMap f ts
 
 instance Traversable Fact where
-    sequenceA (Fact tag ts) = Fact tag <$> sequenceA ts
-    traverse f (Fact tag ts) = Fact tag <$> traverse f ts
+    sequenceA (Fact tag an ts) = Fact tag an <$> sequenceA ts
+    traverse f (Fact tag an ts) = Fact tag an <$> traverse f ts
 
 instance Sized t => Sized (Fact t) where
-  size (Fact _ args) = size args
+  size (Fact _ _ args) = size args
 
 instance HasFrees t => HasFrees (Fact t) where
     foldFrees  f = foldMap  (foldFrees f)
@@ -161,25 +186,30 @@ data DirTag = UpK | DnK
             deriving( Eq, Ord, Show )
 
 kdFact, kuFact, termFact :: t -> Fact t
-kdFact = Fact KDFact . return
-kuFact = Fact KUFact . return
-termFact = Fact TermFact . return
+kdFact = Fact KDFact S.empty . return
+kuFact = Fact KUFact S.empty . return
+termFact = Fact TermFact S.empty . return
+
+-- | Make annotated KU/KD facts
+kdFactAnn, kuFactAnn :: S.Set FactAnnotation -> t -> Fact t
+kdFactAnn ann = Fact KDFact ann . return
+kuFactAnn ann = Fact KUFact ann . return
 
 -- | View a message-deduction fact.
 kFactView :: LNFact -> Maybe (DirTag, LNTerm)
 kFactView fa = case fa of
-    Fact KUFact [m] -> Just (UpK, m)
-    Fact KUFact _   -> errMalformed "kFactView" fa
-    Fact KDFact [m] -> Just (DnK, m)
-    Fact KDFact _   -> errMalformed "kFactView" fa
-    _               -> Nothing
+    Fact KUFact _ [m] -> Just (UpK, m)
+    Fact KUFact _ _   -> errMalformed "kFactView" fa
+    Fact KDFact _ [m] -> Just (DnK, m)
+    Fact KDFact _ _   -> errMalformed "kFactView" fa
+    _                 -> Nothing
 
 -- | View a deduction logging fact.
 dedFactView :: LNFact -> Maybe LNTerm
 dedFactView fa = case fa of
-    Fact DedFact [m] -> Just m
-    Fact DedFact _   -> errMalformed "dedFactView" fa
-    _                -> Nothing
+    Fact DedFact _ [m] -> Just m
+    Fact DedFact _ _   -> errMalformed "dedFactView" fa
+    _                  -> Nothing
 
 -- | True if the fact is a message-deduction fact.
 isKFact :: LNFact -> Bool
@@ -187,28 +217,28 @@ isKFact = isJust . kFactView
 
 -- | True if the fact is a KU-fact.
 isKUFact :: LNFact -> Bool
-isKUFact (Fact KUFact _) = True
-isKUFact _               = False
+isKUFact (Fact KUFact _ _) = True
+isKUFact _                 = False
 
 -- | True if the fact is a KD-fact.
 isKDFact :: LNFact -> Bool
-isKDFact (Fact KDFact _) = True
-isKDFact _               = False
+isKDFact (Fact KDFact _ _) = True
+isKDFact _                 = False
 
 -- | True if the fact is a KD-fact concerning an Xor Term.
 isKDXorFact :: LNFact -> Bool
-isKDXorFact (Fact KDFact [m]) = isXor m
-isKDXorFact _                 = False
+isKDXorFact (Fact KDFact _ [m]) = isXor m
+isKDXorFact _                   = False
 
 -- | converts a KU-Fact into a KD-Fact with the same terms
 convertKUtoKD :: LNFact -> LNFact
-convertKUtoKD (Fact KUFact m) = (Fact KDFact m)
-convertKUtoKD f               = f
+convertKUtoKD (Fact KUFact a m) = (Fact KDFact a m)
+convertKUtoKD f                 = f
 
 -- | converts a KD-Fact into a KU-Fact with the same terms
 convertKDtoKU :: LNFact -> LNFact
-convertKDtoKU (Fact KDFact m) = (Fact KUFact m)
-convertKDtoKU f               = f
+convertKDtoKU (Fact KDFact a m) = (Fact KUFact a m)
+convertKDtoKU f                 = f
 
 -- | Mark a fact as malformed.
 errMalformed :: String -> LNFact -> a
@@ -220,15 +250,19 @@ errMalformed caller fa =
 
 -- | A fact denoting a message sent by the protocol to the intruder.
 outFact :: t -> Fact t
-outFact = Fact OutFact . return
+outFact = Fact OutFact S.empty . return
 
 -- | A fresh fact denotes a fresh unguessable name.
 freshFact :: t -> Fact t
-freshFact = Fact FreshFact . return
+freshFact = Fact FreshFact S.empty . return
 
 -- | A fact denoting that the intruder sent a message to the protocol.
 inFact :: t -> Fact t
-inFact = Fact InFact . return
+inFact = Fact InFact S.empty . return
+
+-- | An annotated fact denoting that the intruder sent a message to the protocol.
+inFactAnn :: S.Set FactAnnotation -> t -> Fact t
+inFactAnn an = Fact InFact an . return
 
 -- | A fact logging that the intruder knows a message.
 kLogFact :: t -> Fact t
@@ -237,20 +271,27 @@ kLogFact = protoFact Linear "K" . return
 -- | A fact logging that the intruder deduced a message using a construction
 -- rule. We use this to formulate invariants over normal dependency graphs.
 dedLogFact :: t -> Fact t
-dedLogFact = Fact DedFact . return
+dedLogFact = Fact DedFact S.empty . return
 
 -- | A protocol fact denotes a fact generated by a protocol rule.
 protoFact :: Multiplicity -> String -> [t] -> Fact t
-protoFact multi name ts = Fact (ProtoFact multi name (length ts)) ts
+protoFact multi name ts = Fact (ProtoFact multi name (length ts)) S.empty ts
 
+-- | An annotated fact denoting a fact generated by a protocol rule.
+protoFactAnn :: Multiplicity -> String -> S.Set FactAnnotation -> [t] -> Fact t
+protoFactAnn multi name an ts = Fact (ProtoFact multi name (length ts)) an ts
+
+-- | Add annotations to an existing fact
+annotateFact :: S.Set FactAnnotation -> Fact t -> Fact t
+annotateFact ann' (Fact tag ann ts) = Fact tag (S.union ann' ann) ts
 
 -- Queries on facts
 -------------------
 
 -- | True iff the fact is a non-special protocol fact.
 isProtoFact :: Fact t -> Bool
-isProtoFact (Fact (ProtoFact _ _ _) _) = True
-isProtoFact _                          = False
+isProtoFact (Fact (ProtoFact _ _ _) _ _) = True
+isProtoFact _                            = False
 
 -- | True if the fact is a linear fact.
 isLinearFact :: Fact t -> Bool
@@ -282,7 +323,7 @@ factTagArity tag = case  tag of
 
 -- | The arity of a 'Fact'.
 factArity :: Fact t -> Int
-factArity (Fact tag ts)
+factArity (Fact tag _ ts)
   | length ts == k = k
   | otherwise      = error $ "factArity: tag of arity " ++ show k ++
                              " applied to " ++ show (length ts) ++ " terms"
@@ -295,7 +336,19 @@ factMultiplicity = factTagMultiplicity . factTag
 
 -- | The terms of a 'Fact'.
 getFactTerms :: Fact t -> [t]
-getFactTerms (Fact _ ts) = ts 
+getFactTerms (Fact _ _ ts) = ts
+
+-- | Get the set of fact annotations
+getFactAnnotations :: Fact t -> S.Set FactAnnotation
+getFactAnnotations (Fact _ ann _) = ann
+
+-- | Whether the fact has been marked as 'solve first' for the heuristic
+isSolveFirstFact :: Fact t -> Bool
+isSolveFirstFact (Fact tag ann _) = SolveFirst `S.member` ann || (isPrefixOf "F_" $ factTagName tag)
+
+-- | Whether the fact has been marked as 'solve last' for the heuristic
+isSolveLastFact :: Fact t -> Bool
+isSolveLastFact (Fact tag ann _)  = SolveLast `S.member` ann  || (isPrefixOf "L_" $ factTagName tag)
 
 ------------------------------------------------------------------------------
 -- NFact
@@ -329,7 +382,7 @@ unifiableLNFacts fa1 fa2 = (not . null) <$> unifyLNFactEqs [Equal fa1 fa2]
 
 -- | Normalize all terms in the fact
 normFact :: LNFact -> WithMaude LNFact
-normFact (Fact h ts) = reader $ \hnd -> (Fact h (map (\term -> runReader (norm' term) hnd) ts))
+normFact (Fact h an ts) = reader $ \hnd -> (Fact h an (map (\term -> runReader (norm' term) hnd) ts))
 
 -- | @matchLFact t p@ is a complete set of AC matchers for the term fact @t@
 -- and the pattern fact @p@.
@@ -343,22 +396,22 @@ matchFact t p =
     
 -- | Get "left" variant of a diff fact
 getLeftFact :: LNFact -> LNFact
-getLeftFact (Fact tag ts) =
-   (Fact tag (map getLeftTerm ts))
+getLeftFact (Fact tag an ts) =
+   (Fact tag an (map getLeftTerm ts))
 
 -- | Get "left" variant of a diff fact
 getRightFact :: LNFact -> LNFact
-getRightFact (Fact tag ts) =
-   (Fact tag (map getRightTerm ts))
+getRightFact (Fact tag an ts) =
+   (Fact tag an (map getRightTerm ts))
 
 -- | Get all variables inside a fact
 getFactVariables :: LNFact -> [LVar]
-getFactVariables (Fact _ ts) =
+getFactVariables (Fact _ _ ts) =
    map fst $ varOccurences ts
 
 -- | If all the fact terms are simple and different msg variables (i.e., not fresh or public), returns the list of all these variables. Otherwise returns Nothing. [This could be relaxed to work for all variables (including fresh and public) if Facts were typed, so that an argument would always have to be fresh or public or general.]
 isTrivialFact :: LNFact -> Maybe [LVar]
-isTrivialFact (Fact _ ts) = case ts of
+isTrivialFact (Fact _ _ ts) = case ts of
       []   -> Just []
       x:xs -> Prelude.foldl combine (getMsgVar x) (map getMsgVar xs)
     where
@@ -397,13 +450,21 @@ showFactTag tag =
 showFactTagArity :: FactTag -> String
 showFactTagArity tag = showFactTag tag ++ "/" ++ show (factTagArity tag)
 
+-- | Show fact annotation
+showFactAnnotation :: FactAnnotation -> String
+showFactAnnotation an = case an of
+    SolveFirst     -> "+"
+    SolveLast      -> "-"
+
 -- | Pretty print a fact.
 prettyFact :: Document d => (t -> d) -> Fact t -> d
-prettyFact ppTerm (Fact tag ts)
-  | factTagArity tag /= length ts = ppFact ("MALFORMED-" ++ show tag) ts
-  | otherwise                     = ppFact (showFactTag tag) ts
+prettyFact ppTerm (Fact tag an ts)
+  | factTagArity tag /= length ts = ppFact ("MALFORMED-" ++ show tag) ts <> ppAnn an
+  | otherwise                     = ppFact (showFactTag tag) ts <> ppAnn an
   where
-    ppFact n = nestShort' (n ++ "(") ")" . fsep . punctuate comma . map ppTerm
+    ppFact n t = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ map ppTerm t
+    ppAnn ann = if S.null ann then text "" else
+        brackets . fsep . punctuate comma $ map (text . showFactAnnotation) $ S.toList ann
 
 -- | Pretty print a 'NFact'.
 prettyNFact :: Document d => LNFact -> d

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -247,6 +247,7 @@ factAnnotation :: Parser FactAnnotation
 factAnnotation = asum
   [ opPlus  *> pure SolveFirst
   , opMinus *> pure SolveLast
+  , symbol "no_precomp" *> pure NoSources
   ]
 
 -- | Parse a fact.

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 -- |
 -- Copyright   : (c) 2010-2012 Simon Meier, Benedikt Schmidt
 -- License     : GPL v3 (see LICENSE)
@@ -61,6 +62,7 @@ data ParseRestriction = ParseRestriction
        , pRstrFormula    :: LNFormula
        }
        deriving( Eq, Ord, Show )
+
 
 -- | True iff the restriction is a LHS restriction.
 isLeftRestriction :: ParseRestriction -> Bool
@@ -240,6 +242,13 @@ msetterm plit = do
 tupleterm :: Ord l => Parser (Term l) -> Parser (Term l)
 tupleterm plit = chainr1 (msetterm plit) ((\a b -> fAppPair (a,b)) <$ comma)
 
+-- | Parse a fact annotation
+factAnnotation :: Parser FactAnnotation
+factAnnotation = asum
+  [ opPlus  *> pure SolveFirst
+  , opMinus *> pure SolveLast
+  ]
+
 -- | Parse a fact.
 fact :: Ord l => Parser (Term l) -> Parser (Fact (Term l))
 fact plit = try (
@@ -250,21 +259,22 @@ fact plit = try (
          (c:_) | isUpper c -> return ()
                | otherwise -> fail "facts must start with upper-case letters"
        ts    <- parens (commaSep (msetterm plit))
-       mkProtoFact multi i ts
+       ann   <- option [] $ list factAnnotation
+       mkProtoFact multi i (S.fromList ann) ts
     <?> "fact" )
   where
     singleTerm _ constr [t] = return $ constr t
     singleTerm f _      ts  = fail $ "fact '" ++ f ++ "' used with arity " ++
                                      show (length ts) ++ " instead of arity one"
 
-    mkProtoFact multi f = case map toUpper f of
+    mkProtoFact multi f ann = case map toUpper f of
       "OUT" -> singleTerm f outFact
-      "IN"  -> singleTerm f inFact
+      "IN"  -> singleTerm f (inFactAnn ann)
       "KU"  -> singleTerm f kuFact
-      "KD"  -> return . Fact KDFact
-      "DED" -> return . Fact DedFact
+      "KD"  -> singleTerm f kdFact
+      "DED" -> singleTerm f dedLogFact
       "FR"  -> singleTerm f freshFact
-      _     -> return . protoFact multi f
+      _     -> return . protoFactAnn multi f ann
 
 
 ------------------------------------------------------------------------------

--- a/lib/theory/src/Theory/Tools/AbstractInterpretation.hs
+++ b/lib/theory/src/Theory/Tools/AbstractInterpretation.hs
@@ -123,8 +123,8 @@ partialEvaluation evalStyle ruEs = reader $ \hnd ->
     -- the same position provided they have the same sort.
     absFact :: LNFact -> LNFact
     absFact fa = case fa of
-        Fact OutFact _ -> outFact (varTerm (LVar "z" LSortMsg 0))
-        Fact tag ts    -> Fact tag $ evalAbstraction $ traverse absTerm ts
+        Fact OutFact _ _ -> outFact (varTerm (LVar "z" LSortMsg 0))
+        Fact tag an ts    -> Fact tag an $ evalAbstraction $ traverse absTerm ts
       where
         evalAbstraction = (`evalBind` noBindings) . (`evalFreshT` nothingUsed)
 

--- a/lib/theory/src/Theory/Tools/IntruderRules.hs
+++ b/lib/theory/src/Theory/Tools/IntruderRules.hs
@@ -81,11 +81,11 @@ rule iequality:
 --   included independently of the message theory
 specialIntruderRules :: Bool -> [IntrRuleAC]
 specialIntruderRules diff =
-    [ kuRule CoerceRule      [kdFact x_var]                 (x_var)         []
+    [ kuRule CoerceRule      [kdFact x_var]                 (x_var)         [] 
     , kuRule PubConstrRule   []                             (x_pub_var)     [(x_pub_var)]
-    , kuRule FreshConstrRule [Fact FreshFact [x_fresh_var]] (x_fresh_var)   []
-    , Rule ISendRule [kuFact x_var]  [Fact InFact [x_var]] [kLogFact x_var] []
-    , Rule IRecvRule [Fact OutFact [x_var]] [Fact KDFact [x_var]] []        []
+    , kuRule FreshConstrRule [freshFact x_fresh_var] (x_fresh_var)          []
+    , Rule ISendRule [kuFact x_var]  [inFact x_var] [kLogFact x_var]        []
+    , Rule IRecvRule [outFact x_var] [kdFact x_var] []                      []
     ] ++
     if diff 
        then [ Rule IEqualityRule [kuFact x_var, kdFact x_var]  [] [] [] ]
@@ -177,10 +177,10 @@ minimizeIntruderRules diff rules =
                    else r:checked
     
     -- We assume that the KD-Fact is the first fact, which is the case in destructionRules above
-    isDoublePremiseRule (Rule _ ((Fact KDFact [t]):prems) concs _ _) =
+    isDoublePremiseRule (Rule _ ((Fact KDFact _ [t]):prems) concs _ _) = 
         frees concs == []
          && not (any containsPrivate (t:(concat $ map getFactTerms prems)))
-         && isMsgVar t && any (==(Fact KUFact [t])) prems
+         && isMsgVar t && any (==(kuFact t)) prems
     isDoublePremiseRule _                                               = False
 
 -- | @subtermIntruderRules diff maudeSig@ returns the set of intruder rules for
@@ -393,10 +393,10 @@ bpVariantsIntruder hnd ru = do
     -- fact that all other variants are of the form
     -- "pmult(..), pmult(..) -> em(..)"
     case ruvariant of
-      Rule i [Fact KDFact args@[viewTerm -> Lit (Var _)], yfact] concs actions nvs ->
-        return $ Rule i [Fact KUFact args, yfact] concs actions nvs
-      Rule i [yfact, Fact KDFact args@[viewTerm -> Lit (Var _)]] concs actions nvs ->
-        return $ Rule i [yfact, Fact KUFact args] concs actions nvs
+      Rule i [Fact KDFact an args@[viewTerm -> Lit (Var _)], yfact] concs actions nvs ->
+        return $ Rule i [Fact KUFact an args, yfact] concs actions nvs
+      Rule i [yfact, Fact KDFact an args@[viewTerm -> Lit (Var _)]] concs actions nvs ->
+        return $ Rule i [yfact, Fact KUFact an args] concs actions nvs
       _ -> return ruvariant
 
   where

--- a/lib/theory/src/Theory/Tools/LoopBreakers.hs
+++ b/lib/theory/src/Theory/Tools/LoopBreakers.hs
@@ -44,6 +44,8 @@ premSolvingRelAC ePrems eConcs eVariants rules = reader $ \hnd -> do
         ruFrom <- rules
         ruTo   <- rules
         (premIdx, premFa0) <- ePrems ruTo
+        -- NoSource Facts are already explicitly excluded from precomputation
+        guard $ not (isNoSourcesFact premFa0)
         guard $ or $ do
             premFa <- instances ruTo premFa0
             concFa <- instances ruFrom =<< (snd <$> eConcs ruFrom)

--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -335,7 +335,7 @@ factReports thy = concat
 
     freshFactArguments = do
        ru                      <- thyProtoRules thy
-       fa@(Fact FreshFact [m]) <- get rPrems ru
+       fa@(Fact FreshFact _ [m]) <- get rPrems ru
        guard (not (isMsgVar m || isFreshVar m))
        return $ (,) "Fr facts must only use a fresh- or a msg-variable" $
            text ("rule " ++ quote (showRuleCaseName ru)) <->
@@ -475,7 +475,7 @@ factReportsDiff thy = concat
 
     freshFactArguments = do
        ru                      <- diffThyProtoRules thy
-       fa@(Fact FreshFact [m]) <- get rPrems ru
+       fa@(Fact FreshFact _ [m]) <- get rPrems ru
        guard (not (isMsgVar m || isFreshVar m))
        return $ (,) "Fr facts must only use a fresh- or a msg-variable" $
            text ("rule " ++ quote (showRuleCaseName ru)) <->
@@ -519,11 +519,11 @@ factReportsDiff thy = concat
         : dedLogFact undefined
         : kuFact undefined
         : (do DiffRuleItem ru <- get diffThyItems thy; get rActs ru)
-        ++ (do DiffRuleItem ru <- get diffThyItems thy; [Fact {factTag = ProtoFact Linear ("DiffProto" ++ (getRuleName ru)) 0, factTerms = []}])
-        ++ (do ru <- get diffThyCacheRight thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factTerms = []}]) 
-        ++ (do ru <- get diffThyDiffCacheRight thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factTerms = []}]) 
-        ++ (do ru <- get diffThyCacheLeft thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factTerms = []}]) 
-        ++ (do ru <- get diffThyDiffCacheLeft thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factTerms = []}]) 
+        ++ (do DiffRuleItem ru <- get diffThyItems thy; [Fact {factTag = ProtoFact Linear ("DiffProto" ++ (getRuleName ru)) 0, factAnnotations = S.empty, factTerms = []}])
+        ++ (do ru <- get diffThyCacheRight thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factAnnotations = S.empty, factTerms = []}]) 
+        ++ (do ru <- get diffThyDiffCacheRight thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factAnnotations = S.empty, factTerms = []}]) 
+        ++ (do ru <- get diffThyCacheLeft thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factAnnotations = S.empty, factTerms = []}]) 
+        ++ (do ru <- get diffThyDiffCacheLeft thy; [Fact {factTag = ProtoFact Linear ("DiffIntr" ++ (getRuleName ru)) 0, factAnnotations = S.empty, factTerms = []}]) 
 
     inexistentActions = do
         EitherLemmaItem (s, l) <- {-trace ("Caches: " ++ show ((get diffThyCacheRight thy) ++ (get diffThyDiffCacheRight thy) ++ (get diffThyCacheLeft thy) ++ (get diffThyDiffCacheLeft thy))) $-} get diffThyItems thy
@@ -781,7 +781,7 @@ multRestrictedReport thy = do
       where
         ruAbstr = abstractRule ru
 
-        mults = [ mt | Fact _ ts <- get rConcs ru, t <- ts, mt <- multTerms t ]
+        mults = [ mt | Fact _ _ ts <- get rConcs ru, t <- ts, mt <- multTerms t ]
 
         multTerms t@(viewTerm -> FApp (AC Mult) _)  = [t]
         multTerms   (viewTerm -> FApp _         as) = concatMap multTerms as
@@ -847,7 +847,7 @@ multRestrictedReportDiff thy = do
       where
         ruAbstr = abstractRule ru
 
-        mults = [ mt | Fact _ ts <- get rConcs ru, t <- ts, mt <- multTerms t ]
+        mults = [ mt | Fact _ _ ts <- get rConcs ru, t <- ts, mt <- multTerms t ]
 
         multTerms t@(viewTerm -> FApp (AC Mult) _)  = [t]
         multTerms   (viewTerm -> FApp _         as) = concatMap multTerms as


### PR DESCRIPTION
Currently supported are [+] and [-], which have been added
to heuristics where appropriate. A fact can be annotated by
including the annotation in brackets after it, e.g.
`F(t1,t2,t3)[+]` to prioritize solving the fact F.

Annotations are ignored in equality tests, unlike `L_` and `F_`
prefixes to fact names. This allows them to be used more precisely
than the prefixes for heuristic information, e.g. one can have two
rules
`[ State(~id,...)[+], ... ] --[ Rule1() ]-> [ State(~id, ...), ... ]`
`[ State(~id,...)[-], ... ] --[ Rule2() ]-> [ State(~id, ...), ... ]`
where the premise goal to solve for `State` is considered high priority
when it is a premise of `Rule1`, and low priority when it is a premise of
`Rule2`, despite having the same fact name.