### PR TITLE
Emacs syntax highlighting

### DIFF
--- a/etc/spthy.el
+++ b/etc/spthy.el
@@ -54,7 +54,7 @@
   ;; Fontify keywords
   (setq font-lock-defaults spthy-font-lock-defaults)
 
-  ;; ;; Double quotes are for lemmas not strings
+  ;; Double quotes are for lemmas not strings
   (modify-syntax-entry ?\" "w" spthy-mode-syntax-table)
   (modify-syntax-entry ?' "\"" spthy-mode-syntax-table)
 

--- a/etc/spthy.el
+++ b/etc/spthy.el
@@ -1,6 +1,19 @@
 ;;; spthy.el --- SPTHY major mode
 ;; Author: Katriel Cohn-Gordon
 
+;; PRE-TAMARIN MODE: [UGLY HACK] this mode is only used to be able to highlight comments '//' AND  '/* */'
+;;                   since 'modify-syntax-entry' seems unable to deal with both types of comments :(
+(require 'generic-x)
+(define-generic-mode
+  'pre-spthy-mode
+  '("//" ("/*" . "*/"))  ;; C-like comments
+  '()
+  '(((rx "X" (group (any ascii)) "X") . 'font-lock-keyword-face))
+  '("\\.spthy$") ;; files for which to activate this mode
+  nil            ;; other functions to call
+  "A mode for Tamarin files") ;; doc string for this mode
+
+;; TAMARIN-MODE
 ;; Keybindings
 (defvar wpdl-mode-map
   (let ((map (make-sparse-keymap)))
@@ -12,16 +25,16 @@
 (add-to-list 'auto-mode-alist '("\\.spthy\\'" . spthy-mode))
 
 (defvar spthy-keywords
-  '("axiom" "lemma" "protocol" "property" "theory" "begin" "end" "subsection" "section" "text" "rule" "let" "in" "Fresh" "fresh" "Public" "public" "signing" "hashing" "All" "Ex" "h" "sk" "pk" "Fr" "In" "Out" "fr" "in" "out" "not"))
+  '("axiom" "lemma" "restriction" "protocol" "property" "text" "rule" "let" "in" "Fresh" "fresh" "Public" "public" "hashing" "All" "Ex" "h" "sk" "pk" "Fr" "In" "Out" "fr" "in" "out" "not" "!"))
 
 (defvar spthy-events
-  '("pb" "lts" "diffie-hellman" "bilinear-pairing" "multiset" "symmetric-encryption" "asymmetric-encryption" "exists-trace" "all-traces" "enable" "assertions" "modulo" "default_rules" "anb-proto"))
+  '("theory" "begin" "end" "subsection" "section" "pb" "lts" "diffie-hellman" "bilinear-pairing" "multiset" "symmetric-encryption" "asymmetric-encryption" "exists-trace" "all-traces" "enable" "assertions" "modulo" "default_rules" "anb-proto" "signing"))
 
 (defvar spthy-operators
-  '("&" "|" "!" "==>" "=" "<=>" "-->" "^"))
+  '("&" "|" "==>" "=" "<=>" "-->" "^" "[" "]->" "-->" "]" "--["))
 
 (defvar spthy-warnings
-  '("@" "functions" "builtins" "equations"))
+  '("@" "functions" "builtins" "equations" "!")) ; we may want to add ! in operators instead
 
 (defvar spthy-quiet
   '("~" "$"))
@@ -35,24 +48,19 @@
      ( ,(regexp-opt spthy-quiet                   ) . font-lock-comment-face)
  )))
 
-(define-derived-mode spthy-mode fundamental-mode "SPTHY"
+(define-derived-mode spthy-mode pre-spthy-mode "SPTHY"
   "Major mode for editing Tamarin's SPTHY files."
   
   ;; Fontify keywords
   (setq font-lock-defaults spthy-font-lock-defaults)
 
-  ;; C-style comments
-  (modify-syntax-entry ?/ ". 14b" spthy-mode-syntax-table)
-  (modify-syntax-entry ?* ". 23b" spthy-mode-syntax-table)
-
-  ;; Double quotes are for lemmas not strings
+  ;; ;; Double quotes are for lemmas not strings
   (modify-syntax-entry ?\" "w" spthy-mode-syntax-table)
   (modify-syntax-entry ?' "\"" spthy-mode-syntax-table)
 
   ;; < > are delimiters too
   (modify-syntax-entry ?< "(" spthy-mode-syntax-table)
   (modify-syntax-entry ?> "(" spthy-mode-syntax-table)
-
   
   )
 


### PR DESCRIPTION
Hacky fix for the PR https://github.com/tamarin-prover/tamarin-prover/pull/271. I've replaced my old mode with this one, which works fine for the models I've tested. Same disclaimer though: it's far from being perfect but it's better than using no highlighting at all.