### PR TITLE
Feature sapic \alpha_inev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,8 @@ feature-locations/licensing.spthy \
 feature-locations/SOC.spthy \
 feature-locations/OTP.spthy \
 feature-locations/AC_counter_with_attack.spthy \
-feature-locations/AC_sid_with_attack.spthy
+feature-locations/AC_sid_with_attack.spthy \
+feature-ass-immediate/test-all.spthy 
 
 # SLOW <=> processing time more than 10sec on Robert's current computer, but less than a day
 SAPIC_CASE_STUDIES_SLOW= encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy \

--- a/examples/sapic/ass_immediate.spthy
+++ b/examples/sapic/ass_immediate.spthy
@@ -1,0 +1,18 @@
+theory AssImmediateYes
+begin
+
+event A()
+
+// need ass_immediate
+
+// L+ & not L- (AllTraces, (True, False))
+lemma lplus_notlminus_all:
+  all-traces
+  "Ex x #i. K(x)@i"
+
+// not L+ & L- (ExistsTraces, (False, True))
+lemma notlplus_lminus_ex:
+  exists-trace
+  "Ex x #i. not K(x)@i"
+
+end

--- a/examples/sapic/feature-ass-immediate/no.spthy
+++ b/examples/sapic/feature-ass-immediate/no.spthy
@@ -1,0 +1,31 @@
+theory AssImmediateNo
+begin
+
+event A()
+
+// the following lemmas are not well formed and cannot be proven. They should
+// only ensure that ass_immediate is NOT added.
+
+// L+ & L- -- (AllTraces, (True, True))
+lemma lplus_lminus_all:
+  all-traces
+  "Ex #i. A()@i"
+
+// L+ & L- -- (ExistsTrace, (True, True))
+lemma lplus_lminus_ex:
+  exists-trace
+  "Ex #i. A()@i"
+
+// L+ & not L- (ExistsTrace, (True, False))
+lemma lplus_notlminus_ex:
+  exists-trace
+  "Ex x #i. K(x)@i"
+
+// not L+ & L- (AllTraces, (False, True))
+// will give warning because it is unguarded.
+lemma notlplus_lminus_all:
+  all-traces
+  "Ex x #i. not K(x)@i"
+  
+
+end

--- a/examples/sapic/feature-ass-immediate/test-all.spthy
+++ b/examples/sapic/feature-ass-immediate/test-all.spthy
@@ -1,0 +1,16 @@
+theory AssImmediateTestAll
+begin
+
+new x; out(x);
+event A();
+in(x,x); 
+event B()
+
+// ass_immediate guarantees that K(x) is between A() and B()
+
+// should verifiy and trigger addition of ass_immediate
+lemma intuitiveTest:
+  all-traces
+  "All #a #b . A()@a & B()@b ==> Ex #i x. K(x)@i & #a<#i & #i<#b"
+
+end

--- a/examples/sapic/feature-ass-immediate/test-exists.spthy
+++ b/examples/sapic/feature-ass-immediate/test-exists.spthy
@@ -1,0 +1,16 @@
+theory AssImmediateTestExists
+begin
+
+new x; out(x);
+event A();
+in(x,x); 
+event B()
+
+// ass_immediate guarantees that K(x) is between A() and B()
+
+// should falsify and trigger addition of ass_immediate
+lemma intuitiveTestPositive:
+  exists-trace
+  "Ex #a #b . A()@a & B()@b & (All #i x. K(x)@i ==> (#i<#a | #b<#i))"
+
+end

--- a/examples/sapic/feature-ass-immediate/yes.spthy
+++ b/examples/sapic/feature-ass-immediate/yes.spthy
@@ -1,0 +1,24 @@
+theory AssImmediateYes
+begin
+
+new x; out(x);
+event A();
+in(x,x); 
+event B()
+
+// ass_immediate guarantees that K(x) is between A() and B()
+
+// the following lemmas are not well formed and cannot be proven. They should
+// only ensure that ass_immediate is added.
+
+// L+ & not L- (AllTraces, (True, False))
+lemma lplus_notlminus_all:
+  all-traces
+  "Ex x #i. K(x)@i"
+
+// not L+ & L- (ExistsTraces, (False, True))
+lemma notlplus_lminus_ex:
+  exists-trace
+  "Ex x #i. not K(x)@i"
+
+end

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -60,12 +60,12 @@ type TransFComb t = ProcessCombinator
 -- | The basetranslation has three functions, one for translating the Null
 -- Process, one for actions (i.e. constructs with only one child process) and
 -- one for combinators (i.e., constructs with two child processes).
-baseTrans :: MonadThrow m =>
+baseTrans :: MonadThrow m => Bool ->
                           (TransFNull (m TranslationResultNull),
                            TransFAct (m TranslationResultAct),
                            TransFComb (m TranslationResultComb))
-baseTrans = (\ a p tx ->  return $ baseTransNull a p tx,
-             \ ac an p tx -> return $ baseTransAction ac an p tx,
+baseTrans needsAssImmediate = (\ a p tx ->  return $ baseTransNull a p tx,
+             \ ac an p tx -> return $ baseTransAction needsAssImmediate ac an p tx,
              \ comb an p tx -> return $ baseTransComb comb an p tx) -- I am sure there is nice notation for that.
 
 --  | Each part of the translation outputs a set of multiset rewrite rules,
@@ -73,8 +73,8 @@ baseTrans = (\ a p tx ->  return $ baseTransNull a p tx,
 baseTransNull :: TransFNull TranslationResultNull
 baseTransNull _ p tildex =  [([State LState p tildex ], [], [], [])]
 
-baseTransAction :: TransFAct TranslationResultAct
-baseTransAction ac an p tildex
+baseTransAction :: Bool -> TransFAct TranslationResultAct
+baseTransAction needsAssImmediate ac an p tildex
     |  Rep <- ac = ([
           ([def_state], [], [State PSemiState (p++[1]) tildex ], []),
           ([State PSemiState (p++[1]) tildex], [], [def_state' tildex], [])
@@ -89,7 +89,7 @@ baseTransAction ac an p tildex
           let tx' = freeset tc `union` freeset t `union` tildex in
           let ts  = fAppPair (tc,t) in
           ([
-          ([def_state, In ts], [ ChannelIn ts], [def_state' tx'], []),
+          ([def_state, In ts], if needsAssImmediate then [ ChannelIn ts] else [], [def_state' tx'], []),
           ([def_state, Message tc t], [], [Ack tc t, def_state' tx'], [])], tx')
     | (ChIn Nothing t) <- ac =
           let tx' = freeset t `union` tildex in
@@ -102,7 +102,7 @@ baseTransAction ac an p tildex
     | (ChOut (Just tc) t) <- ac, Nothing <- secretChannel an =
           let semistate = State LSemiState (p++[1]) tildex in
           ([
-          ([def_state, In tc], [ ChannelIn tc], [Out t, def_state' tildex], []),
+          ([def_state, In tc], if needsAssImmediate then [ ChannelIn tc] else [], [Out t, def_state' tildex], []),
           ([def_state], [], [Message tc t,semistate], []),
           ([semistate, Ack tc t], [], [def_state' tildex], [])], tildex)
     | (ChOut Nothing t) <- ac =
@@ -124,10 +124,10 @@ baseTransAction ac an p tildex
           ([([def_state], [UnlockNamed t v, UnlockUnnamed t v ], [def_state' tildex], [])], tildex)
     | (Unlock _ ) <- ac, Nothing <- lock an = throw ( NotImplementedError "Unannotated unlock" :: SapicException AnnotatedProcess)
     | (Event f ) <- ac =
-          ([([def_state], [TamarinAct f], [def_state' tildex], [])], tildex)
+          ([([def_state], [TamarinAct f] ++ if needsAssImmediate then [EventEmpty] else [], [def_state' tildex], [])], tildex)
     | (MSR (l,a,r,res)) <- ac =
           let tx' = freeset' r `union` tildex in
-          ([(def_state:map TamarinFact l, map TamarinAct a, def_state' tx':map TamarinFact r, res)], tx')
+          ([(def_state:map TamarinFact l, map TamarinAct a ++ if needsAssImmediate then [EventEmpty] else [], def_state' tx':map TamarinFact r, res)], tx')
     | otherwise = throw ((NotImplementedError $ "baseTransAction:" ++ prettySapicAction ac) :: SapicException AnnotatedProcess)
     where
         def_state = State LState p tildex -- default state when entering
@@ -308,10 +308,19 @@ resNotEq = [QQ.r|restriction predicate_not_eq:
 "All #i a b. Pred_Not_Eq(a,b)@i ==> not(a = b)"
 |]
 
+
+resInEv :: String
+resInEv = [QQ.r|restriction ass_immediate:
+"All x #t3. ChannelIn(x)@t3 ==> (Ex #t2. K(x)@t2 & #t2 < #t3
+                                & (All #t1. Event()@t1  ==> #t1 < #t2 | #t3 < #t1)
+                                & (All #t1 xp. K(xp)@t1 ==> #t1 < #t2 | #t3 < #t1))"
+|]
+
+
 -- | generate restrictions depending on options set (op) and the structure
 -- of the process (anP)
-baseRestr :: (MonadThrow m, MonadCatch m) => AnProcess ProcessAnnotation -> Bool -> [SyntacticRestriction] -> m [SyntacticRestriction]
-baseRestr anP hasAccountabilityLemmaWithControl prevRestr =
+baseRestr :: (MonadThrow m, MonadCatch m) => AnProcess ProcessAnnotation -> Bool -> Bool -> [SyntacticRestriction] -> m [SyntacticRestriction]
+baseRestr anP needsAssImmediate hasAccountabilityLemmaWithControl prevRestr =
   let hardcoded_l =
        (if contains isLookup then
         if contains isDelete then
@@ -323,6 +332,8 @@ baseRestr anP hasAccountabilityLemmaWithControl prevRestr =
         addIf (contains isEq) [resEq, resNotEq]
         ++
         addIf hasAccountabilityLemmaWithControl [resSingleSession]
+        ++
+        addIf needsAssImmediate [resInEv]
     in
     do
         hardcoded <- mapM toEx hardcoded_l
@@ -340,11 +351,5 @@ baseRestr anP hasAccountabilityLemmaWithControl prevRestr =
             | otherwise  = []
         getLockPositions = pfoldMap getLock
 
-        -- TODO add feature checking lemmas for wellformedness, adding ass_immeadiate_in if necessary 
         -- This is what SAPIC did
           -- @ (if op.accountability then [] else [res_single_session_l])
-        -- (*  ^ ass_immeadiate_in -> disabled, sound for most lemmas, see liveness paper
-         -- *                  it would be better if we would actually check whether each lemma
-         -- *                  is of the right form so we can leave it out...
-         -- *                  *)
-    -- in

--- a/lib/sapic/src/Sapic/Facts.hs
+++ b/lib/sapic/src/Sapic/Facts.hs
@@ -48,29 +48,39 @@ import Data.Color
 -- import Control.Monad.Trans.FastFresh
 
 -- | Facts that are used as actions
-data TransAction =  InitEmpty
-  -- to implement with accountability extension
-  -- | InitId
-  -- | StopId 
-  -- | EventEmpty
-  -- | EventId
-  | PredicateA LNFact
-  | NegPredicateA LNFact
-  | ProgressFrom ProcessPosition
-  | ProgressTo ProcessPosition ProcessPosition
-  | Receive ProcessPosition SapicTerm
+data TransAction = 
+  -- base translation
+  InitEmpty
+  --    storage
   | IsIn SapicTerm LVar
   | IsNotSet SapicTerm
   | InsertA SapicTerm SapicTerm
   | DeleteA SapicTerm
-  | ChannelIn SapicTerm
-  | Send ProcessPosition SapicTerm
+  --    locks
   | LockUnnamed SapicTerm LVar
   | LockNamed SapicTerm LVar
   | UnlockUnnamed SapicTerm LVar
   | UnlockNamed SapicTerm LVar
+  --     ass_immedeate
+  | ChannelIn SapicTerm
+  | EventEmpty
+  --    support for msrs
   | TamarinAct LNFact
+  --    predicate support
+  | PredicateA LNFact
+  | NegPredicateA LNFact
+  -- progress translation 
+  | ProgressFrom ProcessPosition
+  | ProgressTo ProcessPosition ProcessPosition
+  -- reliable channels
+  | Send ProcessPosition SapicTerm
+  | Receive ProcessPosition SapicTerm
+  -- location
   | Report LVar LVar
+  -- to implement with accountability extension
+  -- | InitId
+  -- | StopId 
+  -- | EventId
 
 -- | Facts that are used as premises and conclusions.
 -- Most important one is the state, containing the variables currently
@@ -186,6 +196,7 @@ actionToFact (IsNotSet t )   =  protoFact Linear "IsNotSet" [t]
 actionToFact (InsertA t1 t2)   =  protoFact Linear "Insert" [t1,t2]
 actionToFact (DeleteA t )   =  protoFact Linear "Delete" [t]
 actionToFact (ChannelIn t)   =  protoFact Linear "ChannelIn" [t]
+actionToFact (EventEmpty)   =   protoFact Linear "Event" []
 actionToFact (PredicateA f)   =  mapFactName (\s -> "Pred_" ++ s) f
 actionToFact (NegPredicateA f)   =  mapFactName (\s -> "Pred_Not_" ++ s) f
 actionToFact (LockNamed t v)   = protoFact Linear (lockFactName v) [lockPubTerm v,varTerm v, t ]


### PR DESCRIPTION
Hi!

This PR introduces a syntactic check on lemmas that helps SAPIC decide if a certain axiom is needed. The code was written by @mokev.

Background: In Appendix E of the full version of "A Novel Approach for Reasoning about Liveness in Cryptographic Protocols and its Application to Fair Exchange" we show that a certain axiom can be skipped for a subset of lemmas. This subset is so large, we could not think of a useful lemma outside of it. 

Previous versions of SAPIC just omitted this axiom, but now we want to do it right: we check for the (highly unlikely!) case where it is needed, and add it if necessary.

No benchmark, because nothing changes for the existing examples (they all fall in this class).

