### PR TITLE
Fix: Ass immediate check

### DIFF
--- a/examples/sapic/feature-ass-immediate/test-channelin.spthy
+++ b/examples/sapic/feature-ass-immediate/test-channelin.spthy
@@ -1,0 +1,14 @@
+theory AssImmediateChannelIn
+begin
+
+new x; out(x);
+in(x); 
+event A()
+
+// should verifiy and NOT trigger addition of ass_immediate
+// since no ChannelIn event is present
+lemma intuitiveTest:
+  all-traces
+  "All #a. A()@a ==> Ex #i x. K(x)@i & #i<#a"
+
+end

--- a/lib/sapic/src/Sapic.hs
+++ b/lib/sapic/src/Sapic.hs
@@ -195,7 +195,7 @@ isPosNegFormula fm = case fm of
     TF  _            -> (True, True)
     Ato (Action _ f) -> isActualKFact $ factTag f
     Ato _            -> (True, True)
-    Not p            -> not2 $ isPosNegFormula p
+    Not p            -> swap $ isPosNegFormula p
     Conn And p q     -> isPosNegFormula p `and2` isPosNegFormula q
     Conn Or  p q     -> isPosNegFormula p `and2` isPosNegFormula q
     Conn Imp p q     -> isPosNegFormula $ Not p .||. q
@@ -206,9 +206,9 @@ isPosNegFormula fm = case fm of
       isActualKFact _ = (True, True)
 
       and2 (x, y) (p, q) = (x && p, y && q)
-      not2 (x, y) = (not x, not y)
+      swap (x, y) = (y, x)
 
-
+-- Checks if the lemma is in the fragment of formulas for which the resInEv restriction is not needed.
 checkAssImmediate :: Lemma p -> Bool
 checkAssImmediate lem = case (L.get lTraceQuantifier lem, isPosNegFormula $ L.get lFormula lem) of
   (AllTraces,   (_, True))     -> True  -- L- for all-traces

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -319,8 +319,8 @@ resInEv = [QQ.r|restriction ass_immediate:
 
 -- | generate restrictions depending on options set (op) and the structure
 -- of the process (anP)
-baseRestr :: (MonadThrow m, MonadCatch m) => AnProcess ProcessAnnotation -> Bool -> Bool -> [SyntacticRestriction] -> m [SyntacticRestriction]
-baseRestr anP needsAssImmediate hasAccountabilityLemmaWithControl prevRestr =
+baseRestr :: (MonadThrow m, MonadCatch m) => AnProcess ProcessAnnotation -> Bool -> Bool -> Bool -> [SyntacticRestriction] -> m [SyntacticRestriction]
+baseRestr anP needsAssImmediate containChannelIn hasAccountabilityLemmaWithControl prevRestr =
   let hardcoded_l =
        (if contains isLookup then
         if contains isDelete then
@@ -333,7 +333,7 @@ baseRestr anP needsAssImmediate hasAccountabilityLemmaWithControl prevRestr =
         ++
         addIf hasAccountabilityLemmaWithControl [resSingleSession]
         ++
-        addIf (needsAssImmediate && contains isChIn) [resInEv]
+        addIf (needsAssImmediate && containChannelIn) [resInEv]
     in
     do
         hardcoded <- mapM toEx hardcoded_l

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -333,7 +333,7 @@ baseRestr anP needsAssImmediate hasAccountabilityLemmaWithControl prevRestr =
         ++
         addIf hasAccountabilityLemmaWithControl [resSingleSession]
         ++
-        addIf needsAssImmediate [resInEv]
+        addIf (needsAssImmediate && contains isChIn) [resInEv]
     in
     do
         hardcoded <- mapM toEx hardcoded_l

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -313,7 +313,7 @@ resInEv :: String
 resInEv = [QQ.r|restriction ass_immediate:
 "All x #t3. ChannelIn(x)@t3 ==> (Ex #t2. K(x)@t2 & #t2 < #t3
                                 & (All #t1. Event()@t1  ==> #t1 < #t2 | #t3 < #t1)
-                                & (All #t1 xp. K(xp)@t1 ==> #t1 < #t2 | #t3 < #t1))"
+                                & (All #t1 xp. K(xp)@t1 ==> #t1 < #t2 | #t1 = #t2 | #t3 < #t1))"
 |]
 
 

--- a/lib/sapic/src/Sapic/ProcessUtils.hs
+++ b/lib/sapic/src/Sapic/ProcessUtils.hs
@@ -15,6 +15,8 @@ module Sapic.ProcessUtils (
 ,  isDelete
 ,  isLock
 ,  isUnlock
+,  isChIn
+,  isChOut
 ) where
 -- import Data.Maybe
 -- import Data.Foldable
@@ -66,7 +68,14 @@ isUnlock :: AnProcess ann -> Bool
 isUnlock (ProcessAction (Unlock _) _ _) = True
 isUnlock _  = False
 
+isChIn :: AnProcess ann -> Bool
+isChIn (ProcessAction (ChIn _ _) _ _) = True
+isChIn _  = False
+
+isChOut :: AnProcess ann -> Bool
+isChOut (ProcessAction (ChOut _ _) _ _) = True
+isChOut _  = False
+
 isEq :: AnProcess ann -> Bool
 isEq (ProcessComb (CondEq _ _) _ _ _) = True
 isEq _  = False
-


### PR DESCRIPTION
The check whether the `resInEv` restriction is needed contained a logic error in the negation case which is now fixed.
The restriction is now only added if the process contains a `ChIn` action.