### PR TITLE
Feature lock restriction first part

### DIFF
--- a/plugins/sapic/annotatedsapicaction.ml
+++ b/plugins/sapic/annotatedsapicaction.ml
@@ -17,8 +17,8 @@ type annotated_sapic_action = Null
                          | Ch_Out of sapic_term * sapic_term
                          | Insert of sapic_term * sapic_term
                          | Delete of sapic_term 
-                         | AnnotatedLock of sapic_term * sapic_var
-                         | AnnotatedUnlock of sapic_term * sapic_var
+                         | AnnotatedLock of sapic_term * int
+                         | AnnotatedUnlock of sapic_term * int
                          | Lock of sapic_term 
                          | Unlock of sapic_term 
                          | Lookup of sapic_term * sapic_term

--- a/plugins/sapic/annotatedsapictree.ml
+++ b/plugins/sapic/annotatedsapictree.ml
@@ -45,7 +45,7 @@ and
 in
 let (result,_) = fold_bottom (fun (l,p_l) (r,p_r) a->
              let p=(max p_l p_r)+1 in
-             let annotation=Fresh("lock"^string_of_int p) in
+             let annotation= p (* Fresh("lock"^string_of_int p) *) in
                match (a:annotated_sapic_action) with
                 Lock(t) -> (Node(AnnotatedLock(t,annotation),
                               annotate_each_closest_unlock t annotation l,

--- a/plugins/sapic/basetranslation.ml
+++ b/plugins/sapic/basetranslation.ml
@@ -62,11 +62,15 @@ let basetrans act p tildex = match act with
       ([State(p,tildex)], [Action("IsIn",[t1; t2])], [State(1::p, tildex @@ (vars_t t2))]);
       ([State(p,tildex)], [Action("IsNotSet",[t1])], [State(2::p,tildex)]) ]
   | AnnotatedUnlock(t,a)  ->
+    let str = "lock"^(string_of_int a) in
+    let unlock_str = "Unlock_"^(string_of_int a) in
     let nonce=a in
-    [([ State(p,tildex)], [Action("Unlock",[Var(nonce); t])], [State(1::p, tildex) ])] 
+    [([ State(p,tildex)], [Action("Unlock",[Var (Pub (string_of_int nonce));  Var (Fresh str); t ]); Action(unlock_str,[Var (Pub (string_of_int nonce));  Var (Fresh str); t ])], [State(1::p, tildex) ])]
   | AnnotatedLock(t,a)  ->
-    let nonce=a in
-    [([ State(p,tildex); Fr(nonce)], [Action("Lock",[Var nonce; t ])], [State(1::p, nonce @:: tildex)])]
+    let str = "lock"^(string_of_int a) in
+    let lock_str = "Lock_"^(string_of_int a) in
+    let nonce=(Fresh str) in
+    [([ State(p,tildex); Fr(nonce)], [Action("Lock",[Var (Pub (string_of_int a)); Var (nonce); t ]);Action(lock_str,[Var (Pub (string_of_int a)); Var (nonce); t ])], [State(1::p, nonce @:: tildex)])]
   | Delete(t)  -> [
       ( [ State(p,tildex)], [Action("Delete",[ t ])], [State(1::p, tildex) ])]
   | Lock(_) | Unlock(_) -> raise (UnAnnotatedLock ("There is an unannotated lock (or unlock) in the proces description, at position:"^pos2string p))

--- a/plugins/sapic/firsttranslation.ml
+++ b/plugins/sapic/firsttranslation.ml
@@ -186,25 +186,6 @@ let progresstrans anP = (* translation for processes with progress *)
   in
   initrule::messsageidrule::(gen trans anP [] varset )
 
-
-(*Returns a list of positions of each defined locks*)
-(* let rec get_lock_positions x = match x with
-      Node(AnnotatedLock(_,a), l, r) -> res_locking_l a ^ ( get_lock_positions (l) ^ get_lock_positions (r))
-    | Node(_, l, r) ->  ( get_lock_positions (l) ^ get_lock_positions (r))
-    | _ -> ""
- *)
-
-
-(*       Empty -> ""
-    |   Node(AnnotatedLock (_,a), left, right) -> res_locking_l a
-    |   Node(AnnotatedUnlock _, left, right) -> ""
-    |   Node(_,left,right) -> (get_lock_positions left) ^ (get_lock_positions right) *)
-
-
-(* let rec get_lock_restrictions x =  match x with
-    [] -> ""
-    | a :: as -> print_lemmas a ^ (get_lock_positions as) ) 
-     *)
     
 let generate_sapic_restrictions annotated_process =
   if (annotated_process = Empty) then ""

--- a/plugins/sapic/firsttranslation.ml
+++ b/plugins/sapic/firsttranslation.ml
@@ -185,13 +185,32 @@ let progresstrans anP = (* translation for processes with progress *)
     }
   in
   initrule::messsageidrule::(gen trans anP [] varset )
-    
+
+
+(*Returns a list of positions of each defined locks*)
+(* let rec get_lock_positions x = match x with
+      Node(AnnotatedLock(_,a), l, r) -> res_locking_l a ^ ( get_lock_positions (l) ^ get_lock_positions (r))
+    | Node(_, l, r) ->  ( get_lock_positions (l) ^ get_lock_positions (r))
+    | _ -> ""
+ *)
+
+
+(*       Empty -> ""
+    |   Node(AnnotatedLock (_,a), left, right) -> res_locking_l a
+    |   Node(AnnotatedUnlock _, left, right) -> ""
+    |   Node(_,left,right) -> (get_lock_positions left) ^ (get_lock_positions right) *)
+
+
+(* let rec get_lock_restrictions x =  match x with
+    [] -> ""
+    | a :: as -> print_lemmas a ^ (get_lock_positions as) ) 
+     *)
     
 let generate_sapic_restrictions annotated_process =
   if (annotated_process = Empty) then ""
   else 
       (if contains_lookup annotated_process then res_set_in ^ res_set_notin else "")
-    ^ (if contains_locking annotated_process then  res_locking else "")
+    (*^ (if contains_locking annotated_process then  List.map res_locking_l (get_lock_positions  annotated_process) else [])*)
     ^ (if contains_eq annotated_process then res_predicate_eq ^ res_predicate_not_eq else "")
     ^ (* Stuff that's always there *)
     res_single_session (*  ^ass_immeadiate_in TODO disabled ass_immeadiate, need to change semantics in the paper *)
@@ -212,7 +231,15 @@ let translation input =
       ^ res_resilient 
     else 
       generate_sapic_restrictions annotated_process
+  (*and sapic_restrictions = List.map print_lemmas (generate_sapic_restrictions annotated_process)*)
+  and sapic_restrictions_locks = 
+    if contains_locking annotated_process
+    then  
+      let lock_list = get_lock_positions annotated_process  
+      in
+      print_lock_restrictions  (remove_duplicates lock_list)
+    else ""
   in
-  input.sign ^ ( print_msr msr ) ^ users_restrictions ^ sapic_restrictions ^
+  input.sign ^ ( print_msr msr ) ^ users_restrictions ^ sapic_restrictions ^  sapic_restrictions_locks ^
   predicate_restrictions ^ lemmas_tamarin 
   ^ "end"

--- a/plugins/sapic/restrictions.ml
+++ b/plugins/sapic/restrictions.ml
@@ -59,6 +59,22 @@ restriction locking:
 
 "
 
+ let res_locking_l pos = " 
+ restriction locking_" ^ string_of_int pos ^ ": 
+ \"All p pp l x lp #t1 #t3 . Lock_" ^ string_of_int pos ^ "(p,l,x)@t1 & Lock(pp,lp,x)@t3 
+         ==> 
+         ( #t1<#t3 
+                  & (Ex #t2. Unlock_" ^ string_of_int pos ^ "(p,l,x)@t2 & #t1<#t2 & #t2<#t3  
+                  & (All #t0 pp  . Unlock(pp,l,x)@t0 ==> #t0=#t2) 
+                  & (All pp lpp #t0 . Lock(pp,lpp,x)@t0 ==> #t0<#t1 | #t0=#t1 | #t2<#t0) 
+                  & (All pp lpp #t0 . Unlock(pp,lpp,x)@t0 ==> #t0<#t1 | #t2<#t0 | #t2=#t0 ) 
+                 )) 
+         | #t3<#t1 | #t1=#t3 \" 
+
+ " 
+
+
+
 let res_single_session = "
 restriction single_session: // for a single session
     \"All #i #j. Init()@i & Init()@j ==> #i=#j\"

--- a/plugins/sapic/translationhelper.ml
+++ b/plugins/sapic/translationhelper.ml
@@ -5,6 +5,7 @@ open Annotatedrule
 open Annotatedsapicaction
 open Annotatedsapictree
 open Atomformulaaction
+open Restrictions
 open Btree
 
 let rec print_lemmas lem_list =
@@ -38,6 +39,18 @@ let rec contains_eq t =
     |   Node(Cond(Action("eq",_)), _, _) -> true
     |   Node(_,left,right) -> (contains_eq left) || (contains_eq right)
 
+let rec get_lock_positions x = match x with
+   Node(AnnotatedLock(_,a), l, r) -> a :: ( get_lock_positions (l)  @ get_lock_positions (r))
+    | Node(_, l, r) -> ( get_lock_positions (l)  @ get_lock_positions (r))
+    | _ -> []
+
+let rec remove_duplicates lst= match lst with
+      [] -> []
+    | h::hs -> h :: (remove_duplicates (List.filter (fun x -> x<>h) hs))
+
+let rec print_lock_restrictions x = match x with
+      [] -> ""
+    | h::t -> res_locking_l h ^ print_lock_restrictions t
 
 
 


### PR DESCRIPTION
Locking and unlocking features in Sapic has been improved with defining restrictions for each lock. The optimisation makes Sapic-translated models containing locks and unlocks be solved easier.

- This branch can be squash-merged.