### PR TITLE
add --stop-on-trace=seqdfs, a true dfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,19 @@ case-studies/%_analyzed-oracle-chaum.spthy: examples/%.spthy $(TAMARIN)
 	mv $<.tmp $@
 	\rm -f $<.out
 
+# individual case studies, special case with sequential dfs
+case-studies/%_analyzed-seqdfs.spthy: examples/%.spthy $(TAMARIN)
+	mkdir -p case-studies/regression/trace
+	# Use -N3, as the fourth core is used by the OS and the console
+	$(TAMARIN) $< --prove --stop-on-trace=seqdfs +RTS -N3 -RTS -o$<.tmp >$<.out
+	# We only produce the target after the run, otherwise aborted
+	# runs already 'finish' the case.
+	printf "\n/* Output\n" >>$<.tmp
+	cat $<.out >>$<.tmp
+	echo "*/" >>$<.tmp
+	mv $<.tmp $@
+	\rm -f $<.out
+
 
 ## Observational Equivalence
 ############################
@@ -337,8 +350,12 @@ REGRESSION_CASE_STUDIES=issue216.spthy issue193.spthy
 
 REGRESSION_TARGETS=$(subst .spthy,_analyzed.spthy,$(addprefix case-studies/regression/trace/,$(REGRESSION_CASE_STUDIES)))
 
+SEQDFS_CASE_STUDIES=seqdfsneeded.spthy
+SEQDFS_TARGETS=$(subst .spthy,_analyzed-seqdfs.spthy,$(addprefix case-studies/regression/trace/,$(SEQDFS_CASE_STUDIES)))
+
+
 # case studies
-regression-case-studies:	$(REGRESSION_TARGETS)
+regression-case-studies:	$(REGRESSION_TARGETS) $(SEQDFS_TARGETS)
 	grep "verified\|falsified\|processing time" case-studies/regression/trace/*.spthy
 
 ## SAPIC

--- a/case-studies-regression/regression/trace/seqdfsneeded_analyzed-seqdfs.spthy
+++ b/case-studies-regression/regression/trace/seqdfsneeded_analyzed-seqdfs.spthy
@@ -1,0 +1,167 @@
+theory seqdfsneeded begin
+
+// Function signature and definition of the equational theory E
+
+functions: fst/1, h/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+
+
+lemma slow:
+  exists-trace "∃ #t. End( ) @ #t"
+/*
+guarded formula characterizing all satisfying traces:
+"∃ #t. (End( ) @ #t)"
+*/
+simplify
+solve( Foo( h(h(h(~x))) ) ▶₀ #t )
+  case AAA_hash
+  solve( Foo( h(h(~x)) ) ▶₀ #vr )
+    case AAA_hash
+    solve( Foo( h(~x) ) ▶₀ #vr.1 )
+      case AAA_hash
+      solve( Foo( ~x ) ▶₀ #vr.2 )
+        case step_2
+        solve( Foo( h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>)))))))))))))))))
+               ) ▶₀ #vr.4 )
+          case AAA_hash
+          solve( Foo( h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))))))))))
+                 ) ▶₀ #vr.5 )
+            case AAA_hash
+            solve( Foo( h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>)))))))))))))))
+                   ) ▶₀ #vr.6 )
+              case AAA_hash
+              solve( Foo( h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))))))))
+                     ) ▶₀ #vr.7 )
+                case AAA_hash
+                solve( Foo( h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))))))) ) ▶₀ #vr.8 )
+                  case AAA_hash
+                  solve( Foo( h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>)))))))))))) ) ▶₀ #vr.9 )
+                    case AAA_hash
+                    solve( Foo( h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))))) ) ▶₀ #vr.10 )
+                      case AAA_hash
+                      solve( Foo( h(h(h(h(h(h(h(h(h(h(<~x, ~x>)))))))))) ) ▶₀ #vr.11 )
+                        case AAA_hash
+                        solve( Foo( h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))) ) ▶₀ #vr.12 )
+                          case AAA_hash
+                          solve( Foo( h(h(h(h(h(h(h(h(<~x, ~x>)))))))) ) ▶₀ #vr.13 )
+                            case AAA_hash
+                            solve( Foo( h(h(h(h(h(h(h(<~x, ~x>))))))) ) ▶₀ #vr.14 )
+                              case AAA_hash
+                              solve( Foo( h(h(h(h(h(h(<~x, ~x>)))))) ) ▶₀ #vr.15 )
+                                case AAA_hash
+                                solve( Foo( h(h(h(h(h(<~x, ~x>))))) ) ▶₀ #vr.16 )
+                                  case AAA_hash
+                                  solve( Foo( h(h(h(h(<~x, ~x>)))) ) ▶₀ #vr.17 )
+                                    case AAA_hash
+                                    solve( Foo( h(h(h(<~x, ~x>))) ) ▶₀ #vr.18 )
+                                      case AAA_hash
+                                      solve( Foo( h(h(<~x, ~x>)) ) ▶₀ #vr.19 )
+                                        case AAA_hash
+                                        solve( Foo( h(<~x, ~x>) ) ▶₀ #vr.20 )
+                                          case AAA_hash
+                                          solve( Foo( <~x, ~x> ) ▶₀ #vr.21 )
+                                            case gen
+                                            SOLVED // trace found
+                                          qed
+                                        qed
+                                      qed
+                                    qed
+                                  qed
+                                qed
+                              qed
+                            qed
+                          qed
+                        qed
+                      qed
+                    qed
+                  qed
+                qed
+              qed
+            qed
+          qed
+        qed
+      qed
+    qed
+  qed
+qed
+
+rule (modulo E) finish:
+   [ Foo( h(h(h(~x))) ) ] --[ End( ) ]-> [ End( ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) AAA_hash:
+   [ Foo( x ) ] --> [ Foo( h(x) ) ]
+
+  // loop breaker: [0]
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) step_2:
+   [ Foo( h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>)))))))))))))))))) ) ]
+  -->
+   [ Foo( ~x ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) gen:
+   [ In( ~x ) ] --> [ Foo( <~x, ~x> ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) decoy:
+   [ Fr( x ), Bar( 'a' )[-, no_precomp] ] --> [ Foo( h(x) ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) amplify_decoy_case1:
+   [ Bar( y ), In( 'a' ), In( x ) ] --> [ Bar( x ) ]
+
+  // loop breaker: [0]
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) amplify_decoy_case2:
+   [ Bar( y ), In( 'b' ), In( x ) ] --> [ Bar( x ) ]
+
+  // loop breaker: [0]
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) amplify_decoy_case3:
+   [ Bar( y ), In( 'c' ), In( x ) ] --> [ Bar( x ) ]
+
+  // loop breaker: [0]
+  /* has exactly the trivial AC variant */
+
+/* All well-formedness checks were successful. */
+
+end
+/* Output
+maude tool: 'maude'
+ checking version: 2.7.1. OK.
+ checking installation: OK.
+SAPIC tool: 'sapic'
+Checking availablity ... OK.
+
+
+analyzing: examples/regression/trace/seqdfsneeded.spthy
+
+------------------------------------------------------------------------------
+analyzed: examples/regression/trace/seqdfsneeded.spthy
+
+  output:          examples/regression/trace/seqdfsneeded.spthy.tmp
+  processing time: 0.097877711s
+  slow (exists-trace): verified (24 steps)
+
+------------------------------------------------------------------------------
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/trace/seqdfsneeded.spthy
+
+  output:          examples/regression/trace/seqdfsneeded.spthy.tmp
+  processing time: 0.097877711s
+  slow (exists-trace): verified (24 steps)
+
+==============================================================================
+*/

--- a/examples/regression/trace/seqdfsneeded.spthy
+++ b/examples/regression/trace/seqdfsneeded.spthy
@@ -1,0 +1,40 @@
+theory seqdfsneeded begin
+functions: h/1
+
+lemma slow: exists-trace "Ex #t. End()@t"
+// End is created by Foo(h(h(~x)))
+rule finish:
+[ Foo(h(h(h(~x)))) ] --[ End() ]-> [ End() ]
+// to hash Foo(x):
+rule AAA_hash:
+[ Foo(x) ] --> [ Foo(h(x)) ]
+// (this rule is always the first case because of AAA_)
+
+// So at depth ~4 we get to Foo(~x)
+// 2 sources:
+// a high depth Foo(<~x, ~x>)
+rule step_2:
+let
+h17 = h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))))))))))))
+in
+[ Foo(h17) ] --> [ Foo(~x) ]
+rule gen:
+[ In(~x) ] --> [ Foo(<~x, ~x>) ]
+// Or Bar('a')
+rule decoy:
+[ Fr(x), Bar('a')[no_precomp,-] ] --> [ Foo(h(x)) ]
+// and there are 3 sources of Bar(x) per depth level
+rule amplify_decoy_case1:
+[ Bar(y), In('a'), In(x) ] --> [ Bar(x) ]
+rule amplify_decoy_case2:
+[ Bar(y), In('b'), In(x) ] --> [ Bar(x) ]
+rule amplify_decoy_case3:
+[ Bar(y), In('c'), In(x) ] --> [ Bar(x) ]
+
+/*
+so iterative deepening (or bfs) will explore 3^{current depth} before
+stopping on the trace found in rule gen
+whereas sequential dfs finds it just fine.
+*/
+
+end

--- a/lib/theory/src/Theory/Proof.hs
+++ b/lib/theory/src/Theory/Proof.hs
@@ -732,7 +732,7 @@ contradictionDiffProver = DiffProver $ \ctxt d sys prf ->
 -- Automatic Prover's
 ------------------------------------------------------------------------------
 
-data SolutionExtractor = CutDFS | CutBFS | CutNothing
+data SolutionExtractor = CutSingleThreadDFS | CutDFS | CutBFS | CutNothing
     deriving( Eq, Ord, Show, Read, Generic, NFData, Binary )
 
 data AutoProver = AutoProver
@@ -747,6 +747,7 @@ runAutoProver (AutoProver defaultHeuristic bound cut) =
     mapProverProof cutSolved $ maybe id boundProver bound autoProver
   where
     cutSolved = case cut of
+      CutSingleThreadDFS     -> cutOnSolvedSingleThreadDFS
       CutDFS     -> cutOnSolvedDFS
       CutBFS     -> cutOnSolvedBFS
       CutNothing -> id
@@ -771,6 +772,7 @@ runAutoDiffProver (AutoProver defaultHeuristic bound cut) =
     mapDiffProverDiffProof cutSolved $ maybe id boundProver bound autoProver
   where
     cutSolved = case cut of
+      CutSingleThreadDFS -> cutOnSolvedSingleThreadDFSDiff
       CutDFS     -> cutOnSolvedDFSDiff
       CutBFS     -> cutOnSolvedBFSDiff
       CutNothing -> id
@@ -804,9 +806,69 @@ instance Semigroup IterDeepRes where
 instance Monoid IterDeepRes where
     mempty = NoSolution
 
+-- | @cutOnSolvedSingleThreadDFS prf@ removes all other cases if an attack is
+-- found. The attack search is performed using a single-thread DFS traversal.
+--
+-- FIXME: Note that this function may use a lot of space, as it holds onto the
+-- whole proof tree.
+cutOnSolvedSingleThreadDFS :: Proof (Maybe a) -> Proof (Maybe a)
+cutOnSolvedSingleThreadDFS prf0 =
+    go $ insertPaths prf0
+  where
+    go prf = case findSolved prf of
+        NoSolution      -> prf0
+        Solution path   -> extractSolved path prf0
+        MaybeNoSolution -> error "Theory.Constraint.cutOnSolvedSingleThreadDFS: impossible, MaybeNoSolution in single thread dfs"
+      where
+        findSolved node = case node of
+              -- do not search in nodes that are not annotated
+              LNode (ProofStep _      (Nothing, _   )) _  -> NoSolution
+              LNode (ProofStep Solved (Just _ , path)) _  -> Solution path
+              LNode (ProofStep _      (Just _ , _   )) cs ->
+                  foldMap findSolved cs
+
+    extractSolved []         p               = p
+    extractSolved (label:ps) (LNode pstep m) = case M.lookup label m of
+        Just subprf ->
+          LNode pstep (M.fromList [(label, extractSolved ps subprf)])
+        Nothing     ->
+          error "Theory.Constraint.cutOnSolvedSingleThreadDFS: impossible, extractSolved failed, invalid path"
+
+-- | @cutOnSolvedSingleThreadDFSDiffDFS prf@ removes all other cases if an
+-- attack is found. The attack search is performed using a single-thread DFS
+-- traversal.
+--
+-- FIXME: Note that this function may use a lot of space, as it holds onto the
+-- whole proof tree.
+cutOnSolvedSingleThreadDFSDiff :: DiffProof (Maybe a) -> DiffProof (Maybe a)
+cutOnSolvedSingleThreadDFSDiff prf0 =
+    go $ insertPathsDiff prf0
+  where
+    go prf = case findSolved prf of
+        NoSolution      -> prf0
+        Solution path   -> extractSolved path prf0
+        MaybeNoSolution -> error "Theory.Constraint.cutOnSolvedSingleThreadDFSDiff: impossible, MaybeNoSolution in single thread dfs"
+      where
+        findSolved node = case node of
+              -- do not search in nodes that are not annotated
+              LNode (DiffProofStep _      (Nothing, _   )) _  -> NoSolution
+              LNode (DiffProofStep DiffAttack (Just _ , path)) _  -> Solution path
+              LNode (DiffProofStep _      (Just _ , _   )) cs ->
+                  foldMap findSolved cs
+
+    extractSolved []         p               = p
+    extractSolved (label:ps) (LNode pstep m) = case M.lookup label m of
+        Just subprf ->
+          LNode pstep (M.fromList [(label, extractSolved ps subprf)])
+        Nothing     ->
+          error "Theory.Constraint.cutOnSolvedSingleThreadDFSDiff: impossible, extractSolved failed, invalid path"
+
 -- | @cutOnSolvedDFS prf@ removes all other cases if an attack is found. The
 -- attack search is performed using a parallel DFS traversal with iterative
 -- deepening.
+-- Note that when an attack is found, other, already started threads will not be
+-- stopped. They will first run to completion, and only afterwards will the proof
+-- complete. If this is undesirable bahavior, use cutOnSolvedSingleThreadDFS.
 --
 -- FIXME: Note that this function may use a lot of space, as it holds onto the
 -- whole proof tree.

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -83,7 +83,7 @@ theoryLoadFlags =
   [ flagOpt "" ["prove"] (updateArg "prove") "LEMMAPREFIX"
       "Attempt to prove a lemma "
 
-  , flagOpt "dfs" ["stop-on-trace"] (updateArg "stopOnTrace") "SEQDFS|DFS|BFS|NONE"
+  , flagOpt "dfs" ["stop-on-trace"] (updateArg "stopOnTrace") "DFS|BFS|SEQDFS|NONE"
       "How to search for traces (default DFS)"
 
   , flagOpt "5" ["bound", "b"] (updateArg "bound") "INT"
@@ -348,12 +348,12 @@ constructAutoProver as =
     setOracleName r = r
 
     stopOnTrace = case (map toLower) <$> findArg "stopOnTrace" as of
-      Nothing     -> CutDFS
-      Just "seqdfs"  -> CutSingleThreadDFS
-      Just "dfs"  -> CutDFS
-      Just "none" -> CutNothing
-      Just "bfs"  -> CutBFS
-      Just other  -> error $ "unknown stop-on-trace method: " ++ other
+      Nothing       -> CutDFS
+      Just "dfs"    -> CutDFS
+      Just "none"   -> CutNothing
+      Just "bfs"    -> CutBFS
+      Just "seqdfs" -> CutSingleThreadDFS
+      Just other    -> error $ "unknown stop-on-trace method: " ++ other
 
 -- | Construct an 'AutoProver' from the given arguments (--bound,
 -- --stop-on-trace).
@@ -383,12 +383,12 @@ constructAutoDiffProver as =
     setOracleName r = r
 
     stopOnTrace = case (map toLower) <$> findArg "stopOnTrace" as of
-      Nothing     -> CutDFS
-      Just "dfs"  -> CutDFS
-      Just "seqdfs"  -> CutSingleThreadDFS
-      Just "none" -> CutNothing
-      Just "bfs"  -> CutBFS
-      Just other  -> error $ "unknown stop-on-trace method: " ++ other
+      Nothing       -> CutDFS
+      Just "dfs"    -> CutDFS
+      Just "none"   -> CutNothing
+      Just "bfs"    -> CutBFS
+      Just "seqdfs" -> CutSingleThreadDFS
+      Just other    -> error $ "unknown stop-on-trace method: " ++ other
 
 
 ------------------------------------------------------------------------------

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -83,7 +83,7 @@ theoryLoadFlags =
   [ flagOpt "" ["prove"] (updateArg "prove") "LEMMAPREFIX"
       "Attempt to prove a lemma "
 
-  , flagOpt "dfs" ["stop-on-trace"] (updateArg "stopOnTrace") "DFS|BFS|NONE"
+  , flagOpt "dfs" ["stop-on-trace"] (updateArg "stopOnTrace") "SEQDFS|DFS|BFS|NONE"
       "How to search for traces (default DFS)"
 
   , flagOpt "5" ["bound", "b"] (updateArg "bound") "INT"
@@ -349,6 +349,7 @@ constructAutoProver as =
 
     stopOnTrace = case (map toLower) <$> findArg "stopOnTrace" as of
       Nothing     -> CutDFS
+      Just "seqdfs"  -> CutSingleThreadDFS
       Just "dfs"  -> CutDFS
       Just "none" -> CutNothing
       Just "bfs"  -> CutBFS
@@ -384,6 +385,7 @@ constructAutoDiffProver as =
     stopOnTrace = case (map toLower) <$> findArg "stopOnTrace" as of
       Nothing     -> CutDFS
       Just "dfs"  -> CutDFS
+      Just "seqdfs"  -> CutSingleThreadDFS
       Just "none" -> CutNothing
       Just "bfs"  -> CutBFS
       Just other  -> error $ "unknown stop-on-trace method: " ++ other

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -724,6 +724,7 @@ getAutoProverR idx extractor bound =
     (proverName, extractorQualfier) = case extractor of
         CutNothing -> ("characterization", ["dfs"])
         CutDFS     -> ("the autoprover",   []     )
+        CutSingleThreadDFS -> ("the autoprover",   []     )
         CutBFS     -> ("the autoprover",   ["bfs"])
 
 -- | Run an autoprover on a given proof path.
@@ -747,6 +748,7 @@ getAutoProverDiffR idx extractor bound s =
     (proverName, extractorQualfier) = case extractor of
         CutNothing -> ("characterization", ["dfs"])
         CutDFS     -> ("the autoprover",   []     )
+        CutSingleThreadDFS -> ("the autoprover",   []     )
         CutBFS     -> ("the autoprover",   ["bfs"])
 
 -- | Run an autoprover on a given proof path.
@@ -770,6 +772,7 @@ getAutoDiffProverR idx extractor bound =
     (proverName, extractorQualfier) = case extractor of
         CutNothing -> ("characterization", ["dfs"])
         CutDFS     -> ("the autoprover",   []     )
+        CutSingleThreadDFS -> ("the autoprover",   []     )
         CutBFS     -> ("the autoprover",   ["bfs"])
 
 

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -722,10 +722,10 @@ getAutoProverR idx extractor bound =
         | otherwise = (Nothing,    []                               )
 
     (proverName, extractorQualfier) = case extractor of
-        CutNothing -> ("characterization", ["dfs"])
-        CutDFS     -> ("the autoprover",   []     )
-        CutSingleThreadDFS -> ("the autoprover",   []     )
-        CutBFS     -> ("the autoprover",   ["bfs"])
+        CutNothing         -> ("characterization", ["dfs"]   )
+        CutDFS             -> ("the autoprover",   []        )
+        CutBFS             -> ("the autoprover",   ["bfs"]   )
+        CutSingleThreadDFS -> ("the autoprover",   ["seqdfs"])
 
 -- | Run an autoprover on a given proof path.
 getAutoProverDiffR :: TheoryIdx
@@ -746,10 +746,10 @@ getAutoProverDiffR idx extractor bound s =
         | otherwise = (Nothing,    []                               )
 
     (proverName, extractorQualfier) = case extractor of
-        CutNothing -> ("characterization", ["dfs"])
-        CutDFS     -> ("the autoprover",   []     )
-        CutSingleThreadDFS -> ("the autoprover",   []     )
-        CutBFS     -> ("the autoprover",   ["bfs"])
+        CutNothing         -> ("characterization", ["dfs"]   )
+        CutDFS             -> ("the autoprover",   []        )
+        CutBFS             -> ("the autoprover",   ["bfs"]   )
+        CutSingleThreadDFS -> ("the autoprover",   ["seqdfs"])
 
 -- | Run an autoprover on a given proof path.
 getAutoDiffProverR :: TheoryIdx

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -593,10 +593,12 @@ mkYesodData "WebUI" [parseRoutes|
 
 instance PathPiece SolutionExtractor where
   toPathPiece CutNothing = "characterize"
+  toPathPiece CutSingleThreadDFS     = "dfs"
   toPathPiece CutDFS     = "idfs"
   toPathPiece CutBFS     = "bfs"
 
   fromPathPiece "characterize" = Just CutNothing
+  fromPathPiece "dfs"          = Just CutSingleThreadDFS
   fromPathPiece "idfs"         = Just CutDFS
   fromPathPiece "bfs"          = Just CutBFS
   fromPathPiece _              = Nothing

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -592,15 +592,15 @@ mkYesodData "WebUI" [parseRoutes|
 
 
 instance PathPiece SolutionExtractor where
-  toPathPiece CutNothing = "characterize"
-  toPathPiece CutSingleThreadDFS     = "dfs"
-  toPathPiece CutDFS     = "idfs"
-  toPathPiece CutBFS     = "bfs"
+  toPathPiece CutNothing         = "characterize"
+  toPathPiece CutDFS             = "idfs"
+  toPathPiece CutBFS             = "bfs"
+  toPathPiece CutSingleThreadDFS = "seqdfs"
 
   fromPathPiece "characterize" = Just CutNothing
-  fromPathPiece "dfs"          = Just CutSingleThreadDFS
   fromPathPiece "idfs"         = Just CutDFS
   fromPathPiece "bfs"          = Just CutBFS
+  fromPathPiece "seqdfs"       = Just CutSingleThreadDFS
   fromPathPiece _              = Nothing
 
 instance PathPiece Side where


### PR DESCRIPTION
--stop-on-trace=dfs is iterative deepening, which is slightly different.
When an attack is found, other threads are not stopped, which can be
expensive in some situations.
This true dfs is single-threaded, though.

As an illustration, here is a handcrafted theory which exhibits the difference in behavior:
```
theory foo begin
functions: h/1

lemma slow: exists-trace "Ex #t. End()@t"
// End is created by Foo(h(h(~x)))
rule finish:
[ Foo(h(h(h(~x)))) ] --[ End() ]-> [ End() ]
// to hash Foo(x):
rule AAA_hash:
[ Foo(x) ] --> [ Foo(h(x)) ]
// (this rule is always the first case because of AAA_)

// So at depth ~4 we get to Foo(~x)
// 2 sources:
// a high depth Foo(<~x, ~x>)
rule step_2:
let
h17 = h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(h(<~x, ~x>))))))))))))))))))
in
[ Foo(h17) ] --> [ Foo(~x) ]
rule gen:
[ In(~x) ] --> [ Foo(<~x, ~x>) ]
// Or Bar('a')
rule decoy:
[ Fr(x), Bar('a')[no_precomp,-] ] --> [ Foo(h(x)) ]
// and there are 3 sources of Bar(x) per depth level
rule amplify_decoy_case1:
[ Bar(y), In('a'), In(x) ] --> [ Bar(x) ]
rule amplify_decoy_case2:
[ Bar(y), In('b'), In(x) ] --> [ Bar(x) ]
rule amplify_decoy_case3:
[ Bar(y), In('c'), In(x) ] --> [ Bar(x) ]

/*
so iterative deepening (or bfs) will explore 3^{current depth} before
stopping on the trace found in rule gen
whereas sequential dfs finds it just fine.
*/

end
```
Proving this theory will take an unreasonable amount of time with `--stop-on-trace=dfs` or `bfs` but will
be instantly proved with `--stop-on-trace=seqdfs`.

cc @rsasse 