### PR TITLE
Parse node-sorted variables in predicate invocations

### DIFF
--- a/examples/sapic/fast/feature-predicates/timepoints.spthy
+++ b/examples/sapic/fast/feature-predicates/timepoints.spthy
@@ -1,0 +1,12 @@
+theory TestPredicate begin
+
+rule ActionRule: [] --[Action('hi')]-> []
+
+predicates: Exists(#time) <=> (∃ val. Action(val)@time)
+
+lemma hi:
+  exists-trace "∃ #t. Exists(#t)"
+
+
+end
+

--- a/lib/theory/src/Theory/Text/Parser/Formula.hs
+++ b/lib/theory/src/Theory/Text/Parser/Formula.hs
@@ -33,7 +33,8 @@ blatom :: Parser (SyntacticAtom BLTerm)
 blatom = fmap (fmapTerm (fmap Free)) <$> asum
   [ Last        <$> try (symbol "last" *> parens nodevarTerm)        <?> "last atom"
   , flip Action <$> try (fact llit <* opAt)        <*> nodevarTerm   <?> "action atom"
-  , Syntactic . Pred <$> try (fact llit)                             <?> "predicate atom"
+  , Syntactic . Pred <$> try (fact llitWithNode )                    <?> "predicate atom"
+      -- (Predicates can be called for timepoints in addition to other logical vars)
   , Less        <$> try (nodevarTerm <* opLess)    <*> nodevarTerm   <?> "less atom"
   , EqE         <$> try (msetterm False llit <* opEqual) <*> msetterm False llit <?> "term equality"
   , EqE         <$>     (nodevarTerm  <* opEqual)  <*> nodevarTerm   <?> "node equality"

--- a/lib/theory/src/Theory/Text/Parser/Term.hs
+++ b/lib/theory/src/Theory/Text/Parser/Term.hs
@@ -13,6 +13,7 @@ module Theory.Text.Parser.Term (
     , llit
     , term
     , llitNoPub
+    , llitWithNode
 )
 where
 
@@ -32,6 +33,10 @@ import           Theory.Text.Parser.Token
 -- | Parse an lit with logical variables.
 llit :: Parser LNTerm
 llit = asum [freshTerm <$> freshName, pubTerm <$> pubName, varTerm <$> msgvar]
+
+-- | Parse an lit with logical variables including timepoint variables
+llitWithNode :: Parser LNTerm
+llitWithNode = asum [freshTerm <$> freshName, pubTerm <$> pubName, varTerm <$> lvar]
 
 -- | Parse an lit with logical variables without public names in single constants.
 llitNoPub :: Parser LNTerm


### PR DESCRIPTION
Fixes https://github.com/tamarin-prover/tamarin-prover/issues/455

(I've ran `make sapic-case-studies-fast` to test.)