### PR TITLE
Adjust parsers to work with Maude 3.1

### DIFF
--- a/lib/term/src/Term/Maude/Parser.hs
+++ b/lib/term/src/Term/Maude/Parser.hs
@@ -224,7 +224,7 @@ parseVariantsReply msig reply = flip parseOnly reply $ do
     <* endOfLine <* string "rewrites: "
     <* takeWhile1 isDigit <* endOfLine <* endOfInput
   where
-    parseVariant = string "Variant #" *> takeWhile1 isDigit *> endOfLine *>
+    parseVariant = string "Variant " *> option '#' (char '#') *> takeWhile1 isDigit *> endOfLine *>
                    string "rewrites: " *> takeWhile1 isDigit *> endOfLine *>
                    parseReprintedTerm *> manyTill parseEntry endOfLine
     parseReprintedTerm = choice [ string "TOP" *> pure LSortMsg, parseSort ]
@@ -235,7 +235,7 @@ parseVariantsReply msig reply = flip parseOnly reply $ do
 -- | @parseSubstitution l@ parses a single substitution returned by Maude.
 parseSubstitution :: MaudeSig -> Parser MSubst
 parseSubstitution msig = do
-    endOfLine *> string "Solution " *> takeWhile1 isDigit *> endOfLine
+    endOfLine *> choice [string "Solution ", string "Unifier ", string "Matcher "] *> takeWhile1 isDigit *> endOfLine
     choice [ string "empty substitution" *> endOfLine *> pure []
            , many1 parseEntry]
   where 

--- a/lib/term/src/Term/Maude/Parser.hs
+++ b/lib/term/src/Term/Maude/Parser.hs
@@ -224,7 +224,7 @@ parseVariantsReply msig reply = flip parseOnly reply $ do
     <* endOfLine <* string "rewrites: "
     <* takeWhile1 isDigit <* endOfLine <* endOfInput
   where
-    parseVariant = string "Variant " *> option '#' (char '#') *> takeWhile1 isDigit *> endOfLine *>
+    parseVariant = string "Variant " *> optional (char '#') *> takeWhile1 isDigit *> endOfLine *>
                    string "rewrites: " *> takeWhile1 isDigit *> endOfLine *>
                    parseReprintedTerm *> manyTill parseEntry endOfLine
     parseReprintedTerm = choice [ string "TOP" *> pure LSortMsg, parseSort ]

--- a/src/Main/Environment.hs
+++ b/src/Main/Environment.hs
@@ -175,7 +175,7 @@ ensureMaude as = do
 
 --  Maude versions prior to 2.7.1 are no longer supported,
 --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0"]
+    supportedVersions = ["2.7.1", "3.0", "3.1"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
Maude 3.1 introduces some output changes, the parsers need to be updated
for this. This change should make it work on either 2.7, 3.0 or the latest 3.1 version.