### PR TITLE
SAPIC: Use different colors in graphs for processes

### DIFF
--- a/plugins/sapic/Makefile
+++ b/plugins/sapic/Makefile
@@ -1,5 +1,5 @@
 TARGET = sapic
-OBJS=exceptions.cmo btree.cmo position.cmo positionplusinit.cmo var.cmo term.cmo fact.cmo atomformulaaction.cmo action.cmo atom.cmo formula.cmo tamarin.cmo sapicterm.cmo sapicvar.cmo sapicaction.cmo lexer.cmo  sapic.cmo annotatedsapicaction.cmo annotatedsapictree.cmo progressfunction.cmo restrictions.cmo annotatedrule.cmo translationhelper.cmo basetranslation.cmo firsttranslation.cmo main.cmo 
+OBJS= color.cmo exceptions.cmo btree.cmo position.cmo positionplusinit.cmo var.cmo term.cmo fact.cmo atomformulaaction.cmo action.cmo atom.cmo formula.cmo tamarin.cmo sapicterm.cmo sapicvar.cmo sapicaction.cmo lexer.cmo  sapic.cmo annotatedsapicaction.cmo annotatedsapictree.cmo progressfunction.cmo restrictions.cmo annotatedrule.cmo translationhelper.cmo basetranslation.cmo firsttranslation.cmo main.cmo 
 FLAGS=-g
 
 OCAMLC    := $(shell command -v ocamlc    2> /dev/null)

--- a/plugins/sapic/annotatedrule.ml
+++ b/plugins/sapic/annotatedrule.ml
@@ -4,6 +4,7 @@ open Fact
 open Action
 open Printf
 open Str
+open Color
 
 let strip_non_alphanumerical (termstring:string) = 
     let r1=regexp "[~)({}]+"
@@ -15,41 +16,67 @@ let strip_non_alphanumerical (termstring:string) =
         (global_replace r3 "equals" termstring))
 
 type annotated_rule = { 
-sapic_terms : annotated_sapic_action list;
-position   : position;
-left       : fact list;
-actions    : action list;
-right      : fact list;
+    process_name : string option;
+    sapic_terms  : annotated_sapic_action list;
+    position     : position;
+    left         : fact list;
+    actions      : action list;
+    right        : fact list;
 }
 
-let rec print_msr (msr: annotated_rule list)  = match msr with
+let color_table : (string, string) Hashtbl.t = Hashtbl.create 10
+
+let rec print_msr (msr: annotated_rule list) = match msr with
     [] -> ""
-    | head :: tail -> 
+    | head :: tail ->
             let comment = String.concat ", " (List.map annotated_sapic_action2string head.sapic_terms) in
             let rulename =  strip_non_alphanumerical comment^"_"^(pos2string head.position) in
+            let (process_name, color) = match head.process_name with
+              | Some p ->
+                    let c = (try Hashtbl.find color_table p
+                             with Not_found -> let n = (rgb2string (random_rgb ())) in Hashtbl.add color_table p n; n)
+                    in (sprintf " [process=%s] " p, sprintf " [color=%s]" c)
+              | None -> (" [process=top-level] ", "") in
             let facts2string factlist= String.concat ", " (List.map fact2string factlist)
             and action_list2string al = String.concat ", " (List.map action2string al)
             in
-            sprintf "rule %s: //%s \n [ %s] --[%s]-> [%s]\n\n" rulename comment (facts2string head.left) (action_list2string head.actions) (facts2string head.right) 
+            sprintf "rule %s%s: //%s%s \n [%s] --[%s]-> [%s]\n\n" rulename color process_name comment (facts2string head.left) (action_list2string head.actions) (facts2string head.right) 
             ^ ( print_msr tail)
 
-let msrs2annotated_rules sapic_terms position msrs  = 
+let msrs2annotated_rules sapic_terms position msrs =
   let disambiguate ls = List.fold_left
       (fun (rules,n) (l,a,r) ->
-          (({ sapic_terms =  sapic_terms @ [Comment(string_of_int n)] ;
-         position=position; 
-         left=l; 
-         actions=a;
-         right=r;
+        (({
+            process_name = None;
+            sapic_terms  = sapic_terms @ [Comment(string_of_int n)];
+            position     = position;
+            left         = l;
+            actions      = a;
+            right        = r;
        }::rules),n+1)) ([],0) ls
   in 
   match msrs with
-    [l,a,r] -> 
-        [{ sapic_terms = sapic_terms ;
-          position=position; 
-          left=l; 
-          actions=a;
-          right=r;
+    | [l,a,r] ->
+        [{
+            process_name = None;
+            sapic_terms  = sapic_terms;
+            position     = position;
+            left         = l;
+            actions      = a;
+            right        = r;
         }]
     | [] -> []
     | x::xs -> match disambiguate (x::xs) with (rules,_) -> List.rev rules
+
+let annotated_rules_update process_name ars =
+    List.map (fun ar ->
+        let p_n = match ar.process_name with
+            Some s -> Some s
+          | None -> process_name
+        in
+        { process_name = p_n;
+          sapic_terms  = ar.sapic_terms;
+          position     = ar.position;
+          left         = ar.left;
+          actions      = ar.actions;
+          right        = ar.right; }) ars

--- a/plugins/sapic/annotatedsapicaction.ml
+++ b/plugins/sapic/annotatedsapicaction.ml
@@ -26,6 +26,7 @@ type annotated_sapic_action = Null
                          | Cond of action
                          | MSR of msr 
                          | Comment of string
+                         | Let of string
 
 let annotated_sapic_action2string = function
         Null -> "Zero"
@@ -46,5 +47,6 @@ let annotated_sapic_action2string = function
         | Cond(s) -> "if "^action2string(s)
         | MSR(prem,ac,conl) -> "MSR"   
         | Comment(s) -> s
+        | Let(s) -> "let "^s^" = "
         | Lock(_) | Unlock(_)  -> raise (UnAnnotatedLock "There is an unannotated lock in the
              * proces description") 

--- a/plugins/sapic/annotatedsapictree.ml
+++ b/plugins/sapic/annotatedsapictree.ml
@@ -26,7 +26,16 @@ let rec sapic_tree2annotatedtree (tree:sapic_btree) = fold_bottom (fun (left:ann
         | Sapicaction.Event(a) -> Node(Event(a),left,right)
         | Sapicaction.Cond(a) -> Node(Cond(a),left,right)
         | Sapicaction.MSR(prem,ac,conl) -> Node(MSR(prem,ac,conl) ,left,right)
+        | Sapicaction.Let(s) -> Node(Let(s), left, right)
     ) Empty tree
+
+
+let annotatedtree2string (tree: annotated_btree) =
+    let rec annotatedtree2string_ex tree indent p = match tree with
+        | Empty -> (Printf.sprintf "%s" (pos2string p)) ^ (String.make indent ' ') ^ (Printf.sprintf "Empty \n")
+        | Node(y, l, r) -> (Printf.sprintf "%s" (pos2string p)) ^ (String.make indent ' ') ^ (Printf.sprintf "%s \n" (annotated_sapic_action2string y)) ^ (annotatedtree2string_ex l (indent+2) (1::p)) ^ (annotatedtree2string_ex r (indent+2) (2::p))
+    in
+        annotatedtree2string_ex tree 0 []
 
 (* We assume that locks are closed in the order of the following unlocks,
 * and that eachone is closed indeed.
@@ -65,6 +74,18 @@ let rec process_at anP = function
         Empty -> raise (InvalidPosition (pos2string (2::xr)))
       | Node(_,_,r) -> r)
   |p -> raise (InvalidPosition ((pos2string p)))
+
+let replace_process_at anP rp p = 
+    let rev_pos = List.rev p in
+    let rec replace_process_at_ex anP rp a cp = match (process_at anP a) with
+        Empty -> raise (InvalidPosition (pos2string p))
+      | Node(y,l,r) -> match cp with
+           [] -> rp
+         | 1::xr -> Node(y, replace_process_at_ex anP rp (1::a) xr, r)
+         | 2::xr -> Node(y, l, replace_process_at_ex anP rp (2::a) xr)
+         | _ ->  raise (InvalidPosition (pos2string p))
+    in
+    replace_process_at_ex anP rp [] rev_pos
 
 module PositionSet = Set.Make( Position );;
 let (@@) (a:PositionSet.t) (b:PositionSet.t) = PositionSet.union a b

--- a/plugins/sapic/basetranslation.ml
+++ b/plugins/sapic/basetranslation.ml
@@ -70,6 +70,7 @@ let basetrans act p tildex = match act with
   | Delete(t)  -> [
       ( [ State(p,tildex)], [Action("Delete",[ t ])], [State(1::p, tildex) ])]
   | Lock(_) | Unlock(_) -> raise (UnAnnotatedLock ("There is an unannotated lock (or unlock) in the proces description, at position:"^pos2string p))
+  | Let(s) -> raise (TranslationError "'Let' should not be present at this point")
   | Comment(s) -> raise (TranslationError "Comments should not be present at this point")
 
 
@@ -124,9 +125,10 @@ let annotated_rules_subst_state tree p' p msrs=
     | x ->  x 
   in
   List.map (fun  ar -> 
-      {  sapic_terms = ar.sapic_terms ;
-         position=ar.position; 
-         left=(List.map subst ar.left); 
+      {  process_name = ar.process_name;
+         sapic_terms = ar.sapic_terms;
+         position=ar.position;
+         left=(List.map subst ar.left);
          actions=ar.actions;
          right=ar.right;}  ) msrs
     

--- a/plugins/sapic/color.ml
+++ b/plugins/sapic/color.ml
@@ -1,0 +1,25 @@
+let round_to_int x = int_of_float (floor (x +. 0.5))
+
+let hue2rgb (p, q, t) =
+    let t' = if t < 0.0 then t +. 1.0 else if t > 1.0 then t -. 1.0 else t in
+    if t' < 1.0 /. 6.0      then p +. (q -. p) *. 6.0 *. t'
+    else if t' < 1.0 /. 2.0 then q
+    else if t' < 2.0 /. 3.0 then p +. (q -. p) *. (2.0 /. 3.0 -. t') *. 6.0
+    else p
+
+let hsl2rgb (h, s, l) =
+    let q = if l < 0.5 then l *. (1.0 +. s) else l +. s -. l *. s in
+    let p = 2.0 *. l -. q in
+    let r = if s = 0.0 then l else hue2rgb (p, q, (h +. 1.0 /. 3.0)) in
+    let g = if s = 0.0 then l else hue2rgb (p, q, h) in
+    let b = if s = 0.0 then l else hue2rgb (p, q, (h -. 1.0 /. 3.0)) in
+  
+    (round_to_int (r *. 255.0), round_to_int (g *. 255.0), round_to_int (b *. 255.0))
+
+let rgb2string (r, g, b) = Printf.sprintf "#%02X%02X%02X" r g b
+
+let random_hsl () = (Random.float 1.0, 0.9 +. (Random.float 0.1), 0.5 +. (Random.float 0.1))
+
+let random_rgb_from_hsl () = hsl2rgb (random_hsl ())
+
+let random_rgb () = (Random.int 256, Random.int 256, Random.int 256)

--- a/plugins/sapic/firsttranslation.ml
+++ b/plugins/sapic/firsttranslation.ml
@@ -30,21 +30,21 @@ let rec gen trans tree p tildex  = match (process_at tree p) with
  * substituion necessary for NDC 
  *)
     Empty -> [] 
-  | Node(y, _, _) -> 
+  | Node(y, left, right) ->
     let sapic_terms=[y] in
     (* TODO a warning when embedded  msrs are used would be nice *)
     let basemsrs = trans y p tildex in
     let msrs = (* subst_by_pstate_where_needed tree p *) basemsrs in
     let tildex'1 = (try next_tildex (1::p) msrs with
         NoNextState -> match y with
-          Null ->  VarSet.empty 
-        | NDC -> tildex
+          Null -> VarSet.empty 
+        | NDC | Let(_) -> tildex
         | _ -> raise ProgrammingError)
     and tildex'2 = try next_tildex (2::p) msrs with
         NoNextState -> 
             (* If we don't get a new tildex because there is no next state, y should be one of the following *)
          (   match y with
-          Null | MSR(_) | Rep | NDC | New (_) | Msg_In(_) 
+          Null | Let(_) | MSR(_) | Rep | NDC | New (_) | Msg_In(_) 
         | Msg_Out(_) | Ch_In(_) | Ch_Out(_) 
         |  Insert(_) | Delete (_) | Event(_) 
         | Lock _ | Unlock _
@@ -54,19 +54,31 @@ let rec gen trans tree p tildex  = match (process_at tree p) with
          )
     in
     if y=NDC then
-       let  l = gen trans tree (1::p) tildex 
-       and  r = gen trans tree (2::p) tildex
+       let  l = gen trans tree (1::p) tildex in
+       let  r = gen trans tree (2::p) tildex
        and  s1 = annotated_rules_subst_state tree p (1::p)
        and  s2 = annotated_rules_subst_state tree p (2::p) 
        in 
           s1(l)@s2(r)
     else
-      msrs2annotated_rules sapic_terms p msrs
-      @  (gen trans tree (1::p) tildex'1)
-      @  (gen trans tree (2::p) tildex'2)
+       let (l, r) = match (left, right) with
+                      (Node(Let(r), ll, Empty), Node(Let(s), rr, Empty)) ->
+                        (let new_tree = replace_process_at tree (Node(y, ll, rr)) p in
+                        (annotated_rules_update (Some r) (gen trans new_tree (1::p) tildex'1), annotated_rules_update (Some s) (gen trans new_tree (2::p) tildex'2)))
+                    | (Node(Let(r), ll, Empty), rr) ->
+                        (let new_tree = replace_process_at tree (Node(y, ll, rr)) p in
+                        (annotated_rules_update (Some r) (gen trans new_tree (1::p) tildex'1), gen trans new_tree (2::p) tildex'2))
+                    | (ll, Node(Let(s), rr, Empty)) ->
+                        (let new_tree = replace_process_at tree (Node(y, ll, rr)) p in
+                        (gen trans new_tree (1::p) tildex'1, annotated_rules_update (Some s) (gen trans new_tree (2::p) tildex'2)))
+                    | (ll, rr) ->
+                        (gen trans tree (1::p) tildex'1, gen trans tree (2::p) tildex'2)
+       in
+       msrs2annotated_rules sapic_terms p msrs @ l @ r
 
 let noprogresstrans anP = 
   let initrule = { 
+    process_name = None;
     sapic_terms = [Comment "Init"];
     position=[];
     left= [];
@@ -161,6 +173,7 @@ let progresstrans anP = (* translation for processes with progress *)
     step3 (child1 p) ( step2 (child2 p) ( step2 (child1 p) (step1msrs)))
   and messsageidrule = 
     { 
+      process_name = None;
       sapic_terms = [Comment "MessageID-rule"];
       position=[];
       left=[Fr(Fresh("x"))];
@@ -173,6 +186,7 @@ let progresstrans anP = (* translation for processes with progress *)
   in
   let initrule =
     { 
+      process_name = None;
       sapic_terms = [Comment "Init"];
       position=[];
       left= if (Progressfunction.is_from pf []) then [Fr(Fresh("prog_"))] else [];
@@ -198,11 +212,13 @@ let generate_sapic_restrictions annotated_process =
 
 let translation input =
   let annotated_process = annotate_locks ( sapic_tree2annotatedtree input.proc) in
+  (* Printf.printf "%s\n" (annotatedtree2string annotated_process); *)
   let msr =  
       if input.op.progress 
       then progresstrans annotated_process
-      else noprogresstrans annotated_process 
-  and lemmas_tamarin = print_lemmas input.lem
+      else noprogresstrans annotated_process
+  in
+  let lemmas_tamarin = print_lemmas input.lem
   and users_restrictions = print_restrictions input.ax
   and predicate_restrictions = print_predicates input.pred
   and sapic_restrictions = 

--- a/plugins/sapic/sapic.mly
+++ b/plugins/sapic/sapic.mly
@@ -299,7 +299,7 @@ process:
 							     $2
 							     (Term.App("rep", [$6;Term.Var(Var.Msg("_loc_"))]))
 							     $9 }
-    | IDENTIFIER                                     { try Hashtbl.find proc_table $1
+    | IDENTIFIER                                     { try Node(Let($1), Hashtbl.find proc_table $1, Empty)
             with Not_found -> Printf.eprintf "The process: %s is undefined. \n " $1; raise Parsing.Parse_error }
      |    rule_body optprocess { Node(MSR($1), $2, Empty) }
 ;

--- a/plugins/sapic/sapicaction.ml
+++ b/plugins/sapic/sapicaction.ml
@@ -24,6 +24,7 @@ type sapic_action = Null
                  | Event of action
                  | Cond of action
                  | MSR of msr 
+                 | Let of string
 
 let sapic_action2string = function
      Null -> "Zero"
@@ -43,6 +44,7 @@ let sapic_action2string = function
     | Event(a) -> "event "^action2string(a)
     | Cond(f) -> "if "^action2string(f)
     | MSR(prem,ac,conl) -> "MSR"   
+    | Let(s) -> "let "^s^" = "
 
 let rec substitute  (id:string) (t:term) process =
   match process with
@@ -55,6 +57,7 @@ let rec substitute  (id:string) (t:term) process =
       | Par
       | NDC -> Node(a, substitute id t left, substitute id t right)
       | Rep -> Node(a, substitute id t left, right)
+      | Let(_) -> raise (InternalRepresentationError "Let node should not be present at this point")
       | New (x) ->
 	if VarSet.mem ( Var.Msg(id) ) ( vars_t (Var(x)) ) then (* rebinding variable id, stop substituting *)
 	  Node( a, left, right )

--- a/plugins/sapic/sapicaction.ml
+++ b/plugins/sapic/sapicaction.ml
@@ -55,9 +55,9 @@ let rec substitute  (id:string) (t:term) process =
       match a with
       | Null -> Node(a, left, right)
       | Par
+      | Let(_)
       | NDC -> Node(a, substitute id t left, substitute id t right)
       | Rep -> Node(a, substitute id t left, right)
-      | Let(_) -> raise (InternalRepresentationError "Let node should not be present at this point")
       | New (x) ->
 	if VarSet.mem ( Var.Msg(id) ) ( vars_t (Var(x)) ) then (* rebinding variable id, stop substituting *)
 	  Node( a, left, right )


### PR DESCRIPTION
Use the color attribute in the rules generated by SAPIC to better distinguish between different processes.