### PR TITLE
Updated parsing of hex colors

### DIFF
--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -305,7 +305,7 @@ ruleAttribute = asum
         hc <- hexColor
         case hexToRGB hc of
             Just rgb  -> return rgb
-            Nothing -> fail $ "Color could not be parsed to RGB"
+            Nothing -> fail $ "Color code " ++ show hc ++ " could not be parsed to RGB"
 
 -- | Parse RuleInfo
 protoRuleInfo :: Parser ProtoRuleEInfo

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -255,7 +255,9 @@ indexedIdentifier = do
 
 -- | Parse a hex RGB color code
 hexColor :: Parser String
-hexColor = optional (symbol "'") *> optional (symbol "#") *> identifier <* optional (symbol "'")
+hexColor = singleQuoted hexCode <|> hexCode
+  where
+    hexCode = optional (symbol "#") *> many1 hexDigit
 
 -- | Parse a logical variable with the given sorts allowed.
 sortedLVar :: [LSort] -> Parser LVar


### PR DESCRIPTION
Previously the parser allowed mismatched quotes, and incorrectly required an identifier instead of hex digits.