### PR TITLE
Allow inline comment after top-level heuristic specification

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Signature.hs
+++ b/lib/theory/src/Theory/Text/Parser/Signature.hs
@@ -175,7 +175,7 @@ preddeclaration thy = do
                     <?> "predicates"
 
 heuristic :: Bool -> Maybe FilePath -> Parser [GoalRanking]
-heuristic diff workDir = symbol "heuristic" *> char ':' *> skipMany (char ' ') *> many1 (goalRanking diff workDir) <* spaces
+heuristic diff workDir = symbol "heuristic" *> char ':' *> skipMany (char ' ') *> many1 (goalRanking diff workDir) <* lexeme spaces
 
 goalRanking :: Bool -> Maybe FilePath -> Parser GoalRanking
 goalRanking diff workDir = try oracleRanking <|> regularRanking <?> "goal ranking"

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -9,8 +9,9 @@
 
 {-# LANGUAGE FlexibleInstances #-}
 module Theory.Text.Parser.Token (
+    lexeme
   -- * Symbols
-    symbol
+  , symbol
   , symbol_
   , dot
   , comma
@@ -166,6 +167,9 @@ parseString srcDesc parser =
 
 -- Token parsers
 ----------------
+
+lexeme :: ParsecT String MaudeSig Identity a -> ParsecT String MaudeSig Identity a
+lexeme = T.lexeme spthy
 
 -- | Parse a symbol.
 symbol :: String -> Parser String


### PR DESCRIPTION
This fixes a regression introduced in PR #406 where inline comments weren't allowed after top-level heuristic specifications.