### PR TITLE
Extra features for preprocessing

### DIFF
--- a/examples/testParser/define.spthy
+++ b/examples/testParser/define.spthy
@@ -1,0 +1,89 @@
+theory define
+
+begin
+
+#ifdef A
+
+rule testA:
+[]--[A()]->[]
+
+#endif
+
+#ifdef not A
+
+rule testnoA:
+[]--[NoA()]->[]
+
+#endif
+
+
+#ifdef B
+
+rule testB:
+[]--[B()]->[]
+
+#else
+
+rule testnoB:
+[]--[NoB()]->[]
+
+#endif
+
+
+lemma reachA:
+ exists-trace
+ "Ex #i. A()@i"
+
+lemma reachnoA:
+ exists-trace
+ "Ex #i. NoA()@i"
+
+
+lemma reachB:
+ exists-trace
+ "Ex #i. B()@i"
+
+lemma reachnotB:
+ exists-trace
+ "Ex #i. NoB()@i"
+
+
+#ifdef C
+
+#define D
+rule testC:
+[]--[C()]->[]
+
+
+#endif
+
+#ifdef D
+
+rule testD:
+[]--[D()]->[]
+
+#endif
+
+
+#ifdef D & C
+
+rule testDC:
+[]--[DC()]->[]
+
+#endif
+
+
+lemma reachC:
+ exists-trace
+ "Ex #i. C()@i"
+
+lemma reachDorC:
+ exists-trace
+ "Ex #i. D()@i"
+
+lemma reachDandC:
+ exists-trace
+ "Ex #i. DC()@i"
+
+
+end

--- a/examples/testParser/include/include/include4.spthy
+++ b/examples/testParser/include/include/include4.spthy
@@ -1,0 +1,2 @@
+rule test:
+ [In(<x,y>)]--[Equal(f1(x),f2(y)), Test()]->[]

--- a/examples/testParser/include/include3.spthy
+++ b/examples/testParser/include/include3.spthy
@@ -1,0 +1,4 @@
+
+equations: f2(x) = f1(x)
+
+#include "include/include4.spthy"

--- a/examples/testParser/include1.spthy
+++ b/examples/testParser/include1.spthy
@@ -1,0 +1,21 @@
+theory Yubikey
+begin
+
+section{* Include Test*}
+
+
+builtins: symmetric-encryption
+
+functions: f1/1
+
+#include "include2.spthy"
+
+#include "include/include3.spthy"
+
+restriction eq:
+  "All x y #t. Equal(x,y)@t ==> x=y"
+
+lemma test:
+ exists-trace
+ "Ex #t. Test()@t"
+end

--- a/examples/testParser/include2.spthy
+++ b/examples/testParser/include2.spthy
@@ -1,0 +1,1 @@
+functions: f2/1

--- a/examples/testParser/includeDiff.spthy
+++ b/examples/testParser/includeDiff.spthy
@@ -1,0 +1,18 @@
+theory Yubikey
+begin
+
+section{* Include Test*}
+
+
+builtins: symmetric-encryption
+
+functions: f1/1
+
+#include "include2.spthy"
+
+#include "include/include3.spthy"
+
+rule test2:
+ [In(<x,y>)]--[Equal(f1(x),diff(f2(y),f1(y))), Test()]->[]
+
+end

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -333,17 +333,32 @@ diffTheory inFile = do
        modifyStateFlag (S.insert flag)
        addItems inFile0 thy
 
-    ifdef :: Maybe FilePath -> OpenDiffTheory -> Parser OpenDiffTheory
+    ifdef :: Maybe FilePath -> OpenDiffTheory ->  Parser OpenDiffTheory
     ifdef inFile0 thy = do
        flag <- symbol_ "#ifdef" *> identifier
        flags0 <- flags <$> getState
        if flag `S.member` flags0
          then do thy' <- addItems inFile0 thy
-                 symbol_ "#endif"
-                 addItems inFile0 thy'
-         else do _ <- manyTill anyChar (try (string "#"))
-                 symbol_ "endif"
-                 addItems inFile0 thy
+                 asum [do symbol_ "#else"
+                          _ <- manyTill anyChar (try (symbol_ "#endif"))
+                          addItems inFile0 thy'
+                       ,do symbol_ "#endif"
+                           addItems inFile0 thy'
+                      ]
+
+         else parseelse
+         where
+           parseelse =
+             do _ <- manyTill anyChar (try (symbol_ "#"))
+                asum
+                 [do (symbol_ "else")
+                     thy' <- addItems inFile0 thy
+                     symbol_ "#endif"
+                     addItems inFile0 thy'
+                 ,do _ <- symbol_ "endif"
+                     addItems inFile0 thy
+                 , parseelse
+                 ]
 
     include :: Maybe FilePath -> OpenDiffTheory -> Parser OpenDiffTheory
     include inFile0 thy = do

--- a/lib/theory/src/Theory/Text/Parser/Restriction.hs
+++ b/lib/theory/src/Theory/Text/Parser/Restriction.hs
@@ -63,7 +63,7 @@ toRestriction rstr = Restriction (pRstrName rstr) (pRstrFormula rstr)
 
 -- | Parse a lemma for an open theory from a string.
 parseRestriction :: String -> Either ParseError SyntacticRestriction
-parseRestriction = parseString "<unknown source>" restriction
+parseRestriction = parseString [] "<unknown source>" restriction
 
 -- | Parse a 'RestrictionAttribute'.
 restrictionAttribute :: Parser RestrictionAttribute

--- a/lib/theory/src/Theory/Text/Parser/Rule.hs
+++ b/lib/theory/src/Theory/Text/Parser/Rule.hs
@@ -40,7 +40,7 @@ import Theory.Text.Parser.Let
 import Theory.Text.Parser.Fact
 import Theory.Text.Parser.Term
 import Theory.Text.Parser.Formula
-import Theory.Sapic ( AnProcess(ProcessNull) )
+
 
 
 -- | Parse a "(modulo ..)" information.
@@ -81,7 +81,7 @@ ruleAttribute = asum
             Nothing -> fail $ "Color code " ++ show hc ++ " could not be parsed to RGB"
     parseAndIgnore = do
                         _ <-  symbol "\""
-                        _ <- manyTill anyChar (try (symbol "\"")) 
+                        _ <- manyTill anyChar (try (symbol "\""))
                         return Nothing
 
 ruleAttributesp :: Parser [RuleAttribute]
@@ -190,5 +190,5 @@ addFacts cmd =
 parseIntruderRules
     :: MaudeSig -> String -> B.ByteString -> Either ParseError [IntrRuleAC]
 parseIntruderRules msig ctxtDesc =
-    parseString ctxtDesc (setState msig >> many intrRule)
+    parseString [] ctxtDesc (setState (mkStateSig msig) >> many intrRule)
   . T.unpack . TE.decodeUtf8

--- a/lib/theory/src/Theory/Text/Parser/Term.hs
+++ b/lib/theory/src/Theory/Text/Parser/Term.hs
@@ -41,8 +41,8 @@ llitNoPub = asum [freshTerm <$> freshName, varTerm <$> msgvar]
 -- if the operator is not known.
 lookupArity :: String -> Parser (Int, Privacy)
 lookupArity op = do
-    maudeSig <- getState
-    case lookup (BC.pack op) (S.toList (noEqFunSyms maudeSig) ++ [(emapSymString, (2,Public))]) of
+    maudeSig <- sig <$> getState
+    case lookup (BC.pack op) (S.toList (noEqFunSyms $ maudeSig) ++ [(emapSymString, (2,Public))]) of
         Nothing    -> fail $ "unknown operator `" ++ op ++ "'"
         Just (k,priv) -> return (k,priv)
 
@@ -82,7 +82,7 @@ diffOp eqn plit = do
   ts <- symbol "diff" *> parens (commaSep (msetterm eqn plit))
   when (2 /= length ts) $ fail
     "the diff operator requires exactly 2 arguments"
-  diff <- enableDiff <$> getState
+  diff <- enableDiff . sig <$> getState
   when eqn $ fail
     "diff operator not allowed in equations"
   unless diff $ fail
@@ -106,10 +106,10 @@ term plit eqn = asum
     application = asum $ map (try . ($ plit)) [naryOpApp eqn, binaryAlgApp eqn, diffOp eqn]
     pairing = angled (tupleterm eqn plit)
     nullaryApp = do
-      maudeSig <- getState
+      maudeSig <- sig <$> getState
       -- FIXME: This try should not be necessary.
       asum [ try (symbol (BC.unpack sym)) *> pure (fApp (NoEq (sym,(0,priv))) [])
-           | NoEq (sym,(0,priv)) <- S.toList $ funSyms maudeSig ]
+           | NoEq (sym,(0,priv)) <- S.toList $ funSyms $ maudeSig ]
 
 -- | A left-associative sequence of exponentations.
 expterm :: Ord l => Bool -> Parser (Term l) -> Parser (Term l)
@@ -118,7 +118,7 @@ expterm eqn plit = chainl1 (term plit eqn) (curry fAppExp <$ opExp)
 -- | A left-associative sequence of multiplications.
 multterm :: Ord l => Bool -> Parser (Term l) -> Parser (Term l)
 multterm eqn plit = do
-    dh <- enableDH <$> getState
+    dh <- enableDH . sig  <$> getState
     if dh && not eqn -- if DH is not enabled, do not accept 'multterm's and 'expterm's
         then chainl1 (expterm eqn plit) ((\a b -> fAppAC Mult [a,b]) <$ opMult)
         else term plit eqn
@@ -126,7 +126,7 @@ multterm eqn plit = do
 -- | A left-associative sequence of xors.
 xorterm :: Ord l => Bool -> Parser (Term l) -> Parser (Term l)
 xorterm eqn plit = do
-    xor <- enableXor <$> getState
+    xor <- enableXor . sig <$> getState
     if xor && not eqn-- if xor is not enabled, do not accept 'xorterms's
         then chainl1 (multterm eqn plit) ((\a b -> fAppAC Xor [a,b]) <$ opXor)
         else multterm eqn plit
@@ -134,7 +134,7 @@ xorterm eqn plit = do
 -- | A left-associative sequence of multiset unions.
 msetterm :: Ord l => Bool -> Parser (Term l) -> Parser (Term l)
 msetterm eqn plit = do
-    mset <- enableMSet <$> getState
+    mset <- enableMSet . sig <$> getState
     if mset && not eqn-- if multiset is not enabled, do not accept 'msetterms's
         then chainl1 (xorterm eqn plit) ((\a b -> fAppAC Union [a,b]) <$ opPlus)
         else xorterm eqn plit

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -97,6 +97,12 @@ module Theory.Text.Parser.Token (
   , commaSep1
   , list
 
+  -- * Parsing State
+  , ParserState(..)
+  , mkStateSig
+  , modifyStateSig
+  , modifyStateFlag
+
     -- * Basic Parsing
   , Parser
   , parseFile
@@ -107,7 +113,13 @@ module Theory.Text.Parser.Token (
 import           Prelude             hiding (id, (.))
 
 import           Data.Foldable       (asum)
+-- import           Data.Label
+-- import           Data.Binary
 import           Data.List (foldl')
+-- import           Control.DeepSeq
+import qualified Data.Set                   as S
+
+-- import           GHC.Generics                        (Generic)
 
 import           Control.Applicative hiding (empty, many, optional)
 import           Control.Category
@@ -127,15 +139,42 @@ import Data.Functor.Identity
 -- Parser
 ------------------------------------------------------------------------------
 
+data ParserState = PState
+       { sig  :: MaudeSig              -- Current signature
+       , flags ::  S.Set String        -- Defined flags for pre-processing
+       }
+       deriving( Eq, Ord, Show )
+
+-- | A monoid instance to combine parser signatures.
+instance Semigroup ParserState where
+ PState sig1 flags1 <> PState sig2 flags2 =
+   PState (sig1 <> sig2) (flags1 `S.union` flags2)
+
+instance Monoid ParserState where
+  mempty = PState {sig=mempty, flags = S.empty}
+
+mkStateSig :: MaudeSig -> ParserState
+mkStateSig sign = mempty {sig=sign}
+
+modifyStateSig ::  Monad m => (MaudeSig -> MaudeSig) -> ParsecT s ParserState m ()
+modifyStateSig modifier = do
+   st <- getState
+   setState (st {sig = modifier $ sig st})
+
+modifyStateFlag ::  Monad m => (S.Set String -> S.Set String) -> ParsecT s ParserState m ()
+modifyStateFlag modifier = do
+   st <- getState
+   setState (st {flags = modifier $ flags st})
+
 -- | A parser for a stream of tokens.
-type Parser a = Parsec String MaudeSig a
+type Parser a = Parsec String ParserState a
 
 -- We can throw exceptions, but not catch them
-instance Catch.MonadThrow (ParsecT String MaudeSig Data.Functor.Identity.Identity) where
+instance Catch.MonadThrow (ParsecT String ParserState Data.Functor.Identity.Identity) where
     throwM e = fail (show e)
 
 -- Use Parsec's support for defining token parsers.
-spthy :: T.TokenParser MaudeSig
+spthy :: T.TokenParser ParserState
 spthy =
     T.makeTokenParser spthyStyle
   where
@@ -154,7 +193,7 @@ spthy =
       }
 
 -- | Run a parser on the contents of a file.
-parseFileWState :: MaudeSig -> Parser a -> FilePath -> IO a
+parseFileWState :: ParserState -> Parser a -> FilePath -> IO a
 parseFileWState initState parser inFile = do
     inp <- readFile inFile
     case parseStringWState initState inFile parser inp of
@@ -162,7 +201,7 @@ parseFileWState initState parser inFile = do
         Left err -> error $ show err
 
 -- | Run a given parser on a given string.
-parseStringWState :: MaudeSig
+parseStringWState :: ParserState
             -> FilePath
             -- ^ Description of the source file. (For error reporting.)"
             -> Parser a
@@ -173,21 +212,22 @@ parseStringWState initState srcDesc parser =
                                            -- was "minimalMaudeSig" -> could lead to errors with parsing diff terms!
 
 -- | Run a given parser on a given string.
-parseString :: FilePath
+parseString :: [String] -- flags
+            -> FilePath
             -- ^ Description of the source file. (For error reporting.)"
             -> Parser a
             -> String         -- ^ Input string.
             -> Either ParseError a
-parseString = parseStringWState pairMaudeSig
+parseString flags0 = parseStringWState $ mempty {sig=pairMaudeSig, flags=S.fromList flags0}
 
-parseFile :: Parser a -> FilePath -> IO a
-parseFile = parseFileWState pairMaudeSig
+parseFile :: [String] -> Parser a -> FilePath -> IO a
+parseFile flags0 = parseFileWState $ mempty {sig=pairMaudeSig, flags=S.fromList flags0}
 
 
 -- Token parsers
 ----------------
 
-lexeme :: ParsecT String MaudeSig Identity a -> ParsecT String MaudeSig Identity a
+lexeme :: ParsecT String ParserState Identity a -> ParsecT String ParserState Identity a
 lexeme = T.lexeme spthy
 
 -- | Parse a symbol.
@@ -495,16 +535,6 @@ opNull = symbol_ "0"
 -- File Path
 -- | Parse a file path, returned with the given prefix s
 filePath :: Parser FilePath
-filePath = many char
---  parseDir s
+filePath = many charDir
   where
-    parseDir fp = asum
-         [  do dir <- identifier
-               _   <- opSlash
-               parseDir (fp <> dir <> [pathSeparator])
-         , do fn <- identifier
-              _ <- symbol "."
-              ext <- identifier
-              return (fp <> fn <> "." <> ext)]
-
-    char = alphaNum <|> oneOf ("." <> [pathSeparator])
+    charDir = alphaNum <|> oneOf ("." <> [pathSeparator])


### PR DESCRIPTION
Slightly expand the preprocessing capabilities.

 * Instructions `#ifdef f` can now support an `#else` branch, and `f`can be a boolean formula over tags.
 * The new instruction `#include "relative/path/to/file.spthy"` allows to include the content of a file. The behavior is recursive, and error reporting corresponds to the file the error is in.
 
As a side effect, the state of the parser was extended, to contain the current set of flags.

Regression tests are not affected. 