### PR TITLE
Fresh order

### DIFF
--- a/lib/term/src/Term/Term.hs
+++ b/lib/term/src/Term/Term.hs
@@ -43,6 +43,7 @@ module Term.Term (
 
     -- ** "Protected" subterms
     , allProtSubterms
+    , elemNotBelowReducible
 
     -- * AC, C, and NonAC funcion symbols
     , FunSym(..)
@@ -93,6 +94,7 @@ module Term.Term (
 -- import           Data.Monoid
 -- import           Data.Foldable (foldMap)
 
+import qualified Data.Set              as S
 import qualified Data.ByteString.Char8 as BC
 import           Extension.Data.ByteString ()
 
@@ -218,6 +220,17 @@ allProtSubterms t@(viewTerm -> FApp _ as) | isPair t || isAC t
 allProtSubterms t@(viewTerm -> FApp _ as) | otherwise
         = t:concatMap allProtSubterms as
 allProtSubterms _                                     = []
+
+-- | Is term @inner@ in term @outer@ and not below a reducible function symbol?
+-- This is used for the Subterm relation
+elemNotBelowReducible :: Eq a => FunSig -> Term a -> Term a -> Bool
+elemNotBelowReducible _ inner outer
+                      | inner == outer = True
+elemNotBelowReducible reducible inner (viewTerm -> FApp f as)
+                      | f `S.notMember` reducible
+                            = any (elemNotBelowReducible reducible inner) as
+elemNotBelowReducible _ _ _ = False
+
 
 ----------------------------------------------------------------------
 -- Pretty printing

--- a/lib/term/src/Term/Unification.hs
+++ b/lib/term/src/Term/Unification.hs
@@ -64,6 +64,7 @@ module Term.Unification (
   , funSyms
   , stRules
   , irreducibleFunSyms
+  , reducibleFunSyms
   , noEqFunSyms
   , addFunSym
   , addCtxtStRule

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -402,7 +402,7 @@ insertImpliedFormulas = do
 
 -- | CR-rule *S_fresh-order*:
 --
--- `i:f`, `j:g`, `t1 ⊏ s1`, ..., `t_(n-1) ⊏ s_(n-1)`
+-- `i:f`, `j:g`
 -- -- insert --
 -- `i<j`
 -- *with `prems(f)u = Fr(~s)` and `prems(g)v = Fact(t))`*


### PR DESCRIPTION
Hi,

I'd like to introduce the following simplification CR-rule *S_fresh-order*:

`i:f`, `j:g`
-- insert --
`i<j`
*with `prems(f)u = Fr(~s)` and `prems(g)v = Fact(t))`*
*if `s` is syntactically in `t` and not below a reducible operator*

Reducible operators are all operators f that are on the left side and on the top of an equation: `f(...) = ...` This does not include AC-equations, i.e., `+` is not reducible.

I proved soundness and completeness for the extended version which uses subterms (though this is not yet in this pull request):

`i:f`, `j:g`, `t1 ⊂ s1`, ..., `t_(n-1) ⊂ s_(n-1)`
-- insert --
`i<j`
*with `prems(f)u = Fr(~s0)` and `prems(g)v = Fact(tn))`*
*if `si` is syntactically in `t_(i+1)` and not below a reducible operator*

# Example:

Consider this minimal example:
```
theory FreshOrderingTest
begin

builtins: hashing

rule Start:
    [ Fr(~s) ]
  --[ Start(~s) ]->
    [ State(~s, h(~s)) ]

rule Step:
    [ State(s, x) ]
  --[ Step(s) ]->
    [ State(s, h(x))]

lemma Order:
	"All s #i #j. Start(s)@i ∧ Step(s)@j ⇒ i<j"

end
```
With *S_fresh-order*, this lemma is directly provable by simplification, otherwise I didn't manage to prove it.

# Regression Tests:

I ran the regression tests, but did not yet include them in this branch - should I do this?
The outcome is roughly:
- quite some case studies (i would guess 10%) take fewer steps to complete
- for the other case studies, the runtime is about 10-20% worse

I think the bad runtime is because each time before adding a new edge `(i,j)`, it has to be checked wether it is already entailed by the existing less relation (`alwaysBefore`).
