### PR TITLE
Fix compatibility with Maude 3.0

### DIFF
--- a/lib/term/src/Term/Maude/Process.hs
+++ b/lib/term/src/Term/Maude/Process.hs
@@ -117,10 +117,10 @@ startMaudeProcess maudePath maudeSig = do
   where
     maudeCmd
       | dEBUGMAUDE = "sh -c \"tee /tmp/maude.input | "
-                     ++ maudePath ++ " -no-tecla -no-banner -no-wrap -batch "
+                     ++ maudePath ++ " -interactive -no-tecla -no-banner -no-wrap -batch "
                      ++ "\" | tee /tmp/maude.output"
       | otherwise  =
-          maudePath ++ " -no-tecla -no-banner -no-wrap -batch "
+          maudePath ++ " -interactive -no-tecla -no-banner -no-wrap -batch "
     executeMaudeCommand hin hout cmd =
         B.hPutStr hin cmd >> hFlush hin >> getToDelim hout >> return ()
     setupCmds = [ "set show command off .\n"


### PR DESCRIPTION
Maude 3.0 does not output the delimiter when stdin is not a tty, so that tamarin-prover will stuck at waiting for the delimiter to appear. Specifying `-interactive` explicitly fixes the issue and tamarin-prover works fine with the new Maude as far as I have tested.