### PR TITLE
Allow optional trailing commas in lists

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -235,11 +235,11 @@ naturalSubscript = T.lexeme spthy $ do
 
 -- | A comma separated list of elements.
 commaSep :: Parser a -> Parser [a]
-commaSep = T.commaSep spthy
+commaSep = flip sepEndBy comma
 
 -- | A comma separated non-empty list of elements.
 commaSep1 :: Parser a -> Parser [a]
-commaSep1 = T.commaSep1 spthy
+commaSep1 = flip sepEndBy1 comma
 
 -- | Parse a list of items '[' item ',' ... ',' item ']'
 list :: Parser a -> Parser [a]

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -233,15 +233,15 @@ naturalSubscript = T.lexeme spthy $ do
     subscriptDigitToInteger d = toInteger $ fromEnum d - fromEnum '₀'
 
 
--- | A comma separated list of elements.
+-- | A comma separated list of elements, optionally ended with a comma.
 commaSep :: Parser a -> Parser [a]
 commaSep = flip sepEndBy comma
 
--- | A comma separated non-empty list of elements.
+-- | A comma separated non-empty list of elements, optionally ended with a comma.
 commaSep1 :: Parser a -> Parser [a]
 commaSep1 = flip sepEndBy1 comma
 
--- | Parse a list of items '[' item ',' ... ',' item ']'
+-- | Parse a list of items '[' item ',' ... ',' item ']', or ended with ',]'
 list :: Parser a -> Parser [a]
 list = brackets . commaSep
 


### PR DESCRIPTION
When e.g. working with rules like

```tamarin
[
  A,
  B,
  C
] --> [ .. ]
```

It's sometimes helpful to be able to reorder rows, or e.g. comment out C:

```tamarin
[
  A,
  C
  B,
] --> [ .. ]

[
  A,
  B,
// C
] --> [ .. ]
```

but unfortunately the parser doesn't currently allow to do this without paying careful attention to the commas. 

This PR allows a comma to follow