### PR TITLE
Plain open goals

### DIFF
--- a/examples/regression/trace/MinValueEq.spthy
+++ b/examples/regression/trace/MinValueEq.spthy
@@ -1,0 +1,14 @@
+theory MinValueEq
+begin
+
+rule AttackerMsg:
+    [ In(x) ]
+  --[ Value(x) ]->
+    [ ]
+
+// should fail
+lemma WrongEquality:
+"All a b #i #j. Value(a)@i & Value(b)@j ⇒ a=b"
+
+
+end

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -239,7 +239,7 @@ execProofMethod ctxt method sys =
       case method of
         Sorry _                  -> return M.empty
         Solved
-          | null (plainOpenGoals sys) -> return M.empty
+          | null (openGoals sys) -> return M.empty
           | otherwise                 -> Nothing 
         SolveGoal goal
           | goal `M.member` L.get sGoals sys -> execSolveGoal goal


### PR DESCRIPTION
Hi,

I found that Tamarin misbehaves on the example `MinValueEq` included in this PR:
- The proof should fail with a contradiction "found trace"
- Instead, the proof just says "sorry" and no goals are left to prove without showing a contradiction (in the interactive mode, I cannot click on a goal any more)

Furthermore, I found, that this error was introduced in #394 (before that change, Tamarin correctly falsified the lemma; with that change, Tamarin says "sorry")

When I replace "plainOpenGoals" by "openGoals" as done in this PR, it gives back the original behaviour while still being able to cope with the example in #394. Also, the regression tests run trough with my change.

I do not really understand the reasoning of @yavivanov on why the plainOpenGoals are necessary.

Best, Philip