### PR TITLE
Add the ability to specify a global default heuristic in a file

### DIFF
--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -75,6 +75,8 @@ module Theory (
   , addRestrictionDiff
   , addLemmaDiff
   , addDiffLemma
+  , addHeuristic
+  , addDiffHeuristic
   , removeLemma
   , removeLemmaDiff
   , removeDiffLemma
@@ -400,7 +402,7 @@ data LemmaAttribute =
        | HideLemma String
        | LHSLemma
        | RHSLemma
-       | LemmaHeuristic String
+       | LemmaHeuristic [GoalRanking]
 --        | BothLemma
        deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
@@ -555,6 +557,7 @@ data DiffTheoryItem r r2 p p2 =
 -- and the lemmas that
 data Theory sig c r p = Theory {
          _thyName      :: String
+       , _thyHeuristic :: [GoalRanking]
        , _thySignature :: sig
        , _thyCache     :: c
        , _thyItems     :: [TheoryItem r p]
@@ -567,6 +570,7 @@ $(mkLabels [''Theory])
 -- | A diff theory contains a set of rewriting rules with diff modeling two instances
 data DiffTheory sig c r r2 p p2 = DiffTheory {
          _diffThyName           :: String
+       , _diffThyHeuristic      :: [GoalRanking]
        , _diffThySignature      :: sig
        , _diffThyCacheLeft      :: c
        , _diffThyCacheRight     :: c
@@ -743,7 +747,16 @@ addDiffLemma :: DiffLemma p -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory s
 addDiffLemma l thy = do
     guard (isNothing $ lookupDiffLemma (L.get lDiffName l) thy)
     return $ modify diffThyItems (++ [DiffLemmaItem l]) thy
-    
+
+-- | Add a new default heuristic. Fails if a heuristic is already defined.
+addHeuristic :: [GoalRanking] -> Theory sig c r p -> Maybe (Theory sig c r p)
+addHeuristic h (Theory n [] sig c i) = Just (Theory n h sig c i)
+addHeuristic _ _ = Nothing
+
+addDiffHeuristic :: [GoalRanking] -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
+addDiffHeuristic h (DiffTheory n [] sig cl cr dcl dcr i) = Just (DiffTheory n h sig cl cr dcl dcr i)
+addDiffHeuristic _ _ = Nothing
+
 -- | Remove a lemma by name. Fails, if the lemma does not exist.
 removeLemma :: String -> Theory sig c r p -> Maybe (Theory sig c r p)
 removeLemma lemmaName thy = do
@@ -829,11 +842,11 @@ addFormalCommentDiff c = modify diffThyItems (++ [DiffTextItem c])
 
 -- | Default theory
 defaultOpenTheory :: Bool -> OpenTheory
-defaultOpenTheory flag = Theory "default" (emptySignaturePure flag) [] []
+defaultOpenTheory flag = Theory "default" [] (emptySignaturePure flag) [] []
 
 -- | Default diff theory
 defaultOpenDiffTheory :: Bool -> OpenDiffTheory
-defaultOpenDiffTheory flag = DiffTheory "default" (emptySignaturePure flag) [] [] [] [] []
+defaultOpenDiffTheory flag = DiffTheory "default" [] (emptySignaturePure flag) [] [] [] [] []
 
 -- Add the default Diff lemma to an Open Diff Theory
 addDefaultDiffLemma:: OpenDiffTheory -> OpenDiffTheory
@@ -854,15 +867,15 @@ addIntrRuleLabels thy =
 -- | Open a theory by dropping the closed world assumption and values whose
 -- soundness depends on it.
 openTheory :: ClosedTheory -> OpenTheory
-openTheory  (Theory n sig c items) =
-    Theory n (toSignaturePure sig) (openRuleCache c)
+openTheory  (Theory n h sig c items) =
+    Theory n h (toSignaturePure sig) (openRuleCache c)
       (map (mapTheoryItem openProtoRule incrementalToSkeletonProof) items)
 
 -- | Open a theory by dropping the closed world assumption and values whose
 -- soundness depends on it.
 openDiffTheory :: ClosedDiffTheory -> OpenDiffTheory
-openDiffTheory  (DiffTheory n sig c1 c2 c3 c4 items) =
-    DiffTheory n (toSignaturePure sig) (openRuleCache c1) (openRuleCache c2) (openRuleCache c3) (openRuleCache c4)
+openDiffTheory  (DiffTheory n h sig c1 c2 c3 c4 items) =
+    DiffTheory n h (toSignaturePure sig) (openRuleCache c1) (openRuleCache c2) (openRuleCache c3) (openRuleCache c4)
       (map (mapDiffTheoryItem id (\(x, y) -> (x, (openProtoRule y))) (\(DiffLemma s a p) -> (DiffLemma s a (incrementalToSkeletonDiffProof p))) (\(x, Lemma a b c d e) -> (x, Lemma a b c d (incrementalToSkeletonProof e)))) items)
 
       
@@ -1001,7 +1014,7 @@ getProofContext l thy = ProofContext
     kind
     ( L.get (cases . thyCache)                 thy)
     inductionHint
-    (headMay [Heuristic (charToGoalRanking <$> grs) | LemmaHeuristic grs <- L.get lAttributes l])
+    specifiedHeuristic
     (toSystemTraceQuantifier $ L.get lTraceQuantifier l)
     (L.get lName l)
     ([ h | HideLemma h <- L.get lAttributes l])
@@ -1016,6 +1029,16 @@ getProofContext l thy = ProofContext
       | any (`elem` [SourceLemma, InvariantLemma]) (L.get lAttributes l) = UseInduction
       | otherwise                                                        = AvoidInduction
 
+    -- Heuristic specified for the lemma > globally specified heuristic > default heuristic
+    specifiedHeuristic = case lattr of
+        Just lh -> Just lh
+        Nothing  -> case L.get thyHeuristic thy of
+                    [] -> Nothing
+                    gh -> Just (Heuristic gh)
+      where
+        lattr = (headMay [Heuristic gr
+                    | LemmaHeuristic gr <- L.get lAttributes l])
+
 -- | Get the proof context for a lemma of the closed theory.
 getProofContextDiff :: Side -> Lemma a -> ClosedDiffTheory -> ProofContext
 getProofContextDiff s l thy = case s of
@@ -1026,7 +1049,7 @@ getProofContextDiff s l thy = case s of
             kind
             ( L.get (cases . diffThyCacheLeft)                 thy)
             inductionHint
-            (headMay [Heuristic (charToGoalRanking <$> grs) | LemmaHeuristic grs <- L.get lAttributes l])
+            specifiedHeuristic
             (toSystemTraceQuantifier $ L.get lTraceQuantifier l)
             (L.get lName l)
             ([ h | HideLemma h <- L.get lAttributes l])
@@ -1040,7 +1063,7 @@ getProofContextDiff s l thy = case s of
             kind
             ( L.get (cases . diffThyCacheRight)              thy)
             inductionHint
-            (headMay [Heuristic (charToGoalRanking <$> grs) | LemmaHeuristic grs <- L.get lAttributes l])
+            specifiedHeuristic
             (toSystemTraceQuantifier $ L.get lTraceQuantifier l)
             (L.get lName l)
             ([ h | HideLemma h <- L.get lAttributes l])
@@ -1054,6 +1077,15 @@ getProofContextDiff s l thy = case s of
     inductionHint
       | any (`elem` [SourceLemma, InvariantLemma]) (L.get lAttributes l) = UseInduction
       | otherwise                                                        = AvoidInduction
+    -- Heuristic specified for the lemma > globally specified heuristic > default heuristic
+    specifiedHeuristic = case lattr of
+        Just lh -> Just lh
+        Nothing  -> case L.get diffThyHeuristic thy of
+                    [] -> Nothing
+                    gh -> Just (Heuristic gh)
+      where
+        lattr = (headMay [Heuristic gr
+                    | LemmaHeuristic gr <- L.get lAttributes l])
 
 -- | Get the proof context for a diff lemma of the closed theory.
 getDiffProofContext :: DiffLemma a -> ClosedDiffTheory -> DiffProofContext
@@ -1072,7 +1104,7 @@ getDiffProofContext l thy = DiffProofContext (proofContext LHS) (proofContext RH
             RefinedSource
             ( L.get (crcRefinedSources . diffThyDiffCacheLeft)              thy)
             AvoidInduction
-            (headMay [Heuristic (charToGoalRankingDiff <$> grs) | LemmaHeuristic grs <- L.get lDiffAttributes l])
+            specifiedHeuristic
             ExistsNoTrace
             ( L.get lDiffName l )
             ([ h | HideLemma h <- L.get lDiffAttributes l])
@@ -1086,13 +1118,22 @@ getDiffProofContext l thy = DiffProofContext (proofContext LHS) (proofContext RH
             RefinedSource
             ( L.get (crcRefinedSources . diffThyDiffCacheRight)              thy)
             AvoidInduction
-            (headMay [Heuristic (charToGoalRankingDiff <$> grs) | LemmaHeuristic grs <- L.get lDiffAttributes l])
+            specifiedHeuristic
             ExistsNoTrace
             ( L.get lDiffName l )
             ([ h | HideLemma h <- L.get lDiffAttributes l])
             True
             (all isSubtermRule  $ filter isDestrRule $ intruderRules $ L.get (crcRules . diffThyCacheRight) thy)
             (any isConstantRule $ filter isDestrRule $ intruderRules $ L.get (crcRules . diffThyCacheRight) thy)
+
+    specifiedHeuristic = case lattr of
+        Just lh -> Just lh
+        Nothing  -> case L.get diffThyHeuristic thy of
+                    [] -> Nothing
+                    gh -> Just (Heuristic gh)
+      where
+        lattr = (headMay [Heuristic gr
+                    | LemmaHeuristic gr <- L.get lDiffAttributes l])
 
 -- | The facts with injective instances in this theory
 getInjectiveFactInsts :: ClosedTheory -> S.Set FactTag
@@ -1176,8 +1217,9 @@ closeDiffTheory maudePath thy0 = do
 -- the given theory.
 closeDiffTheoryWithMaude :: SignatureWithMaude -> OpenDiffTheory -> ClosedDiffTheory
 closeDiffTheoryWithMaude sig thy0 = do
-    proveDiffTheory (const True) (const True) checkProof checkDiffProof (DiffTheory (L.get diffThyName thy0) sig cacheLeft cacheRight diffCacheLeft diffCacheRight items)
+    proveDiffTheory (const True) (const True) checkProof checkDiffProof (DiffTheory (L.get diffThyName thy0) h sig cacheLeft cacheRight diffCacheLeft diffCacheRight items)
   where
+    h              = L.get diffThyHeuristic thy0
     diffCacheLeft  = closeRuleCache restrictionsLeft  typAsms sig leftClosedRules  (L.get diffThyDiffCacheLeft  thy0) True
     diffCacheRight = closeRuleCache restrictionsRight typAsms sig rightClosedRules (L.get diffThyDiffCacheRight thy0) True
     cacheLeft  = closeRuleCache restrictionsLeft  typAsms sig leftClosedRules  (L.get diffThyCacheLeft  thy0) False
@@ -1218,9 +1260,9 @@ closeDiffTheoryWithMaude sig thy0 = do
 
     -- extract protocol rules
     leftClosedRules  :: [ClosedProtoRule]
-    leftClosedRules  = leftTheoryRules  (DiffTheory errClose errClose errClose errClose errClose errClose items)
+    leftClosedRules  = leftTheoryRules  (DiffTheory errClose errClose errClose errClose errClose errClose errClose items)
     rightClosedRules :: [ClosedProtoRule]
-    rightClosedRules = rightTheoryRules (DiffTheory errClose errClose errClose errClose errClose errClose items)
+    rightClosedRules = rightTheoryRules (DiffTheory errClose errClose errClose errClose errClose errClose errClose items)
     errClose  = error "closeDiffTheory"
 
     addSolvingLoopBreakers = useAutoLoopBreakersAC
@@ -1243,8 +1285,9 @@ closeDiffTheoryWithMaude sig thy0 = do
 closeTheoryWithMaude :: SignatureWithMaude -> OpenTheory -> ClosedTheory
 closeTheoryWithMaude sig thy0 = do
       proveTheory (const True) checkProof
-    $ Theory (L.get thyName thy0) sig cache items
+    $ Theory (L.get thyName thy0) h sig cache items
   where
+    h          = L.get thyHeuristic thy0
     cache      = closeRuleCache restrictions typAsms sig rules (L.get thyCache thy0) False
     checkProof = checkAndExtendProver (sorryProver Nothing)
 
@@ -1272,7 +1315,7 @@ closeTheoryWithMaude sig thy0 = do
 
     -- extract protocol rules
     rules :: [ClosedProtoRule]
-    rules = theoryRules (Theory errClose errClose errClose items)
+    rules = theoryRules (Theory errClose errClose errClose errClose items)
     errClose = error "closeTheory"
 
     addSolvingLoopBreakers = useAutoLoopBreakersAC
@@ -1598,6 +1641,7 @@ prettyTheory ppSig ppCache ppRule ppPrf thy = vsep $
     [ kwTheoryHeader $ text $ L.get thyName thy
     , lineComment_ "Function signature and definition of the equational theory E"
     , ppSig $ L.get thySignature thy
+    , if thyH == [] then text "" else text "heuristic: " <> text (prettyGoalRankings thyH)
     , ppCache $ L.get thyCache thy
     ] ++
     parMap rdeepseq ppItem (L.get thyItems thy) ++
@@ -1605,6 +1649,7 @@ prettyTheory ppSig ppCache ppRule ppPrf thy = vsep $
   where
     ppItem = foldTheoryItem
         ppRule prettyRestriction (prettyLemma ppPrf) (uncurry prettyFormalComment)
+    thyH = L.get thyHeuristic thy
 
 -- | Pretty print a diff theory.
 prettyDiffTheory :: HighlightDocument d
@@ -1614,6 +1659,7 @@ prettyDiffTheory ppSig ppCache ppRule ppDiffPrf ppPrf thy = vsep $
     [ kwTheoryHeader $ text $ L.get diffThyName thy
     , lineComment_ "Function signature and definition of the equational theory E"
     , ppSig $ L.get diffThySignature thy
+    , if thyH == [] then text "" else text "heuristic: " <> text (prettyGoalRankings thyH)
     , ppCache $ L.get diffThyCacheLeft thy
     , ppCache $ L.get diffThyCacheRight thy
     , ppCache $ L.get diffThyDiffCacheLeft thy
@@ -1624,6 +1670,7 @@ prettyDiffTheory ppSig ppCache ppRule ppDiffPrf ppPrf thy = vsep $
   where
     ppItem = foldDiffTheoryItem
         prettyDiffRule ppRule (prettyDiffLemma ppDiffPrf) (prettyEitherLemma ppPrf) prettyEitherRestriction (uncurry prettyFormalComment)
+    thyH = L.get diffThyHeuristic thy
 
 -- | Pretty print the lemma name together with its attributes.
 prettyLemmaName :: HighlightDocument d => Lemma p -> d
@@ -1636,7 +1683,7 @@ prettyLemmaName l = case L.get lAttributes l of
     prettyLemmaAttribute ReuseLemma         = text "reuse"
     prettyLemmaAttribute InvariantLemma     = text "use_induction"
     prettyLemmaAttribute (HideLemma s)      = text ("hide_lemma=" ++ s)
-    prettyLemmaAttribute (LemmaHeuristic h) = text ("heuristic=" ++ h)
+    prettyLemmaAttribute (LemmaHeuristic h) = text ("heuristic=" ++ (prettyGoalRankings h))
     prettyLemmaAttribute LHSLemma           = text "left"
     prettyLemmaAttribute RHSLemma           = text "right"
 --     prettyLemmaAttribute BothLemma      = text "both"

--- a/lib/theory/src/Theory/Constraint/Solver/Heuristics.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Heuristics.hs
@@ -29,6 +29,8 @@ module Theory.Constraint.Solver.Heuristics (
   , listGoalRankingsDiff
 
   , goalRankingName
+  , prettyGoalRankings
+  , prettyGoalRanking
 ) where
 
 import           GHC.Generics       (Generic)
@@ -36,6 +38,7 @@ import           Data.Binary
 import           Control.DeepSeq
 import           Data.Maybe         (fromMaybe)
 import qualified Data.Map as M
+import           Data.List          (find)
 
 import           Theory.Text.Pretty
 
@@ -123,3 +126,15 @@ goalRankingName ranking =
         InjRanking useLoopBreakers    -> "heuristics adapted to stateful injective protocols" ++ loopStatus useLoopBreakers
    where
      loopStatus b = " (loop breakers " ++ (if b then "allowed" else "delayed") ++ ")"
+
+prettyGoalRankings :: [GoalRanking] -> String
+prettyGoalRankings rs = map prettyGoalRanking rs
+
+prettyGoalRanking :: GoalRanking -> Char
+prettyGoalRanking ranking = case find (\(_,v) -> v == ranking) $ combinedIdentifiers of
+    Just (k,_) -> k
+    Nothing    -> error "Goal ranking does not have a defined identifier"
+  where
+    -- Note because find works left first this will look at non-diff identifiers first. Thus,
+    -- this assumes the diff rankings don't use a different character for the same goal ranking.
+    combinedIdentifiers = (M.toList goalRankingIdentifiers) ++ (M.toList goalRankingIdentifiersDiff)


### PR DESCRIPTION
This change allows files to contain a line
```
heuristic: <heuristicchoice>
```
to specify a default heuristic for all lemmas in the file. Heuristic choices that are specified for a particular lemma are still respected (they take priority over the lemma for the file)

This can be used by SAPIC, for example, to set a default heuristic in all generated files.

In addition this PR improves the way heuristics are parsed when specified as a lemma attribute; tamarin will now immediately output an error when the file contains an invalid heuristic choice in the lemma attribute.

(PR to the Manual to follow)