### PR TITLE
Fix compatibility with GHC 9

### DIFF
--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -415,16 +415,6 @@ eitherProofContext ctxt s = if s==LHS then L.get dpcPCLeft ctxt else L.get dpcPC
 -- Instances
 ------------
 
-instance HasFrees Source where
-    foldFrees f th =
-        foldFrees f (L.get cdGoal th)   `mappend`
-        foldFrees f (L.get cdCases th)
-
-    foldFreesOcc  _ _ = const mempty
-
-    mapFrees f th = Source <$> mapFrees f (L.get cdGoal th)
-                                    <*> mapFrees f (L.get cdCases th)
-
 data DiffProofType = RuleEquivalence | None
     deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
@@ -1483,6 +1473,15 @@ instance HasFrees System where
                <*> mapFrees fun k
                <*> mapFrees fun l
 
+instance HasFrees Source where
+    foldFrees f th =
+        foldFrees f (L.get cdGoal th)   `mappend`
+        foldFrees f (L.get cdCases th)
+
+    foldFreesOcc  _ _ = const mempty
+
+    mapFrees f th = Source <$> mapFrees f (L.get cdGoal th)
+                                    <*> mapFrees f (L.get cdCases th)
 
 -- Special comparison functions to ignore new var instantiations
 ----------------------------------------------------------------

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -101,22 +101,6 @@ data JSONGraphNode = JSONGraphNode
     , jgnMetadata :: Maybe JSONGraphNodeMetadata
     } deriving (Show)
 
--- | Optional fields are not handled correctly with automatically derived instances
--- hence, we have our own here.
-instance FromJSON JSONGraphNode where
-    parseJSON = withObject "JSONGraphNode" $ \o -> JSONGraphNode
-        <$> o .: "jgnId"
-        <*> o .: "jgnType"
-        <*> o .: "jgnLabel"
-        <*> o .:? "jgnMetadata"
-
-instance ToJSON JSONGraphNode where
-    toJSON (JSONGraphNode jgnId' jgnType' jgnLabel' jgnMetadata') = object $ catMaybes
-        [ ("jgnId" .=) <$> pure jgnId'
-        , ("jgnType" .=) <$> pure jgnType'
-        , ("jgnLabel" .=) <$> pure jgnLabel'
-        , ("jgnMetadata" .=) <$> jgnMetadata' ]
-
 -- | Representation of an edge of a JSON graph.
 data JSONGraphEdge = JSONGraphEdge 
     {
@@ -146,6 +130,22 @@ data JSONGraphs = JSONGraphs
 
 -- | Derive ToJSON and FromJSON. 
 concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphEdge, ''JSONGraph, ''JSONGraphs]
+
+-- | Optional fields are not handled correctly with automatically derived instances
+-- hence, we have our own here.
+instance FromJSON JSONGraphNode where
+    parseJSON = withObject "JSONGraphNode" $ \o -> JSONGraphNode
+        <$> o .: "jgnId"
+        <*> o .: "jgnType"
+        <*> o .: "jgnLabel"
+        <*> o .:? "jgnMetadata"
+
+instance ToJSON JSONGraphNode where
+    toJSON (JSONGraphNode jgnId' jgnType' jgnLabel' jgnMetadata') = object $ catMaybes
+        [ ("jgnId" .=) <$> pure jgnId'
+        , ("jgnType" .=) <$> pure jgnType'
+        , ("jgnLabel" .=) <$> pure jgnLabel'
+        , ("jgnMetadata" .=) <$> jgnMetadata' ]
 
 -- | Generation of JSON text from JSON graphs.
 


### PR DESCRIPTION
GHC 9 is more strict on instance ordering:
https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#the-order-of-th-splices-is-more-important