### PR TITLE
Update GHC to 8.8.3 (lts-15.9)

### DIFF
--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -45,6 +45,7 @@ import           Data.Color
 import           Control.Applicative        hiding (empty, many, optional)
 import           Control.Category
 import           Control.Monad
+import qualified Control.Monad.Fail         as Fail
 import qualified Control.Monad.Catch        as Catch
 
 import           Text.Parsec                hiding ((<|>))
@@ -1199,6 +1200,10 @@ instance Show (ParsingException) where
     show TryingToAddFreshRule = "The fresh rule is implicitely contained in the theory and does not need to be added."
 
 instance Catch.Exception ParsingException
+
+instance Fail.MonadFail (Either Catch.SomeException) where
+  fail = Fail.fail
+
 
 liftEitherToEx :: (Catch.MonadThrow m, Catch.Exception e) => (t -> e) -> Either t a -> m a
 liftEitherToEx _ (Right r)     = return r

--- a/lib/utils/src/Control/Monad/Trans/Disj.hs
+++ b/lib/utils/src/Control/Monad/Trans/Disj.hs
@@ -23,6 +23,7 @@ import Control.Monad.List
 import Control.Monad.Reader
 import Control.Monad.Disj.Class
 
+
 ------------------------------------------------------------------------------
 -- The 'DisjT' monad transformer
 ------------------------------------------------------------------------------
@@ -46,12 +47,14 @@ runDisjT = runListT . unDisjT
 ------------
 
 instance Monad m => Monad (DisjT m) where
-    -- Ensure that contradictions are not reported via fail!
-    fail    = error
     {-# INLINE return #-}
     return  = DisjT . return
     {-# INLINE (>>=) #-}
     m >>= f = DisjT $ (unDisjT . f) =<< unDisjT m
+
+instance MonadFail m => MonadFail (DisjT m) where
+    -- Ensure that contradictions are not reported via fail!
+    fail = error
 
 instance Monad m => MonadDisj (DisjT m) where
     contradictoryBecause _ = DisjT mzero

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -66,6 +66,7 @@ import qualified Data.Text           as T
 import           Data.Time.LocalTime
 import qualified Data.Binary         as Bin
 import           Data.Binary.Orphans()
+import           Data.Binary.Instances()
 
 import           Control.DeepSeq
 import           GHC.Generics (Generic)

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 - lib/term/
 - lib/utils/
 - lib/sapic/
-extra-deps: []
-resolver: lts-13.2
+extra-deps: [ binary-instances-1 ]
+resolver: lts-14.27
 nix:
   packages: [ zlib ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 - lib/term/
 - lib/utils/
 - lib/sapic/
-extra-deps: [ binary-instances-1 ]
-resolver: lts-14.27
+extra-deps: [ binary-instances-1, fclabels-2.0.4 ]
+resolver: lts-15.9
 nix:
   packages: [ zlib ]

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -110,7 +110,7 @@ executable tamarin-prover
     
     -- -XFlexibleInstances
 
-    ghc-options:       -Wall -fwarn-tabs -rtsopts -feager-blackholing
+    ghc-options:       -Wall -fwarn-tabs -rtsopts -feager-blackholing -main-is Main
     ghc-prof-options:  -auto-all
 
     -- Parallelize by default. Only activated for GHC 7.4, as this flag was
@@ -127,6 +127,7 @@ executable tamarin-prover
       , base
       , binary
       , binary-orphans
+      , binary-instances
       , blaze-builder
       , blaze-html
       , bytestring
@@ -165,7 +166,7 @@ executable tamarin-prover
     other-modules:
       Paths_tamarin_prover
 
-      Main
+      -- Main
       Main.Console
       Main.Environment
       Main.TheoryLoader


### PR DESCRIPTION
The version update is necessary to build Tamarin under Nix as there is no ghc863 target anymore.
Since version 1.0, binary-orphans no longer provides exports for other packages. That functionality has been moved to binary-instances which is now added as an extra dependency.

See also the relevant issue for nixpkgs https://github.com/NixOS/nixpkgs/pull/69356.