### PR TITLE
Fix parsing of #endif by avoiding clash with color rule attribute

### DIFF
--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -1358,8 +1358,7 @@ theory flags0 = do
          then do thy' <- addItems flags thy
                  symbol_ "#endif"
                  addItems flags thy'
-         else do _ <- manyTill anyChar (try (string "#"))
-                 symbol_ "endif"
+         else do _ <- manyTill anyChar (try (symbol_ "#endif"))
                  addItems flags thy
 
     -- check process defined only once


### PR DESCRIPTION
The changes in #375 broke the parsing of `#endif` since it didn't take the possibility of color rule attributes into account which also include a `#` symbol.

This is fixed by directly trying to parse an `#endif` which cannot be mistaken for a color.