### PR TITLE
fix haddock errors

### DIFF
--- a/lib/sapic/src/Sapic.hs
+++ b/lib/sapic/src/Sapic.hs
@@ -133,7 +133,7 @@ translate th = case theoryProcesses th of
   -- in
   -- input.sign ^ ( print_msr msr' ) ^ sapic_restrictions ^
   -- predicate_restrictions ^ lemmas_tamarin
-  -- <CIRCUMFLEX> "end"
+  --- ^ "end"
 
 -- | Processes through an annotated process and translates every single action
 -- | according to trans. It substitutes states by pstates for replication and

--- a/lib/sapic/src/Sapic.hs
+++ b/lib/sapic/src/Sapic.hs
@@ -133,7 +133,7 @@ translate th = case theoryProcesses th of
   -- in
   -- input.sign ^ ( print_msr msr' ) ^ sapic_restrictions ^
   -- predicate_restrictions ^ lemmas_tamarin
-  -- ^ "end"
+  -- <CIRCUMFLEX> "end"
 
 -- | Processes through an annotated process and translates every single action
 -- | according to trans. It substitutes states by pstates for replication and

--- a/lib/sapic/src/Sapic/Facts.hs
+++ b/lib/sapic/src/Sapic/Facts.hs
@@ -78,9 +78,9 @@ data TransAction =
   -- location
   | Report LVar LVar
   -- to implement with accountability extension
-  -- | InitId
-  -- | StopId 
-  -- | EventId
+  -- <PIPE> InitId
+  -- <PIPE> StopId 
+  -- <PIPE> EventId
 
 -- | Facts that are used as premises and conclusions.
 -- Most important one is the state, containing the variables currently
@@ -185,10 +185,10 @@ varMsgId p = LVar n s i
 -- actionToFact :: TransAction -> Fact t
 actionToFact :: TransAction -> Fact (VTerm Name LVar)
 actionToFact InitEmpty = protoFact Linear "Init" []
-  -- | Not implemented yet: progress
-  -- | StopId
-  -- | EventEmpty
-  -- | EventId
+  -- <PIPE> Not implemented yet: progress
+  -- <PIPE> StopId
+  -- <PIPE> EventEmpty
+  -- <PIPE> EventId
 actionToFact (Send p t) = protoFact Linear "Send" [varTerm $ varMsgId p ,t]
 actionToFact (Receive p t) = protoFact Linear "Receive" [varTerm $ varMsgId p ,t]
 actionToFact (IsIn t v)   =  protoFact Linear "IsIn" [t,varTerm v]

--- a/lib/sapic/src/Sapic/Facts.hs
+++ b/lib/sapic/src/Sapic/Facts.hs
@@ -78,9 +78,9 @@ data TransAction =
   -- location
   | Report LVar LVar
   -- to implement with accountability extension
-  -- <PIPE> InitId
-  -- <PIPE> StopId 
-  -- <PIPE> EventId
+  --- | InitId
+  --- | StopId 
+  --- | EventId
 
 -- | Facts that are used as premises and conclusions.
 -- Most important one is the state, containing the variables currently
@@ -185,10 +185,10 @@ varMsgId p = LVar n s i
 -- actionToFact :: TransAction -> Fact t
 actionToFact :: TransAction -> Fact (VTerm Name LVar)
 actionToFact InitEmpty = protoFact Linear "Init" []
-  -- <PIPE> Not implemented yet: progress
-  -- <PIPE> StopId
-  -- <PIPE> EventEmpty
-  -- <PIPE> EventId
+  --- | Not implemented yet: progress
+  --- | StopId
+  --- | EventEmpty
+  --- | EventId
 actionToFact (Send p t) = protoFact Linear "Send" [varTerm $ varMsgId p ,t]
 actionToFact (Receive p t) = protoFact Linear "Receive" [varTerm $ varMsgId p ,t]
 actionToFact (IsIn t v)   =  protoFact Linear "IsIn" [t,varTerm v]

--- a/lib/sapic/src/Sapic/ProgressFunction.hs
+++ b/lib/sapic/src/Sapic/ProgressFunction.hs
@@ -26,11 +26,11 @@ import qualified Data.Map.Strict as M
 
 type ProgressFunction = M.Map ProcessPosition (S.Set (S.Set ProcessPosition))
  
--- <PIPE> suffix list p to each element of set *)
+--- | suffix list p to each element of set *)
 (<.>) :: Ord a => [a] -> S.Set [a]  -> S.Set [a]
 (<.>) pos set = S.map (\pos' -> pos ++ pos' ) set 
 
--- <PIPE> suffix list p to each element in a set of set of sets *)
+--- | suffix list p to each element in a set of set of sets *)
 (<..>) :: Ord a => [a] -> S.Set (S.Set [a]) -> S.Set (S.Set [a])
 (<..>) pos setset  = S.map (\set' -> pos <.> set') setset
 

--- a/lib/sapic/src/Sapic/ProgressFunction.hs
+++ b/lib/sapic/src/Sapic/ProgressFunction.hs
@@ -26,11 +26,11 @@ import qualified Data.Map.Strict as M
 
 type ProgressFunction = M.Map ProcessPosition (S.Set (S.Set ProcessPosition))
  
- -- | suffix list p to each element of set *)
+-- <PIPE> suffix list p to each element of set *)
 (<.>) :: Ord a => [a] -> S.Set [a]  -> S.Set [a]
 (<.>) pos set = S.map (\pos' -> pos ++ pos' ) set 
 
--- | suffix list p to each element in a set of set of sets *)
+-- <PIPE> suffix list p to each element in a set of set of sets *)
 (<..>) :: Ord a => [a] -> S.Set (S.Set [a]) -> S.Set (S.Set [a])
 (<..>) pos setset  = S.map (\set' -> pos <.> set') setset
 

--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -459,7 +459,7 @@ closeRuleCache restrictions typAsms sig protoRules intrRules isdiff = -- trace (
         sig classifiedRules injFactInstances RawSource [] AvoidInduction Nothing
         (error "closeRuleCache: trace quantifier should not matter here")
         (error "closeRuleCache: lemma name should not matter here") [] isdiff
-        (all isSubtermRule {-<DOLLAR> trace (show destr ++ " - " ++ show (map isSubtermRule destr))-} destr) (any isConstantRule destr)
+        (all isSubtermRule {-- $ trace (show destr ++ " - " ++ show (map isSubtermRule destr))-} destr) (any isConstantRule destr)
 
     -- inj fact instances
     injFactInstances =

--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -459,7 +459,7 @@ closeRuleCache restrictions typAsms sig protoRules intrRules isdiff = -- trace (
         sig classifiedRules injFactInstances RawSource [] AvoidInduction Nothing
         (error "closeRuleCache: trace quantifier should not matter here")
         (error "closeRuleCache: lemma name should not matter here") [] isdiff
-        (all isSubtermRule {-$ trace (show destr ++ " - " ++ show (map isSubtermRule destr))-} destr) (any isConstantRule destr)
+        (all isSubtermRule {-<DOLLAR> trace (show destr ++ " - " ++ show (map isSubtermRule destr))-} destr) (any isConstantRule destr)
 
     -- inj fact instances
     injFactInstances =

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -91,7 +91,7 @@ openGoals sys = do
                     -- message variables are not solved, except if the node already exists in the system -> facilitates finding contradictions
                     || (isMsgVar m && Nothing == M.lookup i (get sNodes sys)) || sortOfLNTerm m == LSortPub
                     -- handled by 'insertAction'
-                    || isPair m || isInverse m || isProduct m -- <PIPE PIPE> isXor m
+                    || isPair m || isInverse m || isProduct m --- || isXor m
                     || isUnion m || isNullaryPublicFunction m
         ActionG _ _                               -> not solved
         PremiseG _ _                              -> not solved

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -91,7 +91,7 @@ openGoals sys = do
                     -- message variables are not solved, except if the node already exists in the system -> facilitates finding contradictions
                     || (isMsgVar m && Nothing == M.lookup i (get sNodes sys)) || sortOfLNTerm m == LSortPub
                     -- handled by 'insertAction'
-                    || isPair m || isInverse m || isProduct m -- || isXor m
+                    || isPair m || isInverse m || isProduct m -- <PIPE PIPE> isXor m
                     || isUnion m || isNullaryPublicFunction m
         ActionG _ _                               -> not solved
         PremiseG _ _                              -> not solved

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -614,7 +614,7 @@ substGoals = do
     changes <- forM goals $ \(goal, status) -> case goal of
         -- Look out for KU-actions that might need to be solved again.
         ActionG i fa@(kFactView -> Just (UpK, m))
-          | (isMsgVar m || isProduct m || isUnion m {-|| isXor m-}) && (apply subst m /= m) ->
+          | (isMsgVar m || isProduct m || isUnion m {-<PIPE PIPE> isXor m-}) && (apply subst m /= m) ->
               insertAction i (apply subst fa)
         _ -> do modM sGoals $
                   M'.insertWith combineGoalStatus (apply subst goal) status

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -614,7 +614,7 @@ substGoals = do
     changes <- forM goals $ \(goal, status) -> case goal of
         -- Look out for KU-actions that might need to be solved again.
         ActionG i fa@(kFactView -> Just (UpK, m))
-          | (isMsgVar m || isProduct m || isUnion m {-<PIPE PIPE> isXor m-}) && (apply subst m /= m) ->
+          | (isMsgVar m || isProduct m || isUnion m {--|| isXor m-}) && (apply subst m /= m) ->
               insertAction i (apply subst fa)
         _ -> do modM sGoals $
                   M'.insertWith combineGoalStatus (apply subst goal) status

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -815,7 +815,7 @@ filterRestrictions ctxt sys formulas = filter (unifiableNodes) formulas
     -- instantiated to a different index *in* the trace.
     unifiableNodes :: LNGuarded -> Bool
     unifiableNodes fm = case fm of
-         (GAto ato)  -> unifiableAtoms {- <DOLLAR-SIGN> trace ("atom on which bvarToLVar will be applied [ato]: " ++ show ato)-} $ [bvarToLVar ato]
+         (GAto ato)  -> unifiableAtoms {-- $ trace ("atom on which bvarToLVar will be applied [ato]: " ++ show ato)-} $ [bvarToLVar ato]
          (GDisj fms) -> any unifiableNodes $ getDisj fms
          (GConj fms) -> any unifiableNodes $ getConj fms
          gg@(GGuarded _ _ _ _) -> case evalFreshAvoiding (openGuarded gg) (L.get sNodes sys) of
@@ -882,7 +882,7 @@ doRestrictionsHold ctxt sys formulas isSolved = -- Just (True, [sys]) -- FIXME J
         res = step forms solved
 
     step :: [(LNGuarded, System)] -> Bool -> [(LNGuarded, System)]
-    step forms solved = map simpGuard $ concat {- <DOLLAR-SIGN> trace (show (map (impliedOrInitial solved) forms))-} $ map (impliedOrInitial solved) forms
+    step forms solved = map simpGuard $ concat {-- $ trace (show (map (impliedOrInitial solved) forms))-} $ map (impliedOrInitial solved) forms
 
     valuation s' = safePartialAtomValuation ctxt s'
 
@@ -1290,7 +1290,7 @@ prettyNonGraphSystem se = vsep $ map combine -- text $ show se
 --   , ("system",          text $ show se)
 --   , ("DEBUG: Goals",    text $ show $ M.toList $ L.get sGoals se) -- prettyGoals False se)
 --   , ("DEBUG: Nodes",    vcat $ map prettyNode $ M.toList $ L.get sNodes se)
---   , ("DEBUG",           text $ "dgIsNotEmpty: " ++ (show (dgIsNotEmpty se)) ++ " allFormulasAreSolved: " ++ (show (allFormulasAreSolved se)) ++ " allOpenGoalsAreSimpleFacts: " ++ (show (allOpenGoalsAreSimpleFacts se)) ++ " allOpenFactGoalsAreIndependent " ++ (show (allOpenFactGoalsAreIndependent se)) ++ " " ++ (if (dgIsNotEmpty se) && (allOpenGoalsAreSimpleFacts se) && (allOpenFactGoalsAreIndependent se) then ((show (map (checkIndependence se) $ unsolvedTrivialGoals se)) ++ " " ++ (show {-<DOLLAR> map (\(premid, x) -> getAllMatchingConcs se premid x)-} $ map (\(nid, pid) -> ((nid, pid), getAllLessPreds se nid)) $ getOpenNodePrems se) ++ " ") else " not trivial ") ++ (show $ unsolvedTrivialGoals se) ++ " " ++ (show $ getOpenNodePrems se))
+--   , ("DEBUG",           text $ "dgIsNotEmpty: " ++ (show (dgIsNotEmpty se)) ++ " allFormulasAreSolved: " ++ (show (allFormulasAreSolved se)) ++ " allOpenGoalsAreSimpleFacts: " ++ (show (allOpenGoalsAreSimpleFacts se)) ++ " allOpenFactGoalsAreIndependent " ++ (show (allOpenFactGoalsAreIndependent se)) ++ " " ++ (if (dgIsNotEmpty se) && (allOpenGoalsAreSimpleFacts se) && (allOpenFactGoalsAreIndependent se) then ((show (map (checkIndependence se) $ unsolvedTrivialGoals se)) ++ " " ++ (show {-- $ map (\(premid, x) -> getAllMatchingConcs se premid x)-} $ map (\(nid, pid) -> ((nid, pid), getAllLessPreds se nid)) $ getOpenNodePrems se) ++ " ") else " not trivial ") ++ (show $ unsolvedTrivialGoals se) ++ " " ++ (show $ getOpenNodePrems se))
   ]
   where
     combine (header, d)  = fsep [keyword_ header <> colon, nest 2 d]

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -815,7 +815,7 @@ filterRestrictions ctxt sys formulas = filter (unifiableNodes) formulas
     -- instantiated to a different index *in* the trace.
     unifiableNodes :: LNGuarded -> Bool
     unifiableNodes fm = case fm of
-         (GAto ato)  -> unifiableAtoms {-$ trace ("atom on which bvarToLVar will be applied [ato]: " ++ show ato)-} $ [bvarToLVar ato]
+         (GAto ato)  -> unifiableAtoms {- <DOLLAR-SIGN> trace ("atom on which bvarToLVar will be applied [ato]: " ++ show ato)-} $ [bvarToLVar ato]
          (GDisj fms) -> any unifiableNodes $ getDisj fms
          (GConj fms) -> any unifiableNodes $ getConj fms
          gg@(GGuarded _ _ _ _) -> case evalFreshAvoiding (openGuarded gg) (L.get sNodes sys) of
@@ -882,7 +882,7 @@ doRestrictionsHold ctxt sys formulas isSolved = -- Just (True, [sys]) -- FIXME J
         res = step forms solved
 
     step :: [(LNGuarded, System)] -> Bool -> [(LNGuarded, System)]
-    step forms solved = map simpGuard $ concat {-$ trace (show (map (impliedOrInitial solved) forms))-} $ map (impliedOrInitial solved) forms
+    step forms solved = map simpGuard $ concat {- <DOLLAR-SIGN> trace (show (map (impliedOrInitial solved) forms))-} $ map (impliedOrInitial solved) forms
 
     valuation s' = safePartialAtomValuation ctxt s'
 
@@ -1290,7 +1290,7 @@ prettyNonGraphSystem se = vsep $ map combine -- text $ show se
 --   , ("system",          text $ show se)
 --   , ("DEBUG: Goals",    text $ show $ M.toList $ L.get sGoals se) -- prettyGoals False se)
 --   , ("DEBUG: Nodes",    vcat $ map prettyNode $ M.toList $ L.get sNodes se)
---   , ("DEBUG",           text $ "dgIsNotEmpty: " ++ (show (dgIsNotEmpty se)) ++ " allFormulasAreSolved: " ++ (show (allFormulasAreSolved se)) ++ " allOpenGoalsAreSimpleFacts: " ++ (show (allOpenGoalsAreSimpleFacts se)) ++ " allOpenFactGoalsAreIndependent " ++ (show (allOpenFactGoalsAreIndependent se)) ++ " " ++ (if (dgIsNotEmpty se) && (allOpenGoalsAreSimpleFacts se) && (allOpenFactGoalsAreIndependent se) then ((show (map (checkIndependence se) $ unsolvedTrivialGoals se)) ++ " " ++ (show {-$ map (\(premid, x) -> getAllMatchingConcs se premid x)-} $ map (\(nid, pid) -> ((nid, pid), getAllLessPreds se nid)) $ getOpenNodePrems se) ++ " ") else " not trivial ") ++ (show $ unsolvedTrivialGoals se) ++ " " ++ (show $ getOpenNodePrems se))
+--   , ("DEBUG",           text $ "dgIsNotEmpty: " ++ (show (dgIsNotEmpty se)) ++ " allFormulasAreSolved: " ++ (show (allFormulasAreSolved se)) ++ " allOpenGoalsAreSimpleFacts: " ++ (show (allOpenGoalsAreSimpleFacts se)) ++ " allOpenFactGoalsAreIndependent " ++ (show (allOpenFactGoalsAreIndependent se)) ++ " " ++ (if (dgIsNotEmpty se) && (allOpenGoalsAreSimpleFacts se) && (allOpenFactGoalsAreIndependent se) then ((show (map (checkIndependence se) $ unsolvedTrivialGoals se)) ++ " " ++ (show {-<DOLLAR> map (\(premid, x) -> getAllMatchingConcs se premid x)-} $ map (\(nid, pid) -> ((nid, pid), getAllLessPreds se nid)) $ getOpenNodePrems se) ++ " ") else " not trivial ") ++ (show $ unsolvedTrivialGoals se) ++ " " ++ (show $ getOpenNodePrems se))
   ]
   where
     combine (header, d)  = fsep [keyword_ header <> colon, nest 2 d]

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1145,7 +1145,7 @@ prettyNamedRule prefix ppInfo ru =
     prefix <-> prettyRuleName ru <> ppAttributes <> colon $-$
     nest 2
     (prettyRule (facts rPrems) acts (facts rConcs))  $-$
-    nest 2 (ppInfo $ L.get rInfo ru) -- <DOLLAR MINUS DOLLAR>
+    nest 2 (ppInfo $ L.get rInfo ru) --- $-$
     where
     acts             = filter isNotDiffAnnotation (L.get rActs ru)
     isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0, factAnnotations = S.empty, factTerms = []})

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1145,7 +1145,7 @@ prettyNamedRule prefix ppInfo ru =
     prefix <-> prettyRuleName ru <> ppAttributes <> colon $-$
     nest 2
     (prettyRule (facts rPrems) acts (facts rConcs))  $-$
-    nest 2 (ppInfo $ L.get rInfo ru) -- $-$
+    nest 2 (ppInfo $ L.get rInfo ru) -- <DOLLAR MINUS DOLLAR>
     where
     acts             = filter isNotDiffAnnotation (L.get rActs ru)
     isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0, factAnnotations = S.empty, factTerms = []})


### PR DESCRIPTION
For using the Intellij Haskell plugin, it was necessary to fix the errors in the Haddock comments such that the command `stack haddock` can run without errors.

This commit only changes comments in the source code.