### PR TITLE
diff mode: conclude to attack as soon as the system is trivial

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -351,6 +351,11 @@ execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ sho
           | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
                                                                       (Just _, Just s, Just sys') -> if (isSolved s sys') && (fst (getMirrorDGandEvaluateRestrictions ctxt sys (isSolved s sys')) == TFalse)
                                                                                                         then return M.empty
+                                                                                                        else if (not (contradictorySystem (eitherProofContext ctxt s) sys')) && (isTrivial sys') && (fst (getMirrorDGandEvaluateRestrictions ctxt sys (isSolved s sys')) == TFalse) then
+                                                                                                        -- here the system is trivial, has no mirror and restrictions do not get in the way.
+                                                                                                        -- If we solve arbitrarily the last remaining trivial goals,
+                                                                                                        -- then there will be an attack.
+                                                                                                        return M.empty
                                                                                                         else Nothing
                                                                       (_ , _ , _)                 -> Nothing
           | otherwise                                         -> Nothing


### PR DESCRIPTION
If a system is not mirrorable and is trivial (for example contains
only !KU(x) goals with x unconstrained) then we know that if we solve
all these goals with public values then it will be an attack.
Unfortunately, this is only one of the cases left to explore, so waiting
for the proof to reach this attack is expensive. Instead we detect this
situation early and immediately conclude to an attack.

cc @rsasse 
(note this patch is different from my previous one. I had found a regression in the test suite. I attached the witness of the regression, just in case.)

In the attachement (I had to zip it because of github) you will find an example file test.spthy where an attack is found earlier with this patch. It is small enough that you can open it interactively.

[foo.zip](https://github.com/tamarin-prover/tamarin-prover/files/2779686/foo.zip)



