### PR TITLE
Remove monad-unlift

### DIFF
--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -79,7 +79,6 @@ import           Web.Types
 import           Yesod.Core
 
 import           Control.Monad.Trans.Resource (runResourceT)
-import           Control.Monad.Trans.Unlift
 
 import           Data.Label
 import           Data.Maybe
@@ -103,8 +102,7 @@ import           Control.Applicative
 import           Control.Concurrent
 import qualified Control.Concurrent.Thread    as Thread ( forkIO )
 import           Control.DeepSeq
-import           Control.Exception.Base
-import qualified Control.Exception.Lifted     as E
+import           Control.Exception.Base       as E
 import           Control.Monad
 import qualified Data.Binary                  as Bin
 import           Data.Time.LocalTime
@@ -300,11 +298,11 @@ getThreads = do
 ------------------------------------------------------------------------------
 
 -- | Print exceptions, if they happen.
-traceExceptions :: MonadBaseControl IO m => String -> m a -> m a
+traceExceptions :: String -> IO a -> IO a
 traceExceptions info =
     E.handle handler
   where
-    handler :: MonadBaseControl IO m => E.SomeException -> m a
+    handler :: E.SomeException -> IO a
     handler e =
       trace (info ++ ": exception `" ++ show e ++ "'") $ E.throwIO e
 
@@ -329,7 +327,7 @@ responseToJson = go
 -- | Fully evaluate a value in a thread that can be canceled.
 evalInThread :: NFData a
              => IO a
-             -> Handler (Either SomeException a)
+             -> Handler (Either E.SomeException a)
 evalInThread io = do
     renderF <- getUrlRender
     maybeRoute <- getCurrentRoute

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -141,8 +141,6 @@ executable tamarin-prover
       , filepath
       , gitrev
       , http-types
-      , lifted-base
-      , monad-unlift
       , mtl
       , parsec
       , process


### PR DESCRIPTION
monad-unlift has been abandoned for years. Let's drop its usage.

Tested to build fine and all tests pass.