### PR TITLE
Fix SAPIC for OCaml 4.12

### DIFF
--- a/plugins/sapic/position.ml
+++ b/plugins/sapic/position.ml
@@ -6,7 +6,7 @@ let pos2string  = List.fold_left (fun s i -> string_of_int(i)^s) ""
 
 type t = position
 let compare (s1:position) (s2:position) = match (s1,s2) with
-    (a::ar,b::br) -> if compare a b = 0 then compare ar br else compare a b
+    (a::ar,b::br) -> if Stdlib.compare a b = 0 then Stdlib.compare ar br else Stdlib.compare a b
   |(a::ar,[]) -> 1
   |([],b::br)-> -1
   |([],[]) -> 0

--- a/plugins/sapic/var.ml
+++ b/plugins/sapic/var.ml
@@ -29,7 +29,7 @@ let compare s1 s2 =
                 | (Temp(n1),Temp(n2)) 
                 | (Msg(n1),Msg(n2)) -> (String.compare n1 n2)
                 (* needs to be a total order! *)
-        | (a,b)  -> compare (rank a) (rank b)
+        | (a,b)  -> Stdlib.compare (rank a) (rank b)
 
 let var2string = function 
         | PubFixed(name) -> "'"^name^"'"


### PR DESCRIPTION
List.compare shadows Stdlib.compare since 4.12, which breaks SAPIC with the following errors:

```
File "position.ml", line 9, characters 32-33:
9 |     (a::ar,b::br) -> if compare a b = 0 then compare ar br else compare a b
                                    ^
Error: This expression has type int but an expression was expected of type
         'a -> 'a -> int
```

```
File "var.ml", line 32, characters 28-36:
32 |         | (a,b)  -> compare (rank a) (rank b)
                                 ^^^^^^^^
Error: This expression has type int but an expression was expected of type
         'a -> 'a -> int
```

This PR refers to Stdlib explicitly which fixes the build, but raises minimum required version of OCaml to 4.07.

For more info, please refer to the upstream PR: https://github.com/ocaml/ocaml/pull/9668