### PR TITLE
Fix infinite loop while rendering graphs

### DIFF
--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -1223,8 +1223,8 @@ imgThyPath imgFormat (graphChoice, graphCommand) cacheDir_ compact showJsonGraph
           renderedOrRendering n = do
               graphExists <- doesFileExist graphPath
               imgExists <- doesFileExist imgPath
-              if (n <= 0 || (graphExists && not imgExists))
-                  then do threadDelay 100             -- wait 10 ms
+              if (n > 0 && graphExists && not imgExists)
+                  then do threadDelay (10 * 1000) -- wait 10 ms
                           renderedOrRendering (n - 1)
                   else return imgExists
 
@@ -1355,8 +1355,8 @@ imgDiffThyPath imgFormat dotCommand cacheDir_ compact simplificationLevel abbrev
           renderedOrRendering n = do
               dotExists <- doesFileExist dotPath
               imgExists <- doesFileExist imgPath
-              if (n <= 0 || (dotExists && not imgExists))
-                  then do threadDelay 100             -- wait 10 ms
+              if (n > 0 && dotExists && not imgExists)
+                  then do threadDelay (10 * 1000) -- wait 10 ms
                           renderedOrRendering (n - 1)
                   else return imgExists
 


### PR DESCRIPTION
When using Tamarin on a remote server over unstable connection it is easy to catch it looping forever (as `n` goes negative).
 
Also this fixes timeout to be 10 msec, not 100 μsec (see [threadDelay docs](http://hackage.haskell.org/package/base-4.11.1.0/docs/Control-Concurrent.html#v:threadDelay)).