### PR TITLE
Fix syntax highlighting for revealing-signing builtin

### DIFF
--- a/etc/notepad_plus_plus_spthy.xml
+++ b/etc/notepad_plus_plus_spthy.xml
@@ -12,7 +12,7 @@
             <Keywords name="Operators">&quot; # $ ( ) , . : [ ] { } ~ &lt; &gt;</Keywords>
             <Keywords name="Comment">1/* 2*/ 0//</Keywords>
             <Keywords name="Words1">axiom lemma equations functions builtins protocol property theory begin end subsection section text rule</Keywords>
-            <Keywords name="Words2">h sk pk Fr In Out fr in out pb lts diffie-hellman symmetric-encryption asymmetric-encryption exists-trace all-traces enable assertions modulo default_rules anb-proto in let Fresh fresh Public public signing hashing</Keywords>
+            <Keywords name="Words2">h sk pk Fr In Out fr in out pb lts diffie-hellman symmetric-encryption asymmetric-encryption exists-trace all-traces enable assertions modulo default_rules anb-proto in let Fresh fresh Public public signing hashing revealing-signing</Keywords>
             <Keywords name="Words3">@ &amp; | ==&gt; = &lt;=&gt;</Keywords>
             <Keywords name="Words4">All Ex</Keywords>
         </KeywordLists>

--- a/etc/spthy.el
+++ b/etc/spthy.el
@@ -28,7 +28,7 @@
   '("axiom" "lemma" "restriction" "protocol" "property" "text" "rule" "let" "in" "Fresh" "fresh" "Public" "public" "hashing" "All" "Ex" "h" "sk" "pk" "Fr" "In" "Out" "fr" "in" "out" "not" "!"))
 
 (defvar spthy-events
-  '("theory" "begin" "end" "subsection" "section" "pb" "lts" "diffie-hellman" "bilinear-pairing" "multiset" "symmetric-encryption" "asymmetric-encryption" "exists-trace" "all-traces" "enable" "assertions" "modulo" "default_rules" "anb-proto" "signing"))
+  '("theory" "begin" "end" "subsection" "section" "pb" "lts" "diffie-hellman" "bilinear-pairing" "multiset" "symmetric-encryption" "asymmetric-encryption" "exists-trace" "all-traces" "enable" "assertions" "modulo" "default_rules" "anb-proto" "signing" "revealing-signing"))
 
 (defvar spthy-operators
   '("&" "|" "==>" "=" "<=>" "-->" "^" "[" "]->" "-->" "]" "--["))

--- a/etc/spthy.vim
+++ b/etc/spthy.vim
@@ -39,7 +39,7 @@ syn match spthyLAtom	        "@"
 syn match spthyLAtom	        "<"
 syn match spthyLAtom	        ">"
 
-syn keyword spthyConstr         aenc sdec senc sdec sign verify hashing signing multiset
+syn keyword spthyConstr         aenc sdec senc sdec sign verify hashing signing multiset revealSign revealVerify getMessage true
 syn match spthyConstr           "\<h("he=e-1
 syn match spthyConstr           "\<sk("he=e-1
 syn match spthyConstr           "\<pk("he=e-1
@@ -51,6 +51,7 @@ syn match spthyConstr           "\^"
 syn match spthyConstr           "\<diffie-hellman"
 syn match spthyConstr           "\<symmetric-encryption"
 syn match spthyConstr           "\<asymmetric-encryption"
+syn match spthyConstr           "\<revealing-signing"
 
 syn keyword spthyDecl           axiom restriction equations functions builtins protocol property in let theory begin end subsection section text
 syn match spthyDecl             "\<lemma\>"


### PR DESCRIPTION
Tested the `vim` files, I don't know about the other two.

I could install and try emacs but it's a fairly simple change ;)

I should mention I don't know a lot about SAPIC, maybe these changes should also be added to the corresponding `sapic.vim` file?