### PR TITLE
Deleted unnecessary lemmas mentioned in issue #438.

### DIFF
--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
@@ -134,12 +134,6 @@ lemma Login_reachable:
   exists-trace
   "Ex #i pid sid x otp1. Login(pid,sid,x,otp1)@i"
 
-// Each succesful login with counter value x was preceeded by a PressButton
-// event with the same counter value
-lemma one_count_foreach_login[reuse,use_induction]:
-        "All pid sid x otp  #t2 . Login(pid,sid,x,otp)@t2 ==>
-         ( Ex #t1  . YubiPress(pid,x)@#t1 & #t1<#t2 )"
-
 // If a succesful Login happens before a second sucesfull Login, the
 // counter value of the first is smaller than the counter value of the
 // second

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
@@ -252,15 +252,6 @@ lemma otp_decode_does_not_help_adv_use_induction[reuse,use_induction]:
     "All #t3 k2 k m sc enc mac . OtpDecode(k2,k,m,sc,enc,mac)@t3
     ==> Ex #t1 pid . YubiPress(pid,sc)@#t1 & #t1<#t3"
 
-/* All keys shared between the YubiHSM and the Authentication Server are
- * either not known to the adversary, or the adversary learned the key used
- * to encrypt said keys in form of AEADs.
- */
-lemma k2_is_secret_use_induction[use_induction,reuse]:
-    "All #t1 #t2 pid k2 . Init(pid,k2)@t1 & K(k2)@t2
-    ==>
-     (Ex #t3 #t4 k . K(k)@t3 & MasterKey(k)@t4 & #t3<#t2)"
-
 /* Neither of those kinds of keys are ever learned by the adversary */
 lemma neither_k_nor_k2_are_ever_leaked_inv[use_induction,reuse]: 
     " 
@@ -272,7 +263,7 @@ not( Ex #t1 #t2 k . MasterKey(k)@t1 & KU(k)@t2 )
 // event with the same counter value
 // This lemma cannot be proven at the moment, but it would be a first step
 // to reach the no_replay result present in Yubikey.spthy
-lemma one_count_foreach_login[reuse,use_induction]:
+lemma one_count_foreach_login[use_induction]:
         "All pid sid x otp  #t2 . Login(pid,sid,x,otp)@t2 ==>
          ( Ex #t1  . YubiPress(pid,x)@#t1 & #t1<#t2 )"
 induction

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
@@ -197,14 +197,6 @@ restriction onetime:
 //  exists-trace
 //  "Ex #i pid sid x otp1. Login(pid,sid, x, otp1)@i"
 
-/* Every counter produced by a Yubikey could be computed by the adversary
- * anyway. (This saves a lot of steps in the backwards induction of the
- * following lemmas).
-*/
-lemma adv_can_guess_counter[reuse,use_induction]:
-    "All pid sc #t2 . YubiPress(pid,sc)@t2
-    ==> (Ex #t1 . K(sc)@#t1 & #t1<#t2)"
-
 /* Everything that can be learned by using OtpDecode is the counter of a
  * Yubikey, which can be computed according to the previous lemma.
 */
@@ -212,29 +204,12 @@ lemma otp_decode_does_not_help_adv_use_induction[reuse,use_induction]:
     "All #t3 k2 k m sc enc mac . OtpDecode(k2,k,m,sc,enc,mac)@t3
     ==> Ex #t1 pid . YubiPress(pid,sc)@#t1 & #t1<#t3"
 
-/* All keys shared between the YubiHSM and the Authentication Server are
- * either not known to the adversary, or the adversary learned the key used
- * to encrypt said keys in form of AEADs.
- */
-lemma k2_is_secret_use_induction[use_induction,reuse]:
-    "All #t1 #t2 pid k2 . Init(pid,k2)@t1 & K(k2)@t2
-    ==>
-     (Ex #t3 #t4 k . K(k)@t3 & MasterKey(k)@t4 & #t3<#t2)"
-
 /* Neither of those kinds of keys are ever learned by the adversary */
 lemma neither_k_nor_k2_are_ever_leaked_inv[use_induction,reuse]: 
     " 
 not( Ex #t1 #t2 k . MasterKey(k)@t1 & KU(k)@t2 )
 & not (Ex  #t5 #t6 k6 pid . Init(pid,k6)@t5 & KU(k6)@t6 )
     "
-
-// Each succesful login with counter value x was preceeded by a PressButton
-// event with the same counter value
-// This lemma cannot be proven at the moment, but it would be a first step
-// to reach the no_replay result present in Yubikey.spthy
-lemma one_count_foreach_login[reuse,use_induction]:
-        "All pid sid x otp  #t2 . Login(pid,sid,x,otp)@t2 ==>
-         ( Ex #t1  . YubiPress(pid,x)@#t1 & #t1<#t2 )"
 
 // If a successful Login happens before a second successful Login, the
 // counter value of the first is smaller than the counter value of the

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_multiset.spthy
@@ -102,12 +102,6 @@ lemma Login_reachable:
   exists-trace
   "Ex #i pid sid x otp1. Login(pid,sid,x,otp1)@i"
 
-// Each succesful login with counter value x was preceeded by a PressButton
-// event with the same counter value
-lemma one_count_foreach_login[reuse,use_induction]:
-        "All pid sid x otp  #t2 . Login(pid,sid,x,otp)@t2 ==>
-         ( Ex #t1  . YubiPress(pid,x)@#t1 & #t1<#t2 )"
-
 // If a succesful Login happens before a second sucesfull Login, the
 // counter value of the first is smaller than the counter value of the
 // second

--- a/examples/sapic/slow/PKCS11/pkcs11-templates.spthy
+++ b/examples/sapic/slow/PKCS11/pkcs11-templates.spthy
@@ -275,38 +275,6 @@ lemma dec_limits[use_induction, reuse]:
         /*    ) @ t )) */
         "
 
-//automatic ATM
-//lemma get_keyvalue[sources]: 
-//    "All k #t2 . GetKeyValue(k)@t2 ==> Ex L_h #t1 . NewKey(L_h,k,'off')@t1"
-
-//automatic ATM
-lemma trusted_as_ut_impossible[reuse]: 
-    "not (Ex L_h k wrap unwrap enc dec sens extr trus wwt wt #t.
-        Insert( <'obj', L_h>,
-                   <k, wrap, unwrap, enc, dec, sens, extr, trus, wwt, wt, 'trusted'>
-           ) @ t )"
-
-//automatic ATM
-lemma untrusted_as_ut_impossible[reuse]: 
-    "not (Ex L_h k wrap unwrap enc dec sens extr trus wwt wt #t.
-        Insert( <'obj', L_h>,
-                   <k, wrap, unwrap, enc, dec, sens, extr, trus, wwt, wt, 'untrusted'>
-           ) @ t )"
-
-//automatic ATM
-lemma untrusted_as_wt_impossible[reuse]: 
-    "not (Ex L_h k wrap unwrap enc dec sens extr trus wwt ut #t.
-        Insert( <'obj', L_h>,
-                   <k, wrap, unwrap, enc, dec, sens, extr, trus, wwt, 'untrusted', ut>
-           ) @ t )"
-
-//automatic ATM
-lemma trusted_as_wt_impossible[reuse]: 
-    "not (Ex L_h k wrap unwrap enc dec sens extr trus wwt ut #t.
-        Insert( <'obj', L_h>,
-                   <k, wrap, unwrap, enc, dec, sens, extr, trus, wwt, 'trusted', ut>
-           ) @ t )"
-
 //currently automatic with lots of time Di 14 Okt 2014 19:21:24 CEST
 
 //need to instantiate insert at t2.2 and t2.1 early, see bad_keys-my_policy_manual_part.spthy

--- a/examples/sapic/slow/Yubikey/Yubikey.spthy
+++ b/examples/sapic/slow/Yubikey/Yubikey.spthy
@@ -106,14 +106,14 @@ lemma one_count_foreach_login[reuse,use_induction]:
 
 /* // It is not possible to have to distinct logins with the same counter */
 /* // value */
-lemma no_replay[reuse]:
+lemma no_replay:
         "not (Ex #i #j pid k x .
          Login(pid,k,x)@i &  Login(pid,k,x)@j 
          & not(#i=#j))"
 
 
 
-lemma injective_correspondance[reuse, use_induction]:
+lemma injective_correspondance[use_induction]:
     "All pid k x #t2 . Login(pid,k,x)@t2 ==>
          ( Ex #t1 sid . YubiPress(pid,sid,k,x)@#t1 & #t1<#t2 )
         & All #t3 . Login(pid,k,x)@t3 ==> #t3=#t2


### PR DESCRIPTION
Removed unnecessary lemmas or `[reuse]` in five example files, see https://github.com/tamarin-prover/tamarin-prover/issues/438