### PR TITLE
Use binary-instances instead of binary-orphans

### DIFF
--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -65,7 +65,7 @@ import           Data.Ord            (comparing)
 import qualified Data.Text           as T
 import           Data.Time.LocalTime
 import qualified Data.Binary         as Bin
-import           Data.Binary.Orphans()
+import           Data.Binary.Instances()
 
 import           Control.DeepSeq
 import           GHC.Generics (Generic)

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -126,7 +126,7 @@ executable tamarin-prover
         HUnit
       , base
       , binary
-      , binary-orphans
+      , binary-instances
       , blaze-builder
       , blaze-html
       , bytestring


### PR DESCRIPTION
tamarin-prover currently doesn't build with binary-orphans 1.0+. Replacing it with binary-instances fixes this problem.

```
[12 of 18] Compiling Web.Types        ( src/Web/Types.hs, dist/build/tamarin-prover/tamarin-prover-tmp/Web/Types.dyn_o )

src/Web/Types.hs:172:24: error:
    • No instance for (Bin.Binary ZonedTime)
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Bin.Binary TheoryInfo)
    |
172 |   } deriving (Generic, Bin.Binary)
    |                        ^^^^^^^^^^

src/Web/Types.hs:185:24: error:
    • No instance for (Bin.Binary ZonedTime)
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Bin.Binary DiffTheoryInfo)
    |
185 |   } deriving (Generic, Bin.Binary)
    |                        ^^^^^^^^^^
```