### PR TITLE
Dockerized Tamarin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.stack-work
+.worktree
+lib/*/.stack-work

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .stack-work
 .worktree
 lib/*/.stack-work
+examples

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -40,7 +40,7 @@ COPY src ./src
 COPY data ./data
 COPY images ./images
 # build the entire thing
-RUN stack build --system-ghc --local-bin-path /usr/local/bin
+RUN stack build --system-ghc
 RUN stack install --system-ghc --local-bin-path /usr/local/bin
 
 # Assemble final image

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,0 +1,74 @@
+FROM fpco/stack-build:lts-16.12 as deps-tamarin
+RUN mkdir /opt/build
+WORKDIR /opt/build
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY stack.yaml stack.yaml.lock tamarin-prover.cabal /opt/build/
+RUN mkdir lib lib/export lib/theory lib/sapic lib/tools lib/term
+COPY lib/sapic/tamarin-prover-sapic.cabal lib/sapic/
+COPY lib/term/tamarin-prover-term.cabal lib/term/
+COPY lib/theory/tamarin-prover-theory.cabal lib/theory/
+COPY lib/utils/tamarin-prover-utils.cabal lib/utils/
+RUN stack build --system-ghc --dependencies-only --ghc-options="+RTS -M600M" -j1
+
+FROM fpco/stack-build:lts-16.12 as build-tamarin
+# Copy compiled dependencies from previous stage
+COPY --from=deps-tamarin /root/.stack /root/.stack
+# copy all files except `etc`, because we don't want this stage to be rebuilt
+# anytime the dockerfiles change
+# docker is braindead: it copies the content of a directory, even if it is in a list
+# so we need to list them one by one
+COPY stack.yaml stack.yaml.lock tamarin-prover.cabal LICENSE /opt/build/
+COPY src  /opt/build/src
+COPY lib /opt/build/lib
+COPY data /opt/build/data
+COPY images /opt/build/images
+WORKDIR /opt/build
+RUN stack build --system-ghc
+RUN mv "$(stack path --local-install-root --system-ghc)/bin" /opt/build/bin
+
+# Base image for stack build so compiled artifact from previous
+# stage should run
+FROM debian:buster-slim as tamarin-prover
+RUN mkdir -p /opt/tamarin
+WORKDIR /opt/tamarin
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    #general stuff
+    graphviz \
+    libncurses5 \
+    bc \
+    locales \
+    curl \
+    ca-certificates \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# set locales so haskell can do it's thing
+# https://stackoverflow.com/questions/28405902/how-to-set-the-locale-inside-a-debian-ubuntu-docker-container
+# The following does NOT work -> locale-gen --no-purge en_US.UTF-8
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# Install built app
+COPY --from=build-tamarin /opt/build/bin .
+
+ENV MAUDEURL="http://maude.cs.illinois.edu/w/images/5/5d/Maude-2.7.1-linux.zip"
+ENV MAUDEZIP="Maude-2.7.1-linux.zip"
+ENV MAUDEFILES="prelude.maude maude.linux64"
+
+# Install new maude maude version
+RUN cd /tmp && curl  -O ${MAUDEURL} \
+&& unzip ${MAUDEZIP} ${MAUDEFILES} -d /opt/tamarin \
+&& rm  ${MAUDEZIP}
+RUN mv maude.linux64 maude && chmod +x maude
+
+ENV RES="etc/docker/res"
+
+COPY ${RES}/README .
+
+ENV PATH=${PATH}:/opt/build/bin:/opt/tamarin
+# ENTRYPOINT ["/opt/tamarin/tamarin-prover"]
+CMD ["cat", "README" ]

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,74 +1,68 @@
-FROM fpco/stack-build:lts-16.12 as deps-tamarin
-RUN mkdir /opt/build
-WORKDIR /opt/build
-ENV DEBIAN_FRONTEND=noninteractive
-
-COPY stack.yaml stack.yaml.lock tamarin-prover.cabal /opt/build/
-RUN mkdir lib lib/export lib/theory lib/sapic lib/tools lib/term
+# Build image
+# based on bullseye, since system-ghc is too old in buster
+FROM debian:bullseye-slim AS tamarin-build
+# install build dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y --no-install-recommends install \
+        haskell-stack \
+        ca-certificates \
+        build-essential \
+        netbase \
+        locales \
+        ghc \
+        zlib1g \
+        zlib1g-dev
+WORKDIR /workspace
+# copy dependency specifications first (need stack.yaml for resolver spec)
+RUN mkdir -p lib/export lib/theory lib/sapic lib/tools lib/term
+COPY stack.yaml tamarin-prover.cabal ./
 COPY lib/sapic/tamarin-prover-sapic.cabal lib/sapic/
 COPY lib/term/tamarin-prover-term.cabal lib/term/
 COPY lib/theory/tamarin-prover-theory.cabal lib/theory/
 COPY lib/utils/tamarin-prover-utils.cabal lib/utils/
-RUN stack build --system-ghc --dependencies-only --ghc-options="+RTS -M600M" -j1
-
-FROM fpco/stack-build:lts-16.12 as build-tamarin
-# Copy compiled dependencies from previous stage
-COPY --from=deps-tamarin /root/.stack /root/.stack
-# copy all files except `etc`, because we don't want this stage to be rebuilt
-# anytime the dockerfiles change
-# docker is braindead: it copies the content of a directory, even if it is in a list
-# so we need to list them one by one
-COPY stack.yaml stack.yaml.lock tamarin-prover.cabal LICENSE /opt/build/
-COPY src  /opt/build/src
-COPY lib /opt/build/lib
-COPY data /opt/build/data
-COPY images /opt/build/images
-WORKDIR /opt/build
-RUN stack build --system-ghc
-RUN mv "$(stack path --local-install-root --system-ghc)/bin" /opt/build/bin
-
-# Base image for stack build so compiled artifact from previous
-# stage should run
-FROM debian:buster-slim as tamarin-prover
-RUN mkdir -p /opt/tamarin
-WORKDIR /opt/tamarin
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    #general stuff
-    graphviz \
-    libncurses5 \
-    bc \
-    locales \
-    curl \
-    ca-certificates \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
-
-# set locales so haskell can do it's thing
-# https://stackoverflow.com/questions/28405902/how-to-set-the-locale-inside-a-debian-ubuntu-docker-container
-# The following does NOT work -> locale-gen --no-purge en_US.UTF-8
+# cache stack package index
+RUN stack update
+# > Compiling language-javascript requires a UTF-8 locale.
+# (https://github.com/erikd/language-javascript/issues/86)
+# thankfully we're only in a temporary build container, so let's change that real quick
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+# build dependencies first, for caching
+RUN stack build --system-ghc --dependencies-only --ghc-options="+RTS -M600M"
+# now copy rest of source code
+COPY LICENSE ./
+# lib needs special handling since it already exists
+COPY lib/. ./lib/
+COPY src ./src
+COPY data ./data
+COPY images ./images
+# build the entire thing
+RUN stack build --system-ghc --local-bin-path /usr/local/bin
+RUN stack install --system-ghc --local-bin-path /usr/local/bin
 
-# Install built app
-COPY --from=build-tamarin /opt/build/bin .
-
-ENV MAUDEURL="http://maude.cs.illinois.edu/w/images/5/5d/Maude-2.7.1-linux.zip"
-ENV MAUDEZIP="Maude-2.7.1-linux.zip"
-ENV MAUDEFILES="prelude.maude maude.linux64"
-
-# Install new maude maude version
-RUN cd /tmp && curl  -O ${MAUDEURL} \
-&& unzip ${MAUDEZIP} ${MAUDEFILES} -d /opt/tamarin \
-&& rm  ${MAUDEZIP}
-RUN mv maude.linux64 maude && chmod +x maude
-
-ENV RES="etc/docker/res"
-
-COPY ${RES}/README .
-
-ENV PATH=${PATH}:/opt/build/bin:/opt/tamarin
-# ENTRYPOINT ["/opt/tamarin/tamarin-prover"]
-CMD ["cat", "README" ]
+# Assemble final image
+# again, based on buillseye, since our build linked to bullseye libs
+FROM debian:bullseye-slim
+# Metadata
+LABEL version="1.0" \
+      description="The Tamarin prover for security protocol verification" \
+      org.opencontainers.image.authors="The Tamarin prover authors"
+# install runtime dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y --no-install-recommends install \
+        maude \
+        graphviz
+COPY --from=tamarin-build /usr/local/bin /usr/local/bin
+RUN useradd -ms /bin/bash tamarin
+USER tamarin
+WORKDIR /home/tamarin
+EXPOSE 3001
+COPY etc/docker/res/README .
+CMD ["cat", "README"]
+# alternatively, launch right into tamarin
+#ENTRYPOINT ["tamarin-prover"]
+#CMD ["interactive", "--port=3001", "--interface=*4", "."]

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -57,12 +57,11 @@ RUN apt-get update && \
         maude \
         graphviz
 COPY --from=tamarin-build /usr/local/bin /usr/local/bin
+COPY etc/docker/res/entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/entrypoint.sh
 RUN useradd -ms /bin/bash tamarin
 USER tamarin
 WORKDIR /home/tamarin
 EXPOSE 3001
 COPY etc/docker/res/README .
-CMD ["cat", "README"]
-# alternatively, launch right into tamarin
-#ENTRYPOINT ["tamarin-prover"]
-#CMD ["interactive", "--port=3001", "--interface=*4", "."]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/etc/docker/build-instructions.md
+++ b/etc/docker/build-instructions.md
@@ -1,0 +1,32 @@
+# Pull and Run (and Build)
+
+These instructions define how to run the docker image.
+
+## Install docker:
+
+- Linux/MacOS: Follow [instructions](https://docs.docker.com/get-docker/)
+- In MacOS, there is a binary docker for Mac, which can be installed as
+  a [package](https://docs.docker.com/docker-for-mac/),
+  or, if you have homebrew, via `brew cask install docker`.
+
+## Pull instructions
+
+```
+TBD
+```
+
+## Run instructions
+
+1. Execute
+```
+docker run tamarin
+```
+
+2. Follow instructions.
+
+## Build instructions
+
+This is only needed for regenerating the image when we update the software.
+
+1. run `./build.sh`
+

--- a/etc/docker/build.sh
+++ b/etc/docker/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# call in top-level dir...
+docker build -t tamarin-prover:latest -f etc/docker/Dockerfile .

--- a/etc/docker/build.sh
+++ b/etc/docker/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # call in top-level dir...
-docker build -t tamarin-prover:latest -f etc/docker/Dockerfile .
+docker build -t tamarin-prover/tamarin:latest -f etc/docker/Dockerfile .

--- a/etc/docker/res/README
+++ b/etc/docker/res/README
@@ -1,7 +1,7 @@
 Use the following alias to give the image access to your host's current working
 dir (at the time of calling) and forward port 3001:
 
-alias docker-tamarin-prover='docker run -p 3001:3001 -v "$PWD:$PWD" -w "$PWD" tamarin-prover tamarin-prover'
+alias docker-tamarin-prover='docker run --rm -it -p 3001:3001 -v "$PWD:$PWD" -w "$PWD" tamarin-prover/tamarin:latest tamarin-prover'
 
 Then run "dockertamarin". Remember to use the "-i" flag in tamarin's
 interactive mode to accept clients on all interfaces, as the docker host is not

--- a/etc/docker/res/README
+++ b/etc/docker/res/README
@@ -3,7 +3,7 @@ dir (at the time of calling) and forward port 3001:
 
 alias docker-tamarin-prover='docker run --rm -it -p 3001:3001 -v "$PWD:$PWD" -w "$PWD" tamarin-prover/tamarin:latest tamarin-prover'
 
-Then run "dockertamarin". Remember to use the "-i" flag in tamarin's
+Then run "docker-tamarin-prover". Remember to use the "-i" flag in tamarin's
 interactive mode to accept clients on all interfaces, as the docker host is not
 localhost to the guest:
 

--- a/etc/docker/res/README
+++ b/etc/docker/res/README
@@ -1,0 +1,10 @@
+Use the following alias to give the image access to your host's current working
+dir (at the time of calling) and forward port 3001:
+
+alias docker-tamarin-prover='docker run -p 3001:3001 -v "$PWD:$PWD" -w "$PWD" tamarin-prover tamarin-prover'
+
+Then run "dockertamarin". Remember to use the "-i" flag in tamarin's
+interactive mode to accept clients on all interfaces, as the docker host is not
+localhost to the guest:
+
+docker-tamarin-prover interactive . -i='*4'

--- a/etc/docker/res/entrypoint.sh
+++ b/etc/docker/res/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -t 0 ]; then
+  # interactive shell
+  if [ "$#" -lt 1 ]; then
+    # no arguments given, probably looking for help
+    cat README
+  else
+    # just run whatever the user wanted
+    exec "$@"
+  fi
+else
+  cat <<'ENDOFINFO'
+--------- The Tamarin Prover Docker Image ---------
+
+It looks like you want to run Tamarin as a service.
+If you want to use it as a commandline tool, use
+`docker run --tty --interactive` for more info.
+
+---------------------------------------------------
+ENDOFINFO
+  exec /usr/local/bin/tamarin-prover \
+    interactive \
+    --port=3001 \
+    --interface='*4' \
+    "."
+fi


### PR DESCRIPTION
Hi!

This PR includes a multistage Dockerfile and  buildscript in `etc/docker`. The docker image displays a README `etc/docker/res/README` instructing the user to set up an alias that relays their working directory on port 3001 to the container. 

This solves https://github.com/tamarin-prover/tamarin-prover/issues/411 

Testing is appreciated. We could also think about putting this on dockerhub. 