### PR TITLE
Fix hex colour parsing (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ features-case-studies:	$(FEATURES_CS_TARGETS)
 ## Regression (old issues)
 ##########################
 
-REGRESSION_CASE_STUDIES=issue216.spthy issue193.spthy
+REGRESSION_CASE_STUDIES=issue216.spthy issue193.spthy issue310.spthy
 
 REGRESSION_TARGETS=$(subst .spthy,_analyzed.spthy,$(addprefix case-studies/regression/trace/,$(REGRESSION_CASE_STUDIES)))
 

--- a/case-studies-regression/regression/trace/issue310_analyzed.spthy
+++ b/case-studies-regression/regression/trace/issue310_analyzed.spthy
@@ -1,0 +1,47 @@
+theory parseColors begin
+
+// Function signature and definition of the equational theory E
+
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+
+
+rule (modulo E) foo[color=#f5b7b1]:
+   [ Fr( ~x ) ] --[ Event( ~x ) ]-> [ Out( ~x ) ]
+
+  /* has exactly the trivial AC variant */
+
+/* All well-formedness checks were successful. */
+
+end
+/* Output
+maude tool: 'maude'
+ checking version: 2.7.1. OK.
+ checking installation: OK.
+SAPIC tool: 'sapic'
+Checking availablity ... OK.
+
+
+analyzing: examples/regression/trace/issue310.spthy
+
+------------------------------------------------------------------------------
+analyzed: examples/regression/trace/issue310.spthy
+
+  output:          examples/regression/trace/issue310.spthy.tmp
+  processing time: 0.0544301s
+
+
+------------------------------------------------------------------------------
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/trace/issue310.spthy
+
+  output:          examples/regression/trace/issue310.spthy.tmp
+  processing time: 0.0544301s
+
+
+==============================================================================
+*/

--- a/examples/regression/trace/issue310.spthy
+++ b/examples/regression/trace/issue310.spthy
@@ -1,0 +1,7 @@
+theory parseColors
+begin
+
+rule foo [color= #f5b7b1 /* some color with spaces around */ ]:
+  [ Fr(~x) ] --[ Event(~x) ]-> [ Out(~x) ]
+
+end

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -255,7 +255,7 @@ indexedIdentifier = do
 
 -- | Parse a hex RGB color code
 hexColor :: Parser String
-hexColor = singleQuoted hexCode <|> hexCode
+hexColor = T.lexeme spthy (singleQuoted hexCode <|> hexCode)
   where
     hexCode = optional (symbol "#") *> many1 hexDigit
 


### PR DESCRIPTION
For posterity, note that adding a new token parser requires manually calling lexeme with the language spec for it to obey the same whitespace rules as the rest of the spec, otherwise it'll not apply the regular whitespace consumption after the token parser is called.

(see http://hackage.haskell.org/package/parsec-3.1.9/docs/Text-Parsec-Token.html#v:lexeme )