### PR TITLE
Fix SAPiC locking restriction

### DIFF
--- a/case-studies-regression/sapic/fast/GJM-contract/contract_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/GJM-contract/contract_analyzed.spthy
@@ -61,7 +61,7 @@ solve( State_111121212111( ct, pk2, sk1, skT ) ▶₀ #i )
                  ∧
                   (#vr.41 < #t2) ∧
                   (#t2 < #vr.51) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, ct ) @ #t0)
                    ⇒
@@ -85,7 +85,7 @@ solve( State_111121212111( ct, pk2, sk1, skT ) ▶₀ #i )
                  ∧
                   (#vr.41 < #t2) ∧
                   (#t2 < #vr.51) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, ct ) @ #t0)
                    ⇒
@@ -1239,7 +1239,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1255,7 +1255,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1271,7 +1271,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1286,7 +1286,7 @@ restriction locking_2:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1296,7 +1296,7 @@ analyzing: examples/sapic/fast/GJM-contract/contract.spthy
 analyzed: examples/sapic/fast/GJM-contract/contract.spthy
 
   output:          examples/sapic/fast/GJM-contract/contract.spthy.tmp
-  processing time: 56.690435s
+  processing time: 19.439569226s
   aborted_and_resolved_exclusive (all-traces): verified (18 steps)
   aborted_contract_reachable (exists-trace): verified (6 steps)
   resolved1_contract_reachable (exists-trace): verified (10 steps)
@@ -1310,7 +1310,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/GJM-contract/contract.spthy
 
   output:          examples/sapic/fast/GJM-contract/contract.spthy.tmp
-  processing time: 56.690435s
+  processing time: 19.439569226s
   aborted_and_resolved_exclusive (all-traces): verified (18 steps)
   aborted_contract_reachable (exists-trace): verified (6 steps)
   resolved1_contract_reachable (exists-trace): verified (10 steps)

--- a/case-studies-regression/sapic/fast/GJM-contract/contract_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/GJM-contract/contract_analyzed.spthy
@@ -61,7 +61,7 @@ solve( State_111121212111( ct, pk2, sk1, skT ) ▶₀ #i )
                  ∧
                   (#vr.41 < #t2) ∧
                   (#t2 < #vr.51) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, ct ) @ #t0)
                    ⇒
@@ -85,7 +85,7 @@ solve( State_111121212111( ct, pk2, sk1, skT ) ▶₀ #i )
                  ∧
                   (#vr.41 < #t2) ∧
                   (#t2 < #vr.51) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.2, ct ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, ct ) @ #t0)
                    ⇒
@@ -1239,7 +1239,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1255,7 +1255,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1271,7 +1271,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1286,7 +1286,7 @@ restriction locking_2:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1296,7 +1296,7 @@ analyzing: examples/sapic/fast/GJM-contract/contract.spthy
 analyzed: examples/sapic/fast/GJM-contract/contract.spthy
 
   output:          examples/sapic/fast/GJM-contract/contract.spthy.tmp
-  processing time: 19.647743051s
+  processing time: 56.690435s
   aborted_and_resolved_exclusive (all-traces): verified (18 steps)
   aborted_contract_reachable (exists-trace): verified (6 steps)
   resolved1_contract_reachable (exists-trace): verified (10 steps)
@@ -1310,7 +1310,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/GJM-contract/contract.spthy
 
   output:          examples/sapic/fast/GJM-contract/contract.spthy.tmp
-  processing time: 19.647743051s
+  processing time: 56.690435s
   aborted_and_resolved_exclusive (all-traces): verified (18 steps)
   aborted_contract_reachable (exists-trace): verified (6 steps)
   resolved1_contract_reachable (exists-trace): verified (10 steps)

--- a/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr-lookup_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr-lookup_analyzed.spthy
@@ -638,7 +638,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -654,7 +654,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -670,7 +670,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -685,7 +685,7 @@ restriction locking_2:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -695,7 +695,7 @@ analyzing: examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy.tmp
-  processing time: 5.762746s
+  processing time: 1.805381116s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (11 steps)
 
 ------------------------------------------------------------------------------
@@ -706,7 +706,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy.tmp
-  processing time: 5.762746s
+  processing time: 1.805381116s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (11 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr-lookup_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr-lookup_analyzed.spthy
@@ -638,7 +638,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -654,7 +654,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -670,7 +670,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -685,7 +685,7 @@ restriction locking_2:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -695,7 +695,7 @@ analyzing: examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy.tmp
-  processing time: 1.609248218s
+  processing time: 5.762746s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (11 steps)
 
 ------------------------------------------------------------------------------
@@ -706,7 +706,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr-lookup.spthy.tmp
-  processing time: 1.609248218s
+  processing time: 5.762746s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (11 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr_analyzed.spthy
@@ -290,7 +290,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -300,7 +300,7 @@ analyzing: examples/sapic/fast/MoedersheimWebService/set-abstr.spthy
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr.spthy.tmp
-  processing time: 2.665273s
+  processing time: 0.685982294s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (8 steps)
 
 ------------------------------------------------------------------------------
@@ -311,7 +311,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr.spthy.tmp
-  processing time: 2.665273s
+  processing time: 0.685982294s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (8 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/MoedersheimWebService/set-abstr_analyzed.spthy
@@ -290,7 +290,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -300,7 +300,7 @@ analyzing: examples/sapic/fast/MoedersheimWebService/set-abstr.spthy
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr.spthy.tmp
-  processing time: 0.668259488s
+  processing time: 2.665273s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (8 steps)
 
 ------------------------------------------------------------------------------
@@ -311,7 +311,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/MoedersheimWebService/set-abstr.spthy
 
   output:          examples/sapic/fast/MoedersheimWebService/set-abstr.spthy.tmp
-  processing time: 0.668259488s
+  processing time: 2.665273s
   Knows_Honest_Key_imp_Revoked (all-traces): verified (8 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_analyzed.spthy
@@ -90,7 +90,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                        ∧
                                         (#t.2 < #t2) ∧
                                         (#t2 < #vr.22) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                          ⇒
@@ -394,7 +394,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                          ∧
                                           (#vr.2 < #t2) ∧
                                           (#t2 < #vr.23) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                            ⇒
@@ -767,7 +767,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                          ∧
                                           (#vr.2 < #t2) ∧
                                           (#t2 < #vr.23) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                            ⇒
@@ -1174,7 +1174,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                  ∧
                   (#vr.2 < #t2) ∧
                   (#t2 < #vr.15) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1213,7 +1213,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                  ∧
                   (#vr.2 < #t2) ∧
                   (#t2 < #vr.15) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1285,7 +1285,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                  ∧
                   (#vr.2 < #t2) ∧
                   (#t2 < #vr.15) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1378,7 +1378,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                        ∧
                                                                         (#t.2 < #t2) ∧
                                                                         (#t2 < #vr.26) ∧
-                                                                        (∀ #t0 pp.
+                                                                        (∀ pp #t0.
                                                                           (Unlock( pp, ~n.4, <~n.1, ~n>
                                                                            ) @ #t0)
                                                                          ⇒
@@ -1405,7 +1405,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                          ∧
                                                                           (#t.3 < #t2) ∧
                                                                           (#t2 < #vr.26) ∧
-                                                                          (∀ #t0 pp.
+                                                                          (∀ pp #t0.
                                                                             (Unlock( pp, ~n.6, <~n.1, ~n>
                                                                              ) @ #t0)
                                                                            ⇒
@@ -1840,7 +1840,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                      ∧
                                                                       (#t.2 < #t2) ∧
                                                                       (#t2 < #vr.26) ∧
-                                                                      (∀ #t0 pp.
+                                                                      (∀ pp #t0.
                                                                         (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0)
                                                                        ⇒
                                                                         #t0 = #t2) ∧
@@ -1865,7 +1865,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                        ∧
                                                                         (#t.3 < #t2) ∧
                                                                         (#t2 < #vr.26) ∧
-                                                                        (∀ #t0 pp.
+                                                                        (∀ pp #t0.
                                                                           (Unlock( pp, ~n.6, <~n.1, ~n>
                                                                            ) @ #t0)
                                                                          ⇒
@@ -2283,8 +2283,8 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                                                                                        ∧
                                                                                                                                         (#t.5 < #t2) ∧
                                                                                                                                         (#t2 < #vr.31) ∧
-                                                                                                                                        (∀ #t0
-                                                                                                                                           pp.
+                                                                                                                                        (∀ pp
+                                                                                                                                           #t0.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.8,
                                                                                                                                                    <
@@ -2359,8 +2359,8 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                                                                                              ∧
                                                                                                                                               (#t.2 < #t2) ∧
                                                                                                                                               (#t2 < #vr.33) ∧
-                                                                                                                                              (∀ #t0
-                                                                                                                                                 pp.
+                                                                                                                                              (∀ pp
+                                                                                                                                                 #t0.
                                                                                                                                                 (Unlock( pp,
                                                                                                                                                          ~n.5,
                                                                                                                                                          <
@@ -2417,8 +2417,8 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                                                                                                ∧
                                                                                                                                                 (#t.3 < #t2) ∧
                                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                                (∀ #t0
-                                                                                                                                                   pp.
+                                                                                                                                                (∀ pp
+                                                                                                                                                   #t0.
                                                                                                                                                   (Unlock( pp,
                                                                                                                                                            ~n.7,
                                                                                                                                                            <
@@ -2844,7 +2844,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -2883,7 +2883,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -2962,7 +2962,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -3034,7 +3034,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                                                            ∧
                                                             (#vr.19 < #t2) ∧
                                                             (#t2 < #vr.24) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.8, <~n.1, ~n> ) @ #t0)
                                                              ⇒
                                                               #t0 = #t2) ∧
@@ -3570,7 +3570,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -3586,7 +3586,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -3638,7 +3638,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -3648,7 +3648,7 @@ analyzing: examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy.tmp
-  processing time: 29.554310137s
+  processing time: 59.05495s
   Executable (exists-trace): verified (47 steps)
   all_received_were_sent (all-traces): verified (16 steps)
   all_received_were_sent_injective (all-traces): verified (138 steps)
@@ -3664,7 +3664,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy.tmp
-  processing time: 29.554310137s
+  processing time: 59.05495s
   Executable (exists-trace): verified (47 steps)
   all_received_were_sent (all-traces): verified (16 steps)
   all_received_were_sent_injective (all-traces): verified (138 steps)

--- a/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_analyzed.spthy
@@ -90,7 +90,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                        ∧
                                         (#t.2 < #t2) ∧
                                         (#t2 < #vr.22) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                          ⇒
@@ -394,7 +394,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                          ∧
                                           (#vr.2 < #t2) ∧
                                           (#t2 < #vr.23) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                            ⇒
@@ -767,7 +767,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                          ∧
                                           (#vr.2 < #t2) ∧
                                           (#t2 < #vr.23) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                            ⇒
@@ -1174,7 +1174,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                  ∧
                   (#vr.2 < #t2) ∧
                   (#t2 < #vr.15) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1213,7 +1213,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                  ∧
                   (#vr.2 < #t2) ∧
                   (#t2 < #vr.15) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1285,7 +1285,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                  ∧
                   (#vr.2 < #t2) ∧
                   (#t2 < #vr.15) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1378,7 +1378,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                        ∧
                                                                         (#t.2 < #t2) ∧
                                                                         (#t2 < #vr.26) ∧
-                                                                        (∀ pp #t0.
+                                                                        (∀ #t0 pp.
                                                                           (Unlock( pp, ~n.4, <~n.1, ~n>
                                                                            ) @ #t0)
                                                                          ⇒
@@ -1405,7 +1405,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                          ∧
                                                                           (#t.3 < #t2) ∧
                                                                           (#t2 < #vr.26) ∧
-                                                                          (∀ pp #t0.
+                                                                          (∀ #t0 pp.
                                                                             (Unlock( pp, ~n.6, <~n.1, ~n>
                                                                              ) @ #t0)
                                                                            ⇒
@@ -1840,7 +1840,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                      ∧
                                                                       (#t.2 < #t2) ∧
                                                                       (#t2 < #vr.26) ∧
-                                                                      (∀ pp #t0.
+                                                                      (∀ #t0 pp.
                                                                         (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0)
                                                                        ⇒
                                                                         #t0 = #t2) ∧
@@ -1865,7 +1865,7 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                        ∧
                                                                         (#t.3 < #t2) ∧
                                                                         (#t2 < #vr.26) ∧
-                                                                        (∀ pp #t0.
+                                                                        (∀ #t0 pp.
                                                                           (Unlock( pp, ~n.6, <~n.1, ~n>
                                                                            ) @ #t0)
                                                                          ⇒
@@ -2283,8 +2283,8 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                                                                                        ∧
                                                                                                                                         (#t.5 < #t2) ∧
                                                                                                                                         (#t2 < #vr.31) ∧
-                                                                                                                                        (∀ pp
-                                                                                                                                           #t0.
+                                                                                                                                        (∀ #t0
+                                                                                                                                           pp.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.8,
                                                                                                                                                    <
@@ -2359,8 +2359,8 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                                                                                              ∧
                                                                                                                                               (#t.2 < #t2) ∧
                                                                                                                                               (#t2 < #vr.33) ∧
-                                                                                                                                              (∀ pp
-                                                                                                                                                 #t0.
+                                                                                                                                              (∀ #t0
+                                                                                                                                                 pp.
                                                                                                                                                 (Unlock( pp,
                                                                                                                                                          ~n.5,
                                                                                                                                                          <
@@ -2417,8 +2417,8 @@ solve( State_1111121111( ~prog_1, ~prog_1111121, ~prog_111112111, MH, SH,
                                                                                                                                                ∧
                                                                                                                                                 (#t.3 < #t2) ∧
                                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                                (∀ pp
-                                                                                                                                                   #t0.
+                                                                                                                                                (∀ #t0
+                                                                                                                                                   pp.
                                                                                                                                                   (Unlock( pp,
                                                                                                                                                            ~n.7,
                                                                                                                                                            <
@@ -2844,7 +2844,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -2883,7 +2883,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -2962,7 +2962,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -3034,7 +3034,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                                                            ∧
                                                             (#vr.19 < #t2) ∧
                                                             (#t2 < #vr.24) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.8, <~n.1, ~n> ) @ #t0)
                                                              ⇒
                                                               #t0 = #t2) ∧
@@ -3570,7 +3570,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -3586,7 +3586,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -3638,7 +3638,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -3648,7 +3648,7 @@ analyzing: examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy.tmp
-  processing time: 59.05495s
+  processing time: 33.663950056s
   Executable (exists-trace): verified (47 steps)
   all_received_were_sent (all-traces): verified (16 steps)
   all_received_were_sent_injective (all-traces): verified (138 steps)
@@ -3664,7 +3664,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation.spthy.tmp
-  processing time: 59.05495s
+  processing time: 33.663950056s
   Executable (exists-trace): verified (47 steps)
   all_received_were_sent (all-traces): verified (16 steps)
   all_received_were_sent_injective (all-traces): verified (138 steps)

--- a/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_variant_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_variant_analyzed.spthy
@@ -94,7 +94,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                          ∧
                                           (#t.2 < #t2) ∧
                                           (#t2 < #vr.23) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                            ⇒
@@ -331,7 +331,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                            ∧
                                             (#t.2 < #t2) ∧
                                             (#t2 < #vr.23) ∧
-                                            (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                            (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                             (∀ pp lpp #t0.
                                               (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                              ⇒
@@ -777,7 +777,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                            ∧
                                             (#t.2 < #t2) ∧
                                             (#t2 < #vr.23) ∧
-                                            (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                            (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                             (∀ pp lpp #t0.
                                               (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                              ⇒
@@ -1263,7 +1263,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.17) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1302,7 +1302,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.17) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1390,7 +1390,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.17) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1533,7 +1533,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -1568,7 +1568,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ #t0 pp.
+                                                                                          (∀ pp #t0.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -2128,7 +2128,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ #t0 pp.
+                                                                                      (∀ pp #t0.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -2161,7 +2161,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -2730,8 +2730,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ #t0
-                                                                                                                                   pp.
+                                                                                                                                (∀ pp
+                                                                                                                                   #t0.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -2806,8 +2806,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ #t0
-                                                                                                                                         pp.
+                                                                                                                                      (∀ pp
+                                                                                                                                         #t0.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -2864,8 +2864,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ #t0
-                                                                                                                                           pp.
+                                                                                                                                        (∀ pp
+                                                                                                                                           #t0.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -3279,7 +3279,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -3314,7 +3314,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ #t0 pp.
+                                                                                          (∀ pp #t0.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -3874,7 +3874,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ #t0 pp.
+                                                                                      (∀ pp #t0.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -3907,7 +3907,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -4476,8 +4476,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ #t0
-                                                                                                                                   pp.
+                                                                                                                                (∀ pp
+                                                                                                                                   #t0.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -4552,8 +4552,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ #t0
-                                                                                                                                         pp.
+                                                                                                                                      (∀ pp
+                                                                                                                                         #t0.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -4610,8 +4610,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ #t0
-                                                                                                                                           pp.
+                                                                                                                                        (∀ pp
+                                                                                                                                           #t0.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -5025,7 +5025,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -5060,7 +5060,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ #t0 pp.
+                                                                                          (∀ pp #t0.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -5620,7 +5620,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ #t0 pp.
+                                                                                      (∀ pp #t0.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -5653,7 +5653,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -6230,8 +6230,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ #t0
-                                                                                                                                   pp.
+                                                                                                                                (∀ pp
+                                                                                                                                   #t0.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -6306,8 +6306,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ #t0
-                                                                                                                                         pp.
+                                                                                                                                      (∀ pp
+                                                                                                                                         #t0.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -6364,8 +6364,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ #t0
-                                                                                                                                           pp.
+                                                                                                                                        (∀ pp
+                                                                                                                                           #t0.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -6779,7 +6779,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -6814,7 +6814,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ #t0 pp.
+                                                                                          (∀ pp #t0.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -7374,7 +7374,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ #t0 pp.
+                                                                                      (∀ pp #t0.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -7407,7 +7407,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -7980,8 +7980,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ #t0
-                                                                                                                                   pp.
+                                                                                                                                (∀ pp
+                                                                                                                                   #t0.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -8056,8 +8056,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ #t0
-                                                                                                                                         pp.
+                                                                                                                                      (∀ pp
+                                                                                                                                         #t0.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -8114,8 +8114,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ #t0
-                                                                                                                                           pp.
+                                                                                                                                        (∀ pp
+                                                                                                                                           #t0.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -8530,7 +8530,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -8565,7 +8565,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ #t0 pp.
+                                                                                          (∀ pp #t0.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -9125,7 +9125,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ #t0 pp.
+                                                                                      (∀ pp #t0.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -9158,7 +9158,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ #t0 pp.
+                                                                                        (∀ pp #t0.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -9739,8 +9739,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ #t0
-                                                                                                                                   pp.
+                                                                                                                                (∀ pp
+                                                                                                                                   #t0.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -9815,8 +9815,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ #t0
-                                                                                                                                         pp.
+                                                                                                                                      (∀ pp
+                                                                                                                                         #t0.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -9873,8 +9873,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ #t0
-                                                                                                                                           pp.
+                                                                                                                                        (∀ pp
+                                                                                                                                           #t0.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -10341,7 +10341,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -10380,7 +10380,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -10459,7 +10459,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -10527,7 +10527,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                                                          ∧
                                                           (#vr.19 < #t2) ∧
                                                           (#t2 < #vr.22) ∧
-                                                          (∀ #t0 pp.
+                                                          (∀ pp #t0.
                                                             (Unlock( pp, ~n.8, <~n.1, ~n> ) @ #t0)
                                                            ⇒
                                                             #t0 = #t2) ∧
@@ -11569,7 +11569,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -11585,7 +11585,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -11638,7 +11638,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -11648,7 +11648,7 @@ analyzing: examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy.tmp
-  processing time: 205.747211133s
+  processing time: 202.981601s
   Executable (exists-trace): verified (36 steps)
   all_received_were_sent (all-traces): verified (18 steps)
   all_received_were_sent_injective (all-traces): verified (168 steps)
@@ -11664,7 +11664,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy.tmp
-  processing time: 205.747211133s
+  processing time: 202.981601s
   Executable (exists-trace): verified (36 steps)
   all_received_were_sent (all-traces): verified (18 steps)
   all_received_were_sent_injective (all-traces): verified (168 steps)

--- a/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_variant_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/SCADA/opc_ua_secure_conversation_variant_analyzed.spthy
@@ -94,7 +94,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                          ∧
                                           (#t.2 < #t2) ∧
                                           (#t2 < #vr.23) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                            ⇒
@@ -331,7 +331,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                            ∧
                                             (#t.2 < #t2) ∧
                                             (#t2 < #vr.23) ∧
-                                            (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                            (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                             (∀ pp lpp #t0.
                                               (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                              ⇒
@@ -777,7 +777,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                            ∧
                                             (#t.2 < #t2) ∧
                                             (#t2 < #vr.23) ∧
-                                            (∀ pp #t0. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                                            (∀ #t0 pp. (Unlock( pp, ~n.5, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                                             (∀ pp lpp #t0.
                                               (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                                              ⇒
@@ -1263,7 +1263,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.17) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1302,7 +1302,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.17) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1390,7 +1390,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.17) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n.1, ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n.1, ~n> ) @ #t0)
                    ⇒
@@ -1533,7 +1533,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -1568,7 +1568,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ pp #t0.
+                                                                                          (∀ #t0 pp.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -2128,7 +2128,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ pp #t0.
+                                                                                      (∀ #t0 pp.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -2161,7 +2161,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -2730,8 +2730,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ pp
-                                                                                                                                   #t0.
+                                                                                                                                (∀ #t0
+                                                                                                                                   pp.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -2806,8 +2806,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ pp
-                                                                                                                                         #t0.
+                                                                                                                                      (∀ #t0
+                                                                                                                                         pp.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -2864,8 +2864,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ pp
-                                                                                                                                           #t0.
+                                                                                                                                        (∀ #t0
+                                                                                                                                           pp.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -3279,7 +3279,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -3314,7 +3314,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ pp #t0.
+                                                                                          (∀ #t0 pp.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -3874,7 +3874,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ pp #t0.
+                                                                                      (∀ #t0 pp.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -3907,7 +3907,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -4476,8 +4476,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ pp
-                                                                                                                                   #t0.
+                                                                                                                                (∀ #t0
+                                                                                                                                   pp.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -4552,8 +4552,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ pp
-                                                                                                                                         #t0.
+                                                                                                                                      (∀ #t0
+                                                                                                                                         pp.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -4610,8 +4610,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ pp
-                                                                                                                                           #t0.
+                                                                                                                                        (∀ #t0
+                                                                                                                                           pp.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -5025,7 +5025,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -5060,7 +5060,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ pp #t0.
+                                                                                          (∀ #t0 pp.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -5620,7 +5620,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ pp #t0.
+                                                                                      (∀ #t0 pp.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -5653,7 +5653,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -6230,8 +6230,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ pp
-                                                                                                                                   #t0.
+                                                                                                                                (∀ #t0
+                                                                                                                                   pp.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -6306,8 +6306,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ pp
-                                                                                                                                         #t0.
+                                                                                                                                      (∀ #t0
+                                                                                                                                         pp.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -6364,8 +6364,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ pp
-                                                                                                                                           #t0.
+                                                                                                                                        (∀ #t0
+                                                                                                                                           pp.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -6779,7 +6779,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -6814,7 +6814,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ pp #t0.
+                                                                                          (∀ #t0 pp.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -7374,7 +7374,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ pp #t0.
+                                                                                      (∀ #t0 pp.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -7407,7 +7407,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -7980,8 +7980,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ pp
-                                                                                                                                   #t0.
+                                                                                                                                (∀ #t0
+                                                                                                                                   pp.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -8056,8 +8056,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ pp
-                                                                                                                                         #t0.
+                                                                                                                                      (∀ #t0
+                                                                                                                                         pp.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -8114,8 +8114,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ pp
-                                                                                                                                           #t0.
+                                                                                                                                        (∀ #t0
+                                                                                                                                           pp.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -8530,7 +8530,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.2 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.4,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -8565,7 +8565,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                          ∧
                                                                                           (#t.3 < #t2) ∧
                                                                                           (#t2 < #vr.28) ∧
-                                                                                          (∀ pp #t0.
+                                                                                          (∀ #t0 pp.
                                                                                             (Unlock( pp, ~n.6,
                                                                                                      <~n.1, ~n
                                                                                                      >
@@ -9125,7 +9125,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                      ∧
                                                                                       (#t.2 < #t2) ∧
                                                                                       (#t2 < #vr.28) ∧
-                                                                                      (∀ pp #t0.
+                                                                                      (∀ #t0 pp.
                                                                                         (Unlock( pp, ~n.5,
                                                                                                  <~n.1, ~n>
                                                                                          ) @ #t0)
@@ -9158,7 +9158,7 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                        ∧
                                                                                         (#t.3 < #t2) ∧
                                                                                         (#t2 < #vr.28) ∧
-                                                                                        (∀ pp #t0.
+                                                                                        (∀ #t0 pp.
                                                                                           (Unlock( pp, ~n.6,
                                                                                                    <~n.1, ~n>
                                                                                            ) @ #t0)
@@ -9739,8 +9739,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                ∧
                                                                                                                                 (#t.5 < #t2) ∧
                                                                                                                                 (#t2 < #vr.33) ∧
-                                                                                                                                (∀ pp
-                                                                                                                                   #t0.
+                                                                                                                                (∀ #t0
+                                                                                                                                   pp.
                                                                                                                                   (Unlock( pp,
                                                                                                                                            ~n.8,
                                                                                                                                            <
@@ -9815,8 +9815,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                      ∧
                                                                                                                                       (#t.2 < #t2) ∧
                                                                                                                                       (#t2 < #vr.35) ∧
-                                                                                                                                      (∀ pp
-                                                                                                                                         #t0.
+                                                                                                                                      (∀ #t0
+                                                                                                                                         pp.
                                                                                                                                         (Unlock( pp,
                                                                                                                                                  ~n.5,
                                                                                                                                                  <
@@ -9873,8 +9873,8 @@ solve( State_11111211111( ~prog_1, ~prog_1111121, ~prog_111112111, MH,
                                                                                                                                        ∧
                                                                                                                                         (#t.3 < #t2) ∧
                                                                                                                                         (#t2 < #vr.35) ∧
-                                                                                                                                        (∀ pp
-                                                                                                                                           #t0.
+                                                                                                                                        (∀ #t0
+                                                                                                                                           pp.
                                                                                                                                           (Unlock( pp,
                                                                                                                                                    ~n.7,
                                                                                                                                                    <
@@ -10341,7 +10341,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -10380,7 +10380,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -10459,7 +10459,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                  ∧
                   (#vr.3 < #t2) ∧
                   (#t2 < #vr.16) ∧
-                  (∀ pp #t0. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
+                  (∀ #t0 pp. (Unlock( pp, ~n.4, <~n, ~n.1> ) @ #t0) ⇒ #t0 = #t2) ∧
                   (∀ pp lpp #t0.
                     (Lock( pp, lpp, <~n, ~n.1> ) @ #t0)
                    ⇒
@@ -10527,7 +10527,7 @@ solve( State_11111111111( ~prog_1, ~prog_1111111, ~prog_111111111, A, B,
                                                          ∧
                                                           (#vr.19 < #t2) ∧
                                                           (#t2 < #vr.22) ∧
-                                                          (∀ pp #t0.
+                                                          (∀ #t0 pp.
                                                             (Unlock( pp, ~n.8, <~n.1, ~n> ) @ #t0)
                                                            ⇒
                                                             #t0 = #t2) ∧
@@ -11569,7 +11569,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -11585,7 +11585,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -11638,7 +11638,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -11648,7 +11648,7 @@ analyzing: examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy.tmp
-  processing time: 202.981601s
+  processing time: 137.149711783s
   Executable (exists-trace): verified (36 steps)
   all_received_were_sent (all-traces): verified (18 steps)
   all_received_were_sent_injective (all-traces): verified (168 steps)
@@ -11664,7 +11664,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy
 
   output:          examples/sapic/fast/SCADA/opc_ua_secure_conversation_variant.spthy.tmp
-  processing time: 202.981601s
+  processing time: 137.149711783s
   Executable (exists-trace): verified (36 steps)
   all_received_were_sent (all-traces): verified (18 steps)
   all_received_were_sent_injective (all-traces): verified (168 steps)

--- a/case-studies-regression/sapic/fast/basic/channels1_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels1_analyzed.spthy
@@ -115,7 +115,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -125,7 +125,7 @@ analyzing: examples/sapic/fast/basic/channels1.spthy
 analyzed: examples/sapic/fast/basic/channels1.spthy
 
   output:          examples/sapic/fast/basic/channels1.spthy.tmp
-  processing time: 0.266339451s
+  processing time: 0.45108s
   secret (all-traces): verified (4 steps)
   received (exists-trace): verified (3 steps)
 
@@ -137,7 +137,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels1.spthy
 
   output:          examples/sapic/fast/basic/channels1.spthy.tmp
-  processing time: 0.266339451s
+  processing time: 0.45108s
   secret (all-traces): verified (4 steps)
   received (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/basic/channels1_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels1_analyzed.spthy
@@ -115,7 +115,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -125,7 +125,7 @@ analyzing: examples/sapic/fast/basic/channels1.spthy
 analyzed: examples/sapic/fast/basic/channels1.spthy
 
   output:          examples/sapic/fast/basic/channels1.spthy.tmp
-  processing time: 0.45108s
+  processing time: 0.168360637s
   secret (all-traces): verified (4 steps)
   received (exists-trace): verified (3 steps)
 
@@ -137,7 +137,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels1.spthy
 
   output:          examples/sapic/fast/basic/channels1.spthy.tmp
-  processing time: 0.45108s
+  processing time: 0.168360637s
   secret (all-traces): verified (4 steps)
   received (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/basic/channels2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels2_analyzed.spthy
@@ -61,7 +61,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -71,7 +71,7 @@ analyzing: examples/sapic/fast/basic/channels2.spthy
 analyzed: examples/sapic/fast/basic/channels2.spthy
 
   output:          examples/sapic/fast/basic/channels2.spthy.tmp
-  processing time: 0.07784918s
+  processing time: 0.092547s
   received (all-traces): verified (2 steps)
 
 ------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels2.spthy
 
   output:          examples/sapic/fast/basic/channels2.spthy.tmp
-  processing time: 0.07784918s
+  processing time: 0.092547s
   received (all-traces): verified (2 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/channels2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels2_analyzed.spthy
@@ -61,7 +61,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -71,7 +71,7 @@ analyzing: examples/sapic/fast/basic/channels2.spthy
 analyzed: examples/sapic/fast/basic/channels2.spthy
 
   output:          examples/sapic/fast/basic/channels2.spthy.tmp
-  processing time: 0.092547s
+  processing time: 0.048803472s
   received (all-traces): verified (2 steps)
 
 ------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels2.spthy
 
   output:          examples/sapic/fast/basic/channels2.spthy.tmp
-  processing time: 0.092547s
+  processing time: 0.048803472s
   received (all-traces): verified (2 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/channels3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels3_analyzed.spthy
@@ -116,7 +116,7 @@ restriction in_event:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -126,7 +126,7 @@ analyzing: examples/sapic/fast/basic/channels3.spthy
 analyzed: examples/sapic/fast/basic/channels3.spthy
 
   output:          examples/sapic/fast/basic/channels3.spthy.tmp
-  processing time: 0.126761532s
+  processing time: 0.224176s
   not_secret (exists-trace): verified (4 steps)
   internal_comm (exists-trace): verified (4 steps)
 
@@ -138,7 +138,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels3.spthy
 
   output:          examples/sapic/fast/basic/channels3.spthy.tmp
-  processing time: 0.126761532s
+  processing time: 0.224176s
   not_secret (exists-trace): verified (4 steps)
   internal_comm (exists-trace): verified (4 steps)
 

--- a/case-studies-regression/sapic/fast/basic/channels3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels3_analyzed.spthy
@@ -116,7 +116,7 @@ restriction in_event:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -126,7 +126,7 @@ analyzing: examples/sapic/fast/basic/channels3.spthy
 analyzed: examples/sapic/fast/basic/channels3.spthy
 
   output:          examples/sapic/fast/basic/channels3.spthy.tmp
-  processing time: 0.224176s
+  processing time: 0.117719903s
   not_secret (exists-trace): verified (4 steps)
   internal_comm (exists-trace): verified (4 steps)
 
@@ -138,7 +138,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels3.spthy
 
   output:          examples/sapic/fast/basic/channels3.spthy.tmp
-  processing time: 0.224176s
+  processing time: 0.117719903s
   not_secret (exists-trace): verified (4 steps)
   internal_comm (exists-trace): verified (4 steps)
 

--- a/case-studies-regression/sapic/fast/basic/channels4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels4_analyzed.spthy
@@ -97,7 +97,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -107,7 +107,7 @@ analyzing: examples/sapic/fast/basic/channels4.spthy
 analyzed: examples/sapic/fast/basic/channels4.spthy
 
   output:          examples/sapic/fast/basic/channels4.spthy.tmp
-  processing time: 0.112606278s
+  processing time: 0.275926s
   secret (all-traces): verified (3 steps)
   received (exists-trace): verified (3 steps)
 
@@ -119,7 +119,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels4.spthy
 
   output:          examples/sapic/fast/basic/channels4.spthy.tmp
-  processing time: 0.112606278s
+  processing time: 0.275926s
   secret (all-traces): verified (3 steps)
   received (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/basic/channels4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/channels4_analyzed.spthy
@@ -97,7 +97,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -107,7 +107,7 @@ analyzing: examples/sapic/fast/basic/channels4.spthy
 analyzed: examples/sapic/fast/basic/channels4.spthy
 
   output:          examples/sapic/fast/basic/channels4.spthy.tmp
-  processing time: 0.275926s
+  processing time: 0.094964463s
   secret (all-traces): verified (3 steps)
   received (exists-trace): verified (3 steps)
 
@@ -119,7 +119,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/channels4.spthy
 
   output:          examples/sapic/fast/basic/channels4.spthy.tmp
-  processing time: 0.275926s
+  processing time: 0.094964463s
   secret (all-traces): verified (3 steps)
   received (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/basic/design-choices_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/design-choices_analyzed.spthy
@@ -27,7 +27,7 @@ solve( (#t1 < #t2)  ∥ (#t2 < #t1) )
                ∧
                 (#vr.1 < #t2) ∧
                 (#t2 < #vr.6) ∧
-                (∀ #t0 pp. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
+                (∀ pp #t0. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
                 (∀ pp lpp #t0.
                   (Lock( pp, lpp, 's' ) @ #t0)
                  ⇒
@@ -78,7 +78,7 @@ next
                ∧
                 (#vr.1 < #t2) ∧
                 (#t2 < #vr.6) ∧
-                (∀ #t0 pp. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
+                (∀ pp #t0. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
                 (∀ pp lpp #t0.
                   (Lock( pp, lpp, 's' ) @ #t0)
                  ⇒
@@ -216,7 +216,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -231,7 +231,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -241,7 +241,7 @@ analyzing: examples/sapic/fast/basic/design-choices.spthy
 analyzed: examples/sapic/fast/basic/design-choices.spthy
 
   output:          examples/sapic/fast/basic/design-choices.spthy.tmp
-  processing time: 0.338865872s
+  processing time: 0.935509s
   visit_once (all-traces): verified (26 steps)
 
 ------------------------------------------------------------------------------
@@ -252,7 +252,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/design-choices.spthy
 
   output:          examples/sapic/fast/basic/design-choices.spthy.tmp
-  processing time: 0.338865872s
+  processing time: 0.935509s
   visit_once (all-traces): verified (26 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/design-choices_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/design-choices_analyzed.spthy
@@ -27,7 +27,7 @@ solve( (#t1 < #t2)  ∥ (#t2 < #t1) )
                ∧
                 (#vr.1 < #t2) ∧
                 (#t2 < #vr.6) ∧
-                (∀ pp #t0. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
+                (∀ #t0 pp. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
                 (∀ pp lpp #t0.
                   (Lock( pp, lpp, 's' ) @ #t0)
                  ⇒
@@ -78,7 +78,7 @@ next
                ∧
                 (#vr.1 < #t2) ∧
                 (#t2 < #vr.6) ∧
-                (∀ pp #t0. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
+                (∀ #t0 pp. (Unlock( pp, ~n, 's' ) @ #t0) ⇒ #t0 = #t2) ∧
                 (∀ pp lpp #t0.
                   (Lock( pp, lpp, 's' ) @ #t0)
                  ⇒
@@ -216,7 +216,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -231,7 +231,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -241,7 +241,7 @@ analyzing: examples/sapic/fast/basic/design-choices.spthy
 analyzed: examples/sapic/fast/basic/design-choices.spthy
 
   output:          examples/sapic/fast/basic/design-choices.spthy.tmp
-  processing time: 0.935509s
+  processing time: 0.300474877s
   visit_once (all-traces): verified (26 steps)
 
 ------------------------------------------------------------------------------
@@ -252,7 +252,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/design-choices.spthy
 
   output:          examples/sapic/fast/basic/design-choices.spthy.tmp
-  processing time: 0.935509s
+  processing time: 0.300474877s
   visit_once (all-traces): verified (26 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/exclusive-secrets_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/exclusive-secrets_analyzed.spthy
@@ -265,7 +265,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -275,7 +275,7 @@ analyzing: examples/sapic/fast/basic/exclusive-secrets.spthy
 analyzed: examples/sapic/fast/basic/exclusive-secrets.spthy
 
   output:          examples/sapic/fast/basic/exclusive-secrets.spthy.tmp
-  processing time: 0.937088s
+  processing time: 0.273375965s
   a_not_secret (exists-trace): verified (5 steps)
   b_not_secret (exists-trace): verified (5 steps)
   sanity (all-traces): verified (8 steps)
@@ -289,7 +289,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/exclusive-secrets.spthy
 
   output:          examples/sapic/fast/basic/exclusive-secrets.spthy.tmp
-  processing time: 0.937088s
+  processing time: 0.273375965s
   a_not_secret (exists-trace): verified (5 steps)
   b_not_secret (exists-trace): verified (5 steps)
   sanity (all-traces): verified (8 steps)

--- a/case-studies-regression/sapic/fast/basic/exclusive-secrets_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/exclusive-secrets_analyzed.spthy
@@ -265,7 +265,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -275,7 +275,7 @@ analyzing: examples/sapic/fast/basic/exclusive-secrets.spthy
 analyzed: examples/sapic/fast/basic/exclusive-secrets.spthy
 
   output:          examples/sapic/fast/basic/exclusive-secrets.spthy.tmp
-  processing time: 0.412303799s
+  processing time: 0.937088s
   a_not_secret (exists-trace): verified (5 steps)
   b_not_secret (exists-trace): verified (5 steps)
   sanity (all-traces): verified (8 steps)
@@ -289,7 +289,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/exclusive-secrets.spthy
 
   output:          examples/sapic/fast/basic/exclusive-secrets.spthy.tmp
-  processing time: 0.412303799s
+  processing time: 0.937088s
   a_not_secret (exists-trace): verified (5 steps)
   b_not_secret (exists-trace): verified (5 steps)
   sanity (all-traces): verified (8 steps)

--- a/case-studies-regression/sapic/fast/basic/no-replication_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/no-replication_analyzed.spthy
@@ -58,7 +58,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -68,7 +68,7 @@ analyzing: examples/sapic/fast/basic/no-replication.spthy
 analyzed: examples/sapic/fast/basic/no-replication.spthy
 
   output:          examples/sapic/fast/basic/no-replication.spthy.tmp
-  processing time: 0.086494188s
+  processing time: 0.108672s
   onlyOneSecret (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/no-replication.spthy
 
   output:          examples/sapic/fast/basic/no-replication.spthy.tmp
-  processing time: 0.086494188s
+  processing time: 0.108672s
   onlyOneSecret (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/no-replication_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/no-replication_analyzed.spthy
@@ -58,7 +58,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -68,7 +68,7 @@ analyzing: examples/sapic/fast/basic/no-replication.spthy
 analyzed: examples/sapic/fast/basic/no-replication.spthy
 
   output:          examples/sapic/fast/basic/no-replication.spthy.tmp
-  processing time: 0.108672s
+  processing time: 0.053403595s
   onlyOneSecret (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/no-replication.spthy
 
   output:          examples/sapic/fast/basic/no-replication.spthy.tmp
-  processing time: 0.108672s
+  processing time: 0.053403595s
   onlyOneSecret (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-1_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-1_analyzed.spthy
@@ -66,7 +66,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -76,7 +76,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-1.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-1.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-1.spthy.tmp
-  processing time: 0.146793s
+  processing time: 0.069637732s
   semicolon_binds_stronger_than_parallel (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-1.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-1.spthy.tmp
-  processing time: 0.146793s
+  processing time: 0.069637732s
   semicolon_binds_stronger_than_parallel (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-1_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-1_analyzed.spthy
@@ -66,7 +66,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -76,7 +76,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-1.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-1.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-1.spthy.tmp
-  processing time: 0.083020328s
+  processing time: 0.146793s
   semicolon_binds_stronger_than_parallel (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-1.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-1.spthy.tmp
-  processing time: 0.083020328s
+  processing time: 0.146793s
   semicolon_binds_stronger_than_parallel (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-2_analyzed.spthy
@@ -61,7 +61,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -71,7 +71,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-2.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-2.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-2.spthy.tmp
-  processing time: 0.068797149s
+  processing time: 0.100876s
   semicolon_binds_stronger_than_NDC (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-2.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-2.spthy.tmp
-  processing time: 0.068797149s
+  processing time: 0.100876s
   semicolon_binds_stronger_than_NDC (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-2_analyzed.spthy
@@ -61,7 +61,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -71,7 +71,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-2.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-2.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-2.spthy.tmp
-  processing time: 0.100876s
+  processing time: 0.072330264s
   semicolon_binds_stronger_than_NDC (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-2.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-2.spthy.tmp
-  processing time: 0.100876s
+  processing time: 0.072330264s
   semicolon_binds_stronger_than_NDC (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-3_analyzed.spthy
@@ -117,7 +117,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -127,7 +127,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-3.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-3.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-3.spthy.tmp
-  processing time: 0.133863s
+  processing time: 0.067967751s
   elseIsResolvedInnerFirst (exists-trace): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -138,7 +138,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-3.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-3.spthy.tmp
-  processing time: 0.133863s
+  processing time: 0.067967751s
   elseIsResolvedInnerFirst (exists-trace): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-3_analyzed.spthy
@@ -117,7 +117,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -127,7 +127,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-3.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-3.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-3.spthy.tmp
-  processing time: 0.085410122s
+  processing time: 0.133863s
   elseIsResolvedInnerFirst (exists-trace): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -138,7 +138,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-3.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-3.spthy.tmp
-  processing time: 0.085410122s
+  processing time: 0.133863s
   elseIsResolvedInnerFirst (exists-trace): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-4_analyzed.spthy
@@ -73,7 +73,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -83,7 +83,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-4.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-4.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-4.spthy.tmp
-  processing time: 0.066916528s
+  processing time: 0.141629s
   second_process_covered (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-4.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-4.spthy.tmp
-  processing time: 0.066916528s
+  processing time: 0.141629s
   second_process_covered (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-4_analyzed.spthy
@@ -73,7 +73,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -83,7 +83,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-4.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-4.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-4.spthy.tmp
-  processing time: 0.141629s
+  processing time: 0.083197688s
   second_process_covered (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-4.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-4.spthy.tmp
-  processing time: 0.141629s
+  processing time: 0.083197688s
   second_process_covered (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-5_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-5_analyzed.spthy
@@ -96,7 +96,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -106,7 +106,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-5.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-5.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-5.spthy.tmp
-  processing time: 0.074785408s
+  processing time: 0.129977s
   second_process_covered (all-traces): verified (5 steps)
 
 ------------------------------------------------------------------------------
@@ -117,7 +117,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-5.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-5.spthy.tmp
-  processing time: 0.074785408s
+  processing time: 0.129977s
   second_process_covered (all-traces): verified (5 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/operator-precedence-5_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/operator-precedence-5_analyzed.spthy
@@ -96,7 +96,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -106,7 +106,7 @@ analyzing: examples/sapic/fast/basic/operator-precedence-5.spthy
 analyzed: examples/sapic/fast/basic/operator-precedence-5.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-5.spthy.tmp
-  processing time: 0.129977s
+  processing time: 0.06524398s
   second_process_covered (all-traces): verified (5 steps)
 
 ------------------------------------------------------------------------------
@@ -117,7 +117,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/operator-precedence-5.spthy
 
   output:          examples/sapic/fast/basic/operator-precedence-5.spthy.tmp
-  processing time: 0.129977s
+  processing time: 0.06524398s
   second_process_covered (all-traces): verified (5 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/reliable-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/reliable-channel_analyzed.spthy
@@ -142,7 +142,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -152,7 +152,7 @@ analyzing: examples/sapic/fast/basic/reliable-channel.spthy
 analyzed: examples/sapic/fast/basic/reliable-channel.spthy
 
   output:          examples/sapic/fast/basic/reliable-channel.spthy.tmp
-  processing time: 0.09334336s
+  processing time: 0.192298s
   A_possible (exists-trace): verified (3 steps)
   B_possible (exists-trace): verified (3 steps)
   A_once (all-traces): verified (8 steps)
@@ -166,7 +166,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/reliable-channel.spthy
 
   output:          examples/sapic/fast/basic/reliable-channel.spthy.tmp
-  processing time: 0.09334336s
+  processing time: 0.192298s
   A_possible (exists-trace): verified (3 steps)
   B_possible (exists-trace): verified (3 steps)
   A_once (all-traces): verified (8 steps)

--- a/case-studies-regression/sapic/fast/basic/reliable-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/reliable-channel_analyzed.spthy
@@ -142,7 +142,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -152,7 +152,7 @@ analyzing: examples/sapic/fast/basic/reliable-channel.spthy
 analyzed: examples/sapic/fast/basic/reliable-channel.spthy
 
   output:          examples/sapic/fast/basic/reliable-channel.spthy.tmp
-  processing time: 0.192298s
+  processing time: 0.063076259s
   A_possible (exists-trace): verified (3 steps)
   B_possible (exists-trace): verified (3 steps)
   A_once (all-traces): verified (8 steps)
@@ -166,7 +166,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/reliable-channel.spthy
 
   output:          examples/sapic/fast/basic/reliable-channel.spthy.tmp
-  processing time: 0.192298s
+  processing time: 0.063076259s
   A_possible (exists-trace): verified (3 steps)
   B_possible (exists-trace): verified (3 steps)
   A_once (all-traces): verified (8 steps)

--- a/case-studies-regression/sapic/fast/basic/replication_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/replication_analyzed.spthy
@@ -68,7 +68,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -78,7 +78,7 @@ analyzing: examples/sapic/fast/basic/replication.spthy
 analyzed: examples/sapic/fast/basic/replication.spthy
 
   output:          examples/sapic/fast/basic/replication.spthy.tmp
-  processing time: 0.090627586s
+  processing time: 0.130799s
   onlyOneSecret (exists-trace): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/replication.spthy
 
   output:          examples/sapic/fast/basic/replication.spthy.tmp
-  processing time: 0.090627586s
+  processing time: 0.130799s
   onlyOneSecret (exists-trace): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/replication_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/replication_analyzed.spthy
@@ -68,7 +68,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -78,7 +78,7 @@ analyzing: examples/sapic/fast/basic/replication.spthy
 analyzed: examples/sapic/fast/basic/replication.spthy
 
   output:          examples/sapic/fast/basic/replication.spthy.tmp
-  processing time: 0.130799s
+  processing time: 0.055508216s
   onlyOneSecret (exists-trace): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/replication.spthy
 
   output:          examples/sapic/fast/basic/replication.spthy.tmp
-  processing time: 0.130799s
+  processing time: 0.055508216s
   onlyOneSecret (exists-trace): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/basic/running-example_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/running-example_analyzed.spthy
@@ -731,7 +731,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -741,7 +741,7 @@ analyzing: examples/sapic/fast/basic/running-example.spthy
 analyzed: examples/sapic/fast/basic/running-example.spthy
 
   output:          examples/sapic/fast/basic/running-example.spthy.tmp
-  processing time: 5.019564s
+  processing time: 2.189912653s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)
@@ -756,7 +756,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/running-example.spthy
 
   output:          examples/sapic/fast/basic/running-example.spthy.tmp
-  processing time: 5.019564s
+  processing time: 2.189912653s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)

--- a/case-studies-regression/sapic/fast/basic/running-example_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/basic/running-example_analyzed.spthy
@@ -731,7 +731,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -741,7 +741,7 @@ analyzing: examples/sapic/fast/basic/running-example.spthy
 analyzed: examples/sapic/fast/basic/running-example.spthy
 
   output:          examples/sapic/fast/basic/running-example.spthy.tmp
-  processing time: 2.308673667s
+  processing time: 5.019564s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)
@@ -756,7 +756,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/basic/running-example.spthy
 
   output:          examples/sapic/fast/basic/running-example.spthy.tmp
-  processing time: 2.308673667s
+  processing time: 5.019564s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini10_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini10_analyzed.spthy
@@ -98,7 +98,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -108,7 +108,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini10.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini10.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini10.spthy.tmp
-  processing time: 0.118898s
+  processing time: 0.067849581s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 
@@ -120,7 +120,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini10.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini10.spthy.tmp
-  processing time: 0.118898s
+  processing time: 0.067849581s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini10_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini10_analyzed.spthy
@@ -98,7 +98,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -108,7 +108,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini10.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini10.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini10.spthy.tmp
-  processing time: 0.103993526s
+  processing time: 0.118898s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 
@@ -120,7 +120,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini10.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini10.spthy.tmp
-  processing time: 0.103993526s
+  processing time: 0.118898s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini1_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini1_analyzed.spthy
@@ -123,7 +123,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -133,7 +133,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini1.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini1.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini1.spthy.tmp
-  processing time: 0.122350749s
+  processing time: 0.185159s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 
@@ -145,7 +145,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini1.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini1.spthy.tmp
-  processing time: 0.122350749s
+  processing time: 0.185159s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini1_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini1_analyzed.spthy
@@ -123,7 +123,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -133,7 +133,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini1.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini1.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini1.spthy.tmp
-  processing time: 0.185159s
+  processing time: 0.091312662s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 
@@ -145,7 +145,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini1.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini1.spthy.tmp
-  processing time: 0.185159s
+  processing time: 0.091312662s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini2_analyzed.spthy
@@ -140,7 +140,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -150,7 +150,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini2.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini2.spthy.tmp
-  processing time: 0.260948s
+  processing time: 0.098965915s
   A_impossible (all-traces): verified (2 steps)
   B_possible (exists-trace): verified (7 steps)
 
@@ -162,7 +162,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini2.spthy.tmp
-  processing time: 0.260948s
+  processing time: 0.098965915s
   A_impossible (all-traces): verified (2 steps)
   B_possible (exists-trace): verified (7 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini2_analyzed.spthy
@@ -140,7 +140,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -150,7 +150,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini2.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini2.spthy.tmp
-  processing time: 0.179813571s
+  processing time: 0.260948s
   A_impossible (all-traces): verified (2 steps)
   B_possible (exists-trace): verified (7 steps)
 
@@ -162,7 +162,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini2.spthy.tmp
-  processing time: 0.179813571s
+  processing time: 0.260948s
   A_impossible (all-traces): verified (2 steps)
   B_possible (exists-trace): verified (7 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini3_analyzed.spthy
@@ -173,7 +173,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -183,7 +183,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini3.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini3.spthy.tmp
-  processing time: 0.160452998s
+  processing time: 0.309914s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   A_once (all-traces): verified (8 steps)
@@ -197,7 +197,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini3.spthy.tmp
-  processing time: 0.160452998s
+  processing time: 0.309914s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   A_once (all-traces): verified (8 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini3_analyzed.spthy
@@ -173,7 +173,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -183,7 +183,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini3.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini3.spthy.tmp
-  processing time: 0.309914s
+  processing time: 0.132866951s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   A_once (all-traces): verified (8 steps)
@@ -197,7 +197,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini3.spthy.tmp
-  processing time: 0.309914s
+  processing time: 0.132866951s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   A_once (all-traces): verified (8 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini4_analyzed.spthy
@@ -123,7 +123,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -133,7 +133,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini4.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini4.spthy.tmp
-  processing time: 0.127202989s
+  processing time: 0.213181s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 
@@ -145,7 +145,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini4.spthy.tmp
-  processing time: 0.127202989s
+  processing time: 0.213181s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini4_analyzed.spthy
@@ -123,7 +123,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -133,7 +133,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini4.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini4.spthy.tmp
-  processing time: 0.213181s
+  processing time: 0.102002336s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 
@@ -145,7 +145,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini4.spthy.tmp
-  processing time: 0.213181s
+  processing time: 0.102002336s
   A_possible (exists-trace): verified (5 steps)
   B_impossible (all-traces): verified (4 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini5_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini5_analyzed.spthy
@@ -227,7 +227,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -237,7 +237,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini5.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini5.spthy.tmp
-  processing time: 0.550689s
+  processing time: 0.200768352s
   A_possible (exists-trace): verified (9 steps)
   B_impossible (all-traces): verified (3 steps)
   C_possible (exists-trace): verified (7 steps)
@@ -250,7 +250,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini5.spthy.tmp
-  processing time: 0.550689s
+  processing time: 0.200768352s
   A_possible (exists-trace): verified (9 steps)
   B_impossible (all-traces): verified (3 steps)
   C_possible (exists-trace): verified (7 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini5_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini5_analyzed.spthy
@@ -227,7 +227,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -237,7 +237,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini5.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini5.spthy.tmp
-  processing time: 0.263519595s
+  processing time: 0.550689s
   A_possible (exists-trace): verified (9 steps)
   B_impossible (all-traces): verified (3 steps)
   C_possible (exists-trace): verified (7 steps)
@@ -250,7 +250,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini5.spthy.tmp
-  processing time: 0.263519595s
+  processing time: 0.550689s
   A_possible (exists-trace): verified (9 steps)
   B_impossible (all-traces): verified (3 steps)
   C_possible (exists-trace): verified (7 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini6_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini6_analyzed.spthy
@@ -169,7 +169,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -179,7 +179,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini6.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini6.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini6.spthy.tmp
-  processing time: 0.185145677s
+  processing time: 0.380636s
   A_possible (exists-trace): verified (10 steps)
   B_impossible (all-traces): verified (2 steps)
 
@@ -191,7 +191,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini6.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini6.spthy.tmp
-  processing time: 0.185145677s
+  processing time: 0.380636s
   A_possible (exists-trace): verified (10 steps)
   B_impossible (all-traces): verified (2 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini6_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini6_analyzed.spthy
@@ -169,7 +169,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -179,7 +179,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini6.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini6.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini6.spthy.tmp
-  processing time: 0.380636s
+  processing time: 0.155113251s
   A_possible (exists-trace): verified (10 steps)
   B_impossible (all-traces): verified (2 steps)
 
@@ -191,7 +191,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini6.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini6.spthy.tmp
-  processing time: 0.380636s
+  processing time: 0.155113251s
   A_possible (exists-trace): verified (10 steps)
   B_impossible (all-traces): verified (2 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini7_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini7_analyzed.spthy
@@ -220,7 +220,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -230,7 +230,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini7.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini7.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini7.spthy.tmp
-  processing time: 0.158410577s
+  processing time: 0.360748s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (8 steps)
   C_possible (exists-trace): verified (8 steps)
@@ -245,7 +245,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini7.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini7.spthy.tmp
-  processing time: 0.158410577s
+  processing time: 0.360748s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (8 steps)
   C_possible (exists-trace): verified (8 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini7_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini7_analyzed.spthy
@@ -220,7 +220,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -230,7 +230,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini7.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini7.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini7.spthy.tmp
-  processing time: 0.360748s
+  processing time: 0.117587324s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (8 steps)
   C_possible (exists-trace): verified (8 steps)
@@ -245,7 +245,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini7.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini7.spthy.tmp
-  processing time: 0.360748s
+  processing time: 0.117587324s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (8 steps)
   C_possible (exists-trace): verified (8 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini8_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini8_analyzed.spthy
@@ -98,7 +98,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -108,7 +108,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini8.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini8.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini8.spthy.tmp
-  processing time: 0.122275s
+  processing time: 0.058462667s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 
@@ -120,7 +120,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini8.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini8.spthy.tmp
-  processing time: 0.122275s
+  processing time: 0.058462667s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini8_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini8_analyzed.spthy
@@ -98,7 +98,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -108,7 +108,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini8.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini8.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini8.spthy.tmp
-  processing time: 0.083140786s
+  processing time: 0.122275s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 
@@ -120,7 +120,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini8.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini8.spthy.tmp
-  processing time: 0.083140786s
+  processing time: 0.122275s
   A_enforced (all-traces): verified (2 steps)
   B_not_enforced (exists-trace): verified (5 steps)
 

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini9_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini9_analyzed.spthy
@@ -222,7 +222,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -232,7 +232,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini9.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini9.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini9.spthy.tmp
-  processing time: 0.556685s
+  processing time: 0.180402583s
   A_possible (exists-trace): verified (15 steps)
   B_possible (exists-trace): verified (7 steps)
   A_or_B (all-traces): verified (7 steps)
@@ -245,7 +245,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini9.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini9.spthy.tmp
-  processing time: 0.556685s
+  processing time: 0.180402583s
   A_possible (exists-trace): verified (15 steps)
   B_possible (exists-trace): verified (7 steps)
   A_or_B (all-traces): verified (7 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/mini9_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/mini9_analyzed.spthy
@@ -222,7 +222,7 @@ restriction reliable:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -232,7 +232,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/mini9.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/mini9.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini9.spthy.tmp
-  processing time: 0.243174609s
+  processing time: 0.556685s
   A_possible (exists-trace): verified (15 steps)
   B_possible (exists-trace): verified (7 steps)
   A_or_B (all-traces): verified (7 steps)
@@ -245,7 +245,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/mini9.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/mini9.spthy.tmp
-  processing time: 0.243174609s
+  processing time: 0.556685s
   A_possible (exists-trace): verified (15 steps)
   B_possible (exists-trace): verified (7 steps)
   A_or_B (all-traces): verified (7 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-2_analyzed.spthy
@@ -221,7 +221,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -231,7 +231,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy.tmp
-  processing time: 0.256532s
+  processing time: 0.116975653s
   A_possible (exists-trace): verified (7 steps)
   B_possible (exists-trace): verified (7 steps)
   C_possible (exists-trace): verified (7 steps)
@@ -245,7 +245,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy.tmp
-  processing time: 0.256532s
+  processing time: 0.116975653s
   A_possible (exists-trace): verified (7 steps)
   B_possible (exists-trace): verified (7 steps)
   C_possible (exists-trace): verified (7 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-2_analyzed.spthy
@@ -221,7 +221,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -231,7 +231,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy.tmp
-  processing time: 0.141321384s
+  processing time: 0.256532s
   A_possible (exists-trace): verified (7 steps)
   B_possible (exists-trace): verified (7 steps)
   C_possible (exists-trace): verified (7 steps)
@@ -245,7 +245,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-2.spthy.tmp
-  processing time: 0.141321384s
+  processing time: 0.256532s
   A_possible (exists-trace): verified (7 steps)
   B_possible (exists-trace): verified (7 steps)
   C_possible (exists-trace): verified (7 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-3_analyzed.spthy
@@ -181,7 +181,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -191,7 +191,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy.tmp
-  processing time: 0.106259461s
+  processing time: 0.175148s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -205,7 +205,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy.tmp
-  processing time: 0.106259461s
+  processing time: 0.175148s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-3_analyzed.spthy
@@ -181,7 +181,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -191,7 +191,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy.tmp
-  processing time: 0.175148s
+  processing time: 0.110875731s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -205,7 +205,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-3.spthy.tmp
-  processing time: 0.175148s
+  processing time: 0.110875731s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-4_analyzed.spthy
@@ -181,7 +181,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -191,7 +191,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy.tmp
-  processing time: 0.125901901s
+  processing time: 0.203554s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -205,7 +205,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy.tmp
-  processing time: 0.125901901s
+  processing time: 0.203554s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-4_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-4_analyzed.spthy
@@ -181,7 +181,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -191,7 +191,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy.tmp
-  processing time: 0.203554s
+  processing time: 0.10961319s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -205,7 +205,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-4.spthy.tmp
-  processing time: 0.203554s
+  processing time: 0.10961319s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-5_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-5_analyzed.spthy
@@ -290,7 +290,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -300,7 +300,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy.tmp
-  processing time: 0.167087992s
+  processing time: 0.450164s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -316,7 +316,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy.tmp
-  processing time: 0.167087992s
+  processing time: 0.450164s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-5_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested-5_analyzed.spthy
@@ -290,7 +290,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -300,7 +300,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy.tmp
-  processing time: 0.450164s
+  processing time: 0.145508666s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -316,7 +316,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested-5.spthy.tmp
-  processing time: 0.450164s
+  processing time: 0.145508666s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested_analyzed.spthy
@@ -244,7 +244,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -254,7 +254,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested.spthy.tmp
-  processing time: 0.305222s
+  processing time: 0.083198148s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -272,7 +272,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested.spthy.tmp
-  processing time: 0.305222s
+  processing time: 0.083198148s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-nested_analyzed.spthy
@@ -244,7 +244,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -254,7 +254,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-nested.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested.spthy.tmp
-  processing time: 0.143994595s
+  processing time: 0.305222s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)
@@ -272,7 +272,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-nested.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-nested.spthy.tmp
-  processing time: 0.143994595s
+  processing time: 0.305222s
   A_possible (exists-trace): verified (5 steps)
   B_possible (exists-trace): verified (5 steps)
   C_possible (exists-trace): verified (5 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-two-replications_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-two-replications_analyzed.spthy
@@ -155,7 +155,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -165,7 +165,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy.tmp
-  processing time: 0.127575s
+  processing time: 0.079804826s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   no_progress_possible (exists-trace): verified (2 steps)
@@ -180,7 +180,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy.tmp
-  processing time: 0.127575s
+  processing time: 0.079804826s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   no_progress_possible (exists-trace): verified (2 steps)

--- a/case-studies-regression/sapic/fast/fairexchange-mini/ndc-two-replications_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/fairexchange-mini/ndc-two-replications_analyzed.spthy
@@ -155,7 +155,7 @@ restriction progressInit:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -165,7 +165,7 @@ analyzing: examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy.tmp
-  processing time: 0.112946235s
+  processing time: 0.127575s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   no_progress_possible (exists-trace): verified (2 steps)
@@ -180,7 +180,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy
 
   output:          examples/sapic/fast/fairexchange-mini/ndc-two-replications.spthy.tmp
-  processing time: 0.112946235s
+  processing time: 0.127575s
   A_possible (exists-trace): verified (4 steps)
   B_possible (exists-trace): verified (4 steps)
   no_progress_possible (exists-trace): verified (2 steps)

--- a/case-studies-regression/sapic/fast/feature-boundonce/boundonce_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-boundonce/boundonce_analyzed.spthy
@@ -46,7 +46,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -56,7 +56,7 @@ analyzing: examples/sapic/fast/feature-boundonce/boundonce.spthy
 analyzed: examples/sapic/fast/feature-boundonce/boundonce.spthy
 
   output:          examples/sapic/fast/feature-boundonce/boundonce.spthy.tmp
-  processing time: 0.064681s
+  processing time: 0.054533185s
 
 
 ------------------------------------------------------------------------------
@@ -67,7 +67,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-boundonce/boundonce.spthy
 
   output:          examples/sapic/fast/feature-boundonce/boundonce.spthy.tmp
-  processing time: 0.064681s
+  processing time: 0.054533185s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-boundonce/boundonce_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-boundonce/boundonce_analyzed.spthy
@@ -46,7 +46,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -56,7 +56,7 @@ analyzing: examples/sapic/fast/feature-boundonce/boundonce.spthy
 analyzed: examples/sapic/fast/feature-boundonce/boundonce.spthy
 
   output:          examples/sapic/fast/feature-boundonce/boundonce.spthy.tmp
-  processing time: 0.060192346s
+  processing time: 0.064681s
 
 
 ------------------------------------------------------------------------------
@@ -67,7 +67,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-boundonce/boundonce.spthy
 
   output:          examples/sapic/fast/feature-boundonce/boundonce.spthy.tmp
-  processing time: 0.060192346s
+  processing time: 0.064681s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel_analyzed.spthy
@@ -78,7 +78,7 @@ restriction in_event:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -88,7 +88,7 @@ analyzing: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-p
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy.tmp
-  processing time: 0.090420689s
+  processing time: 0.125015s
   test (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -99,7 +99,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy.tmp
-  processing time: 0.090420689s
+  processing time: 0.125015s
   test (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel_analyzed.spthy
@@ -78,7 +78,7 @@ restriction in_event:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -88,7 +88,7 @@ analyzing: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-p
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy.tmp
-  processing time: 0.125015s
+  processing time: 0.060736908s
   test (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -99,7 +99,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-private-channel.spthy.tmp
-  processing time: 0.125015s
+  processing time: 0.060736908s
   test (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel_analyzed.spthy
@@ -71,7 +71,7 @@ restriction in_event:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -81,7 +81,7 @@ analyzing: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-p
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy.tmp
-  processing time: 0.113234s
+  processing time: 0.050532273s
   test (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy.tmp
-  processing time: 0.113234s
+  processing time: 0.050532273s
   test (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel_analyzed.spthy
@@ -71,7 +71,7 @@ restriction in_event:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -81,7 +81,7 @@ analyzing: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-p
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy.tmp
-  processing time: 0.066367282s
+  processing time: 0.113234s
   test (all-traces): verified (4 steps)
 
 ------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy
 
   output:          examples/sapic/fast/feature-inevent-restriction/inevent-restriction-public-channel.spthy.tmp
-  processing time: 0.066367282s
+  processing time: 0.113234s
   test (all-traces): verified (4 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks2_analyzed.spthy
@@ -46,7 +46,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -56,7 +56,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/let-blocks2.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks2.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks2.spthy.tmp
-  processing time: 0.095588672s
+  processing time: 0.115838s
 
 
 ------------------------------------------------------------------------------
@@ -67,7 +67,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks2.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks2.spthy.tmp
-  processing time: 0.095588672s
+  processing time: 0.115838s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks2_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks2_analyzed.spthy
@@ -46,7 +46,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -56,7 +56,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/let-blocks2.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks2.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks2.spthy.tmp
-  processing time: 0.115838s
+  processing time: 0.056060875s
 
 
 ------------------------------------------------------------------------------
@@ -67,7 +67,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks2.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks2.spthy.tmp
-  processing time: 0.115838s
+  processing time: 0.056060875s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks3_analyzed.spthy
@@ -36,7 +36,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -46,7 +46,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/let-blocks3.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks3.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks3.spthy.tmp
-  processing time: 0.070032078s
+  processing time: 0.058174s
 
 
 ------------------------------------------------------------------------------
@@ -57,7 +57,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks3.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks3.spthy.tmp
-  processing time: 0.070032078s
+  processing time: 0.058174s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks3_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks3_analyzed.spthy
@@ -36,7 +36,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -46,7 +46,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/let-blocks3.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks3.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks3.spthy.tmp
-  processing time: 0.058174s
+  processing time: 0.039568899s
 
 
 ------------------------------------------------------------------------------
@@ -57,7 +57,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks3.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks3.spthy.tmp
-  processing time: 0.058174s
+  processing time: 0.039568899s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks_analyzed.spthy
@@ -731,7 +731,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -741,7 +741,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/let-blocks.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks.spthy.tmp
-  processing time: 2.008544488s
+  processing time: 5.036532s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)
@@ -756,7 +756,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks.spthy.tmp
-  processing time: 2.008544488s
+  processing time: 5.036532s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)

--- a/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/let-blocks_analyzed.spthy
@@ -731,7 +731,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -741,7 +741,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/let-blocks.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks.spthy.tmp
-  processing time: 5.036532s
+  processing time: 2.274623952s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)
@@ -756,7 +756,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/let-blocks.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/let-blocks.spthy.tmp
-  processing time: 5.036532s
+  processing time: 2.274623952s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (47 steps)

--- a/case-studies-regression/sapic/fast/feature-let-bindings/match_new_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/match_new_analyzed.spthy
@@ -98,7 +98,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -108,7 +108,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/match_new.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/match_new.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/match_new.spthy.tmp
-  processing time: 0.146896s
+  processing time: 0.062681788s
   no_acceptP (all-traces): verified (2 steps)
   acceptQ (exists-trace): verified (3 steps)
 
@@ -120,7 +120,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/match_new.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/match_new.spthy.tmp
-  processing time: 0.146896s
+  processing time: 0.062681788s
   no_acceptP (all-traces): verified (2 steps)
   acceptQ (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/feature-let-bindings/match_new_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-let-bindings/match_new_analyzed.spthy
@@ -98,7 +98,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -108,7 +108,7 @@ analyzing: examples/sapic/fast/feature-let-bindings/match_new.spthy
 analyzed: examples/sapic/fast/feature-let-bindings/match_new.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/match_new.spthy.tmp
-  processing time: 0.083793658s
+  processing time: 0.146896s
   no_acceptP (all-traces): verified (2 steps)
   acceptQ (exists-trace): verified (3 steps)
 
@@ -120,7 +120,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-let-bindings/match_new.spthy
 
   output:          examples/sapic/fast/feature-let-bindings/match_new.spthy.tmp
-  processing time: 0.083793658s
+  processing time: 0.146896s
   no_acceptP (all-traces): verified (2 steps)
   acceptQ (exists-trace): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/feature-locations/AC_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/AC_analyzed.spthy
@@ -52,7 +52,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.34) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.2 ) @ #t0)
                      ⇒
@@ -232,7 +232,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.34) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.1 ) @ #t0)
                      ⇒
@@ -430,7 +430,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.2 ) @ #t0)
                      ⇒
@@ -514,7 +514,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.1 ) @ #t0)
                      ⇒
@@ -1008,7 +1008,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1024,7 +1024,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1039,7 +1039,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1049,7 +1049,7 @@ analyzing: examples/sapic/fast/feature-locations/AC.spthy
 analyzed: examples/sapic/fast/feature-locations/AC.spthy
 
   output:          examples/sapic/fast/feature-locations/AC.spthy.tmp
-  processing time: 7.405606817s
+  processing time: 11.115128s
   attested_comput (all-traces): verified (184 steps)
 
 ------------------------------------------------------------------------------
@@ -1060,7 +1060,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/AC.spthy
 
   output:          examples/sapic/fast/feature-locations/AC.spthy.tmp
-  processing time: 7.405606817s
+  processing time: 11.115128s
   attested_comput (all-traces): verified (184 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-locations/AC_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/AC_analyzed.spthy
@@ -52,7 +52,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.34) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.2 ) @ #t0)
                      ⇒
@@ -232,7 +232,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.34) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.1 ) @ #t0)
                      ⇒
@@ -430,7 +430,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.2 ) @ #t0)
                      ⇒
@@ -514,7 +514,7 @@ next
                    ∧
                     (#vr.2 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.2, ~n.1 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.1 ) @ #t0)
                      ⇒
@@ -1008,7 +1008,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1024,7 +1024,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1039,7 +1039,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1049,7 +1049,7 @@ analyzing: examples/sapic/fast/feature-locations/AC.spthy
 analyzed: examples/sapic/fast/feature-locations/AC.spthy
 
   output:          examples/sapic/fast/feature-locations/AC.spthy.tmp
-  processing time: 11.115128s
+  processing time: 8.752980035s
   attested_comput (all-traces): verified (184 steps)
 
 ------------------------------------------------------------------------------
@@ -1060,7 +1060,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/AC.spthy
 
   output:          examples/sapic/fast/feature-locations/AC.spthy.tmp
-  processing time: 11.115128s
+  processing time: 8.752980035s
   attested_comput (all-traces): verified (184 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-locations/AKE_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/AKE_analyzed.spthy
@@ -283,7 +283,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -293,7 +293,7 @@ analyzing: examples/sapic/fast/feature-locations/AKE.spthy
 analyzed: examples/sapic/fast/feature-locations/AKE.spthy
 
   output:          examples/sapic/fast/feature-locations/AKE.spthy.tmp
-  processing time: 0.578711966s
+  processing time: 1.250389s
   sanity3 (all-traces): verified (3 steps)
   secrecy (all-traces): verified (7 steps)
 
@@ -305,7 +305,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/AKE.spthy
 
   output:          examples/sapic/fast/feature-locations/AKE.spthy.tmp
-  processing time: 0.578711966s
+  processing time: 1.250389s
   sanity3 (all-traces): verified (3 steps)
   secrecy (all-traces): verified (7 steps)
 

--- a/case-studies-regression/sapic/fast/feature-locations/AKE_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/AKE_analyzed.spthy
@@ -283,7 +283,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -293,7 +293,7 @@ analyzing: examples/sapic/fast/feature-locations/AKE.spthy
 analyzed: examples/sapic/fast/feature-locations/AKE.spthy
 
   output:          examples/sapic/fast/feature-locations/AKE.spthy.tmp
-  processing time: 1.250389s
+  processing time: 0.710949186s
   sanity3 (all-traces): verified (3 steps)
   secrecy (all-traces): verified (7 steps)
 
@@ -305,7 +305,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/AKE.spthy
 
   output:          examples/sapic/fast/feature-locations/AKE.spthy.tmp
-  processing time: 1.250389s
+  processing time: 0.710949186s
   sanity3 (all-traces): verified (3 steps)
   secrecy (all-traces): verified (7 steps)
 

--- a/case-studies-regression/sapic/fast/feature-locations/OTP_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/OTP_analyzed.spthy
@@ -1167,7 +1167,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1177,7 +1177,7 @@ analyzing: examples/sapic/fast/feature-locations/OTP.spthy
 analyzed: examples/sapic/fast/feature-locations/OTP.spthy
 
   output:          examples/sapic/fast/feature-locations/OTP.spthy.tmp
-  processing time: 10.665532012s
+  processing time: 19.504634s
   secrecy_key (all-traces): verified (8 steps)
   key_ex (all-traces): verified (15 steps)
   secrecy_ex (all-traces): verified (11 steps)
@@ -1195,7 +1195,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/OTP.spthy
 
   output:          examples/sapic/fast/feature-locations/OTP.spthy.tmp
-  processing time: 10.665532012s
+  processing time: 19.504634s
   secrecy_key (all-traces): verified (8 steps)
   key_ex (all-traces): verified (15 steps)
   secrecy_ex (all-traces): verified (11 steps)

--- a/case-studies-regression/sapic/fast/feature-locations/OTP_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/OTP_analyzed.spthy
@@ -1167,7 +1167,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1177,7 +1177,7 @@ analyzing: examples/sapic/fast/feature-locations/OTP.spthy
 analyzed: examples/sapic/fast/feature-locations/OTP.spthy
 
   output:          examples/sapic/fast/feature-locations/OTP.spthy.tmp
-  processing time: 19.504634s
+  processing time: 12.546810481s
   secrecy_key (all-traces): verified (8 steps)
   key_ex (all-traces): verified (15 steps)
   secrecy_ex (all-traces): verified (11 steps)
@@ -1195,7 +1195,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/OTP.spthy
 
   output:          examples/sapic/fast/feature-locations/OTP.spthy.tmp
-  processing time: 19.504634s
+  processing time: 12.546810481s
   secrecy_key (all-traces): verified (8 steps)
   key_ex (all-traces): verified (15 steps)
   secrecy_ex (all-traces): verified (11 steps)

--- a/case-studies-regression/sapic/fast/feature-locations/SOC_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/SOC_analyzed.spthy
@@ -91,7 +91,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -124,7 +124,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -177,7 +177,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -205,7 +205,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -261,7 +261,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -289,7 +289,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -429,7 +429,7 @@ solve( State_1211111111111111( init, ip, old_i, k, signed, skV, storeV,
                          ∧
                           (#vr.2 < #t2) ∧
                           (#t2 < #vr.53) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n.5 ) @ #t0)
                            ⇒
@@ -580,7 +580,7 @@ solve( State_1211111111111111( init, ip, old_i, k, signed, skV, storeV,
                          ∧
                           (#vr.2 < #t2) ∧
                           (#t2 < #vr.52) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n.5 ) @ #t0)
                            ⇒
@@ -1509,7 +1509,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1525,7 +1525,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1540,7 +1540,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1550,7 +1550,7 @@ analyzing: examples/sapic/fast/feature-locations/SOC.spthy
 analyzed: examples/sapic/fast/feature-locations/SOC.spthy
 
   output:          examples/sapic/fast/feature-locations/SOC.spthy.tmp
-  processing time: 9.798238872s
+  processing time: 14.707436s
   secrecy (all-traces): verified (5 steps)
   Input (all-traces): verified (41 steps)
   secrecy_computes2 (all-traces): verified (11 steps)
@@ -1565,7 +1565,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/SOC.spthy
 
   output:          examples/sapic/fast/feature-locations/SOC.spthy.tmp
-  processing time: 9.798238872s
+  processing time: 14.707436s
   secrecy (all-traces): verified (5 steps)
   Input (all-traces): verified (41 steps)
   secrecy_computes2 (all-traces): verified (11 steps)

--- a/case-studies-regression/sapic/fast/feature-locations/SOC_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/SOC_analyzed.spthy
@@ -91,7 +91,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -124,7 +124,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -177,7 +177,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -205,7 +205,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -261,7 +261,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -289,7 +289,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -429,7 +429,7 @@ solve( State_1211111111111111( init, ip, old_i, k, signed, skV, storeV,
                          ∧
                           (#vr.2 < #t2) ∧
                           (#t2 < #vr.53) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n.5 ) @ #t0)
                            ⇒
@@ -580,7 +580,7 @@ solve( State_1211111111111111( init, ip, old_i, k, signed, skV, storeV,
                          ∧
                           (#vr.2 < #t2) ∧
                           (#t2 < #vr.52) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.6, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n.5 ) @ #t0)
                            ⇒
@@ -1509,7 +1509,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1525,7 +1525,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -1540,7 +1540,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1550,7 +1550,7 @@ analyzing: examples/sapic/fast/feature-locations/SOC.spthy
 analyzed: examples/sapic/fast/feature-locations/SOC.spthy
 
   output:          examples/sapic/fast/feature-locations/SOC.spthy.tmp
-  processing time: 14.707436s
+  processing time: 13.197062219s
   secrecy (all-traces): verified (5 steps)
   Input (all-traces): verified (41 steps)
   secrecy_computes2 (all-traces): verified (11 steps)
@@ -1565,7 +1565,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/SOC.spthy
 
   output:          examples/sapic/fast/feature-locations/SOC.spthy.tmp
-  processing time: 14.707436s
+  processing time: 13.197062219s
   secrecy (all-traces): verified (5 steps)
   Input (all-traces): verified (41 steps)
   secrecy_computes2 (all-traces): verified (11 steps)

--- a/case-studies-regression/sapic/fast/feature-locations/licensing_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/licensing_analyzed.spthy
@@ -932,7 +932,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -942,7 +942,7 @@ analyzing: examples/sapic/fast/feature-locations/licensing.spthy
 analyzed: examples/sapic/fast/feature-locations/licensing.spthy
 
   output:          examples/sapic/fast/feature-locations/licensing.spthy.tmp
-  processing time: 10.332308s
+  processing time: 8.395902552s
   attested_comput (all-traces): verified (19 steps)
   unique (all-traces): verified (84 steps)
   final (all-traces): verified (44 steps)
@@ -955,7 +955,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/licensing.spthy
 
   output:          examples/sapic/fast/feature-locations/licensing.spthy.tmp
-  processing time: 10.332308s
+  processing time: 8.395902552s
   attested_comput (all-traces): verified (19 steps)
   unique (all-traces): verified (84 steps)
   final (all-traces): verified (44 steps)

--- a/case-studies-regression/sapic/fast/feature-locations/licensing_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locations/licensing_analyzed.spthy
@@ -932,7 +932,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -942,7 +942,7 @@ analyzing: examples/sapic/fast/feature-locations/licensing.spthy
 analyzed: examples/sapic/fast/feature-locations/licensing.spthy
 
   output:          examples/sapic/fast/feature-locations/licensing.spthy.tmp
-  processing time: 7.421431559s
+  processing time: 10.332308s
   attested_comput (all-traces): verified (19 steps)
   unique (all-traces): verified (84 steps)
   final (all-traces): verified (44 steps)
@@ -955,7 +955,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locations/licensing.spthy
 
   output:          examples/sapic/fast/feature-locations/licensing.spthy.tmp
-  processing time: 7.421431559s
+  processing time: 10.332308s
   attested_comput (all-traces): verified (19 steps)
   unique (all-traces): verified (84 steps)
   final (all-traces): verified (44 steps)

--- a/case-studies-regression/sapic/fast/feature-locking-restriction/locking-restriction_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locking-restriction/locking-restriction_analyzed.spthy
@@ -1,0 +1,111 @@
+theory LockingRestriction begin
+
+// Function signature and definition of the equational theory E
+
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+heuristic: p
+
+lemma ANotReachable:
+  all-traces "¬(∃ #t. A( ) @ #t)"
+/*
+guarded formula characterizing all counter-examples:
+"∃ #t. (A( ) @ #t)"
+*/
+simplify
+by solve( State_11( lock, lock.1 ) ▶₀ #t )
+
+rule (modulo E) Init[color=#ffffff, process="lock 'P';"]:
+   [ ] --[ Init( ) ]-> [ State_( ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) lockP_0_[color=#ffffff, process="lock 'P';"]:
+   [ State_( ), Fr( lock ) ]
+  --[ Lock_0( '0', lock, 'P' ), Lock( '0', lock, 'P' ) ]->
+   [ State_1( lock ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) lockP_0_1[color=#6c8040, process="lock 'P';"]:
+   [ State_1( lock ), Fr( lock.1 ) ]
+  --[ Lock_1( '1', lock.1, 'P' ), Lock( '1', lock.1, 'P' ) ]->
+   [ State_11( lock, lock.1 ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) eventA_0_11[color=#6c8040, process="event A( );"]:
+   [ State_11( lock, lock.1 ) ] --[ A( ) ]-> [ State_111( lock, lock.1 ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) unlockP_0_111[color=#6c8040, process="unlock 'P';"]:
+   [ State_111( lock, lock.1 ) ]
+  --[ Unlock_1( '1', lock.1, 'P' ), Unlock( '1', lock.1, 'P' ) ]->
+   [ State_1111( lock, lock.1 ) ]
+
+  /* has exactly the trivial AC variant */
+
+rule (modulo E) p_0_1111[color=#6c8040, process="0"]:
+   [ State_1111( lock, lock.1 ) ] --> [ ]
+
+  /* has exactly the trivial AC variant */
+
+restriction single_session:
+  "∀ #i #j. ((Init( ) @ #i) ∧ (Init( ) @ #j)) ⇒ (#i = #j)"
+  // safety formula
+
+restriction locking_1:
+  "∀ p pp l x lp #t1 #t3.
+    ((Lock_1( p, l, x ) @ #t1) ∧ (Lock( pp, lp, x ) @ #t3)) ⇒
+    ((((#t1 < #t3) ∧
+       (∃ #t2.
+         (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+          (∀ pp.1 lpp #t0.
+            (Lock( pp.1, lpp, x ) @ #t0) ⇒
+            (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
+         (∀ pp.1 lpp #t0.
+           (Unlock( pp.1, lpp, x ) @ #t0) ⇒
+           (((#t0 < #t1) ∨ (#t2 < #t0)) ∨ (#t2 = #t0))))) ∨
+      (#t3 < #t1)) ∨
+     (#t1 = #t3))"
+
+restriction locking_0:
+  "∀ p pp l x lp #t1 #t3.
+    ((Lock_0( p, l, x ) @ #t1) ∧ (Lock( pp, lp, x ) @ #t3)) ⇒
+    ((#t3 < #t1) ∨ (#t1 = #t3))"
+  // safety formula
+
+/* All well-formedness checks were successful. */
+
+end
+/* Output
+maude tool: 'maude'
+ checking version: 2.7.1. OK.
+ checking installation: OK.
+
+
+analyzing: examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
+
+------------------------------------------------------------------------------
+analyzed: examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
+
+  output:          examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy.tmp
+  processing time: 0.083803s
+  ANotReachable (all-traces): verified (2 steps)
+
+------------------------------------------------------------------------------
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
+
+  output:          examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy.tmp
+  processing time: 0.083803s
+  ANotReachable (all-traces): verified (2 steps)
+
+==============================================================================
+*/

--- a/case-studies-regression/sapic/fast/feature-locking-restriction/locking-restriction_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-locking-restriction/locking-restriction_analyzed.spthy
@@ -62,7 +62,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -83,7 +83,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -93,7 +93,7 @@ analyzing: examples/sapic/fast/feature-locking-restriction/locking-restriction.s
 analyzed: examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
 
   output:          examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy.tmp
-  processing time: 0.083803s
+  processing time: 0.062385388s
   ANotReachable (all-traces): verified (2 steps)
 
 ------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
 
   output:          examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy.tmp
-  processing time: 0.083803s
+  processing time: 0.062385388s
   ANotReachable (all-traces): verified (2 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-predicates/binding_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/binding_analyzed.spthy
@@ -106,7 +106,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -116,7 +116,7 @@ analyzing: examples/sapic/fast/feature-predicates/binding.spthy
 analyzed: examples/sapic/fast/feature-predicates/binding.spthy
 
   output:          examples/sapic/fast/feature-predicates/binding.spthy.tmp
-  processing time: 0.096485767s
+  processing time: 0.091513s
   C_exists (exists-trace): verified (4 steps)
   A_before_C (all-traces): verified (3 steps)
 
@@ -128,7 +128,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/binding.spthy
 
   output:          examples/sapic/fast/feature-predicates/binding.spthy.tmp
-  processing time: 0.096485767s
+  processing time: 0.091513s
   C_exists (exists-trace): verified (4 steps)
   A_before_C (all-traces): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/feature-predicates/binding_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/binding_analyzed.spthy
@@ -106,7 +106,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -116,7 +116,7 @@ analyzing: examples/sapic/fast/feature-predicates/binding.spthy
 analyzed: examples/sapic/fast/feature-predicates/binding.spthy
 
   output:          examples/sapic/fast/feature-predicates/binding.spthy.tmp
-  processing time: 0.091513s
+  processing time: 0.069346372s
   C_exists (exists-trace): verified (4 steps)
   A_before_C (all-traces): verified (3 steps)
 
@@ -128,7 +128,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/binding.spthy
 
   output:          examples/sapic/fast/feature-predicates/binding.spthy.tmp
-  processing time: 0.091513s
+  processing time: 0.069346372s
   C_exists (exists-trace): verified (4 steps)
   A_before_C (all-traces): verified (3 steps)
 

--- a/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-manual_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-manual_analyzed.spthy
@@ -126,7 +126,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -284,7 +284,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -312,7 +312,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n.1, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -400,7 +400,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -488,7 +488,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -516,7 +516,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -947,7 +947,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -962,7 +962,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -972,7 +972,7 @@ analyzing: examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy.tmp
-  processing time: 5.768109s
+  processing time: 2.778045421s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)
@@ -987,7 +987,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy.tmp
-  processing time: 5.768109s
+  processing time: 2.778045421s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)

--- a/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-manual_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-manual_analyzed.spthy
@@ -126,7 +126,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -284,7 +284,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -312,7 +312,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n.1, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -400,7 +400,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -488,7 +488,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -516,7 +516,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -947,7 +947,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -962,7 +962,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -972,7 +972,7 @@ analyzing: examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy.tmp
-  processing time: 2.78140646s
+  processing time: 5.768109s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)
@@ -987,7 +987,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-manual.spthy.tmp
-  processing time: 2.78140646s
+  processing time: 5.768109s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)

--- a/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict-variant_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict-variant_analyzed.spthy
@@ -127,7 +127,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -288,7 +288,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -316,7 +316,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n.1, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -408,7 +408,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -499,7 +499,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -527,7 +527,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -968,7 +968,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -983,7 +983,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -993,7 +993,7 @@ analyzing: examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy.tmp
-  processing time: 5.372734s
+  processing time: 3.362289948s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (60 steps)
@@ -1008,7 +1008,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy.tmp
-  processing time: 5.372734s
+  processing time: 3.362289948s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (60 steps)

--- a/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict-variant_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict-variant_analyzed.spthy
@@ -127,7 +127,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -288,7 +288,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -316,7 +316,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n.1, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -408,7 +408,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -499,7 +499,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -527,7 +527,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -968,7 +968,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -983,7 +983,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -993,7 +993,7 @@ analyzing: examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy.tmp
-  processing time: 2.818791706s
+  processing time: 5.372734s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (60 steps)
@@ -1008,7 +1008,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict-variant.spthy.tmp
-  processing time: 2.818791706s
+  processing time: 5.372734s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (60 steps)

--- a/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict_analyzed.spthy
@@ -124,7 +124,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -282,7 +282,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -310,7 +310,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n.1, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -398,7 +398,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -486,7 +486,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -514,7 +514,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -982,7 +982,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -997,7 +997,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1007,7 +1007,7 @@ analyzing: examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy.tmp
-  processing time: 2.758982516s
+  processing time: 4.665248s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)
@@ -1022,7 +1022,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy.tmp
-  processing time: 2.758982516s
+  processing time: 4.665248s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)

--- a/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/decwrap-destr-restrict_analyzed.spthy
@@ -124,7 +124,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -282,7 +282,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -310,7 +310,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n.1, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -398,7 +398,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -486,7 +486,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -514,7 +514,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -982,7 +982,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -997,7 +997,7 @@ restriction locking_0:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1007,7 +1007,7 @@ analyzing: examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy.tmp
-  processing time: 4.665248s
+  processing time: 3.038948841s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)
@@ -1022,7 +1022,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy
 
   output:          examples/sapic/fast/feature-predicates/decwrap-destr-restrict.spthy.tmp
-  processing time: 4.665248s
+  processing time: 3.038948841s
   can_create_key (exists-trace): verified (3 steps)
   can_obtain_wrapping (exists-trace): verified (11 steps)
   dec_limits (all-traces): verified (59 steps)

--- a/case-studies-regression/sapic/fast/feature-predicates/pub_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/pub_analyzed.spthy
@@ -305,7 +305,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -315,7 +315,7 @@ analyzing: examples/sapic/fast/feature-predicates/pub.spthy
 analyzed: examples/sapic/fast/feature-predicates/pub.spthy
 
   output:          examples/sapic/fast/feature-predicates/pub.spthy.tmp
-  processing time: 0.096002777s
+  processing time: 0.092562s
 
 
 ------------------------------------------------------------------------------
@@ -326,7 +326,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/pub.spthy
 
   output:          examples/sapic/fast/feature-predicates/pub.spthy.tmp
-  processing time: 0.096002777s
+  processing time: 0.092562s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-predicates/pub_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/pub_analyzed.spthy
@@ -305,7 +305,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -315,7 +315,7 @@ analyzing: examples/sapic/fast/feature-predicates/pub.spthy
 analyzed: examples/sapic/fast/feature-predicates/pub.spthy
 
   output:          examples/sapic/fast/feature-predicates/pub.spthy.tmp
-  processing time: 0.092562s
+  processing time: 0.160996163s
 
 
 ------------------------------------------------------------------------------
@@ -326,7 +326,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/pub.spthy
 
   output:          examples/sapic/fast/feature-predicates/pub.spthy.tmp
-  processing time: 0.092562s
+  processing time: 0.160996163s
 
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-predicates/simple_example_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/simple_example_analyzed.spthy
@@ -74,7 +74,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -84,7 +84,7 @@ analyzing: examples/sapic/fast/feature-predicates/simple_example.spthy
 analyzed: examples/sapic/fast/feature-predicates/simple_example.spthy
 
   output:          examples/sapic/fast/feature-predicates/simple_example.spthy.tmp
-  processing time: 0.072559s
+  processing time: 0.116265553s
   bogus_exists (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/simple_example.spthy
 
   output:          examples/sapic/fast/feature-predicates/simple_example.spthy.tmp
-  processing time: 0.072559s
+  processing time: 0.116265553s
   bogus_exists (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-predicates/simple_example_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/simple_example_analyzed.spthy
@@ -74,7 +74,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -84,7 +84,7 @@ analyzing: examples/sapic/fast/feature-predicates/simple_example.spthy
 analyzed: examples/sapic/fast/feature-predicates/simple_example.spthy
 
   output:          examples/sapic/fast/feature-predicates/simple_example.spthy.tmp
-  processing time: 0.087245364s
+  processing time: 0.072559s
   bogus_exists (exists-trace): verified (3 steps)
 
 ------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/simple_example.spthy
 
   output:          examples/sapic/fast/feature-predicates/simple_example.spthy.tmp
-  processing time: 0.087245364s
+  processing time: 0.072559s
   bogus_exists (exists-trace): verified (3 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-predicates/timepoints_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/timepoints_analyzed.spthy
@@ -28,7 +28,7 @@ SOLVED // trace found
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -38,7 +38,7 @@ analyzing: examples/sapic/fast/feature-predicates/timepoints.spthy
 analyzed: examples/sapic/fast/feature-predicates/timepoints.spthy
 
   output:          examples/sapic/fast/feature-predicates/timepoints.spthy.tmp
-  processing time: 0.056575s
+  processing time: 0.068770351s
   hi (exists-trace): verified (2 steps)
 
 ------------------------------------------------------------------------------
@@ -49,7 +49,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-predicates/timepoints.spthy
 
   output:          examples/sapic/fast/feature-predicates/timepoints.spthy.tmp
-  processing time: 0.056575s
+  processing time: 0.068770351s
   hi (exists-trace): verified (2 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/fast/feature-predicates/timepoints_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-predicates/timepoints_analyzed.spthy
@@ -1,0 +1,56 @@
+theory TestPredicate begin
+
+// Function signature and definition of the equational theory E
+
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+
+
+rule (modulo E) ActionRule:
+   [ ] --[ Action( 'hi' ) ]-> [ ]
+
+  /* has exactly the trivial AC variant */
+
+predicate: Exists( #time )<=>∃ val. Action( val ) @ #time
+
+lemma hi:
+  exists-trace "∃ #t val. Action( val ) @ #t"
+/*
+guarded formula characterizing all satisfying traces:
+"∃ #t val. (Action( val ) @ #t)"
+*/
+simplify
+SOLVED // trace found
+
+/* All well-formedness checks were successful. */
+
+end
+/* Output
+maude tool: 'maude'
+ checking version: 2.7.1. OK.
+ checking installation: OK.
+
+
+analyzing: examples/sapic/fast/feature-predicates/timepoints.spthy
+
+------------------------------------------------------------------------------
+analyzed: examples/sapic/fast/feature-predicates/timepoints.spthy
+
+  output:          examples/sapic/fast/feature-predicates/timepoints.spthy.tmp
+  processing time: 0.056575s
+  hi (exists-trace): verified (2 steps)
+
+------------------------------------------------------------------------------
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/sapic/fast/feature-predicates/timepoints.spthy
+
+  output:          examples/sapic/fast/feature-predicates/timepoints.spthy.tmp
+  processing time: 0.056575s
+  hi (exists-trace): verified (2 steps)
+
+==============================================================================
+*/

--- a/case-studies-regression/sapic/fast/feature-secret-channel/secret-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-secret-channel/secret-channel_analyzed.spthy
@@ -307,7 +307,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -317,7 +317,7 @@ analyzing: examples/sapic/fast/feature-secret-channel/secret-channel.spthy
 analyzed: examples/sapic/fast/feature-secret-channel/secret-channel.spthy
 
   output:          examples/sapic/fast/feature-secret-channel/secret-channel.spthy.tmp
-  processing time: 1.082376548s
+  processing time: 2.147991s
   secret (all-traces): verified (3 steps)
   auth (all-traces): verified (5 steps)
   auth2 (all-traces): verified (5 steps)
@@ -332,7 +332,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-secret-channel/secret-channel.spthy
 
   output:          examples/sapic/fast/feature-secret-channel/secret-channel.spthy.tmp
-  processing time: 1.082376548s
+  processing time: 2.147991s
   secret (all-traces): verified (3 steps)
   auth (all-traces): verified (5 steps)
   auth2 (all-traces): verified (5 steps)

--- a/case-studies-regression/sapic/fast/feature-secret-channel/secret-channel_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-secret-channel/secret-channel_analyzed.spthy
@@ -307,7 +307,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -317,7 +317,7 @@ analyzing: examples/sapic/fast/feature-secret-channel/secret-channel.spthy
 analyzed: examples/sapic/fast/feature-secret-channel/secret-channel.spthy
 
   output:          examples/sapic/fast/feature-secret-channel/secret-channel.spthy.tmp
-  processing time: 2.147991s
+  processing time: 1.231358503s
   secret (all-traces): verified (3 steps)
   auth (all-traces): verified (5 steps)
   auth2 (all-traces): verified (5 steps)
@@ -332,7 +332,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-secret-channel/secret-channel.spthy
 
   output:          examples/sapic/fast/feature-secret-channel/secret-channel.spthy.tmp
-  processing time: 2.147991s
+  processing time: 1.231358503s
   secret (all-traces): verified (3 steps)
   auth (all-traces): verified (5 steps)
   auth2 (all-traces): verified (5 steps)

--- a/case-studies-regression/sapic/fast/feature-xor/CH07_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-xor/CH07_analyzed.spthy
@@ -1362,7 +1362,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1372,7 +1372,7 @@ analyzing: examples/sapic/fast/feature-xor/CH07.spthy
 analyzed: examples/sapic/fast/feature-xor/CH07.spthy
 
   output:          examples/sapic/fast/feature-xor/CH07.spthy.tmp
-  processing time: 10.085023s
+  processing time: 9.000325699s
   recentalive_tag_attack (exists-trace): verified (10 steps)
   recentalive_reader (all-traces): verified (24 steps)
   noninjectiveagreement_tag (all-traces): verified (77 steps)
@@ -1387,7 +1387,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-xor/CH07.spthy
 
   output:          examples/sapic/fast/feature-xor/CH07.spthy.tmp
-  processing time: 10.085023s
+  processing time: 9.000325699s
   recentalive_tag_attack (exists-trace): verified (10 steps)
   recentalive_reader (all-traces): verified (24 steps)
   noninjectiveagreement_tag (all-traces): verified (77 steps)

--- a/case-studies-regression/sapic/fast/feature-xor/CH07_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-xor/CH07_analyzed.spthy
@@ -1362,7 +1362,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1372,7 +1372,7 @@ analyzing: examples/sapic/fast/feature-xor/CH07.spthy
 analyzed: examples/sapic/fast/feature-xor/CH07.spthy
 
   output:          examples/sapic/fast/feature-xor/CH07.spthy.tmp
-  processing time: 8.650198134s
+  processing time: 10.085023s
   recentalive_tag_attack (exists-trace): verified (10 steps)
   recentalive_reader (all-traces): verified (24 steps)
   noninjectiveagreement_tag (all-traces): verified (77 steps)
@@ -1387,7 +1387,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-xor/CH07.spthy
 
   output:          examples/sapic/fast/feature-xor/CH07.spthy.tmp
-  processing time: 8.650198134s
+  processing time: 10.085023s
   recentalive_tag_attack (exists-trace): verified (10 steps)
   recentalive_reader (all-traces): verified (24 steps)
   noninjectiveagreement_tag (all-traces): verified (77 steps)

--- a/case-studies-regression/sapic/fast/feature-xor/CRxor_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-xor/CRxor_analyzed.spthy
@@ -738,7 +738,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -748,7 +748,7 @@ analyzing: examples/sapic/fast/feature-xor/CRxor.spthy
 analyzed: examples/sapic/fast/feature-xor/CRxor.spthy
 
   output:          examples/sapic/fast/feature-xor/CRxor.spthy.tmp
-  processing time: 2.448601532s
+  processing time: 3.793927s
   alive (all-traces): verified (111 steps)
   recentalive_tag (exists-trace): verified (10 steps)
   executable (exists-trace): verified (9 steps)
@@ -761,7 +761,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-xor/CRxor.spthy
 
   output:          examples/sapic/fast/feature-xor/CRxor.spthy.tmp
-  processing time: 2.448601532s
+  processing time: 3.793927s
   alive (all-traces): verified (111 steps)
   recentalive_tag (exists-trace): verified (10 steps)
   executable (exists-trace): verified (9 steps)

--- a/case-studies-regression/sapic/fast/feature-xor/CRxor_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-xor/CRxor_analyzed.spthy
@@ -738,7 +738,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -748,7 +748,7 @@ analyzing: examples/sapic/fast/feature-xor/CRxor.spthy
 analyzed: examples/sapic/fast/feature-xor/CRxor.spthy
 
   output:          examples/sapic/fast/feature-xor/CRxor.spthy.tmp
-  processing time: 3.793927s
+  processing time: 3.008278777s
   alive (all-traces): verified (111 steps)
   recentalive_tag (exists-trace): verified (10 steps)
   executable (exists-trace): verified (9 steps)
@@ -761,7 +761,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-xor/CRxor.spthy
 
   output:          examples/sapic/fast/feature-xor/CRxor.spthy.tmp
-  processing time: 3.793927s
+  processing time: 3.008278777s
   alive (all-traces): verified (111 steps)
   recentalive_tag (exists-trace): verified (10 steps)
   executable (exists-trace): verified (9 steps)

--- a/case-studies-regression/sapic/fast/feature-xor/KCL07_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-xor/KCL07_analyzed.spthy
@@ -930,7 +930,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -940,7 +940,7 @@ analyzing: examples/sapic/fast/feature-xor/KCL07.spthy
 analyzed: examples/sapic/fast/feature-xor/KCL07.spthy
 
   output:          examples/sapic/fast/feature-xor/KCL07.spthy.tmp
-  processing time: 6.901185s
+  processing time: 7.724773295s
   recentalive_tag (all-traces): verified (223 steps)
   executable (exists-trace): verified (16 steps)
 
@@ -952,7 +952,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-xor/KCL07.spthy
 
   output:          examples/sapic/fast/feature-xor/KCL07.spthy.tmp
-  processing time: 6.901185s
+  processing time: 7.724773295s
   recentalive_tag (all-traces): verified (223 steps)
   executable (exists-trace): verified (16 steps)
 

--- a/case-studies-regression/sapic/fast/feature-xor/KCL07_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/feature-xor/KCL07_analyzed.spthy
@@ -930,7 +930,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -940,7 +940,7 @@ analyzing: examples/sapic/fast/feature-xor/KCL07.spthy
 analyzed: examples/sapic/fast/feature-xor/KCL07.spthy
 
   output:          examples/sapic/fast/feature-xor/KCL07.spthy.tmp
-  processing time: 5.21100226s
+  processing time: 6.901185s
   recentalive_tag (all-traces): verified (223 steps)
   executable (exists-trace): verified (16 steps)
 
@@ -952,7 +952,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/feature-xor/KCL07.spthy
 
   output:          examples/sapic/fast/feature-xor/KCL07.spthy.tmp
-  processing time: 5.21100226s
+  processing time: 6.901185s
   recentalive_tag (all-traces): verified (223 steps)
   executable (exists-trace): verified (16 steps)
 

--- a/case-studies-regression/sapic/fast/statVerifLeftRight/stateverif_left_right_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/statVerifLeftRight/stateverif_left_right_analyzed.spthy
@@ -71,7 +71,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -104,7 +104,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -144,7 +144,7 @@ next
                          ∧
                           (#vr.3 < #t2) ∧
                           (#t2 < #vr.22) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n ) @ #t0)
                            ⇒
@@ -367,7 +367,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.24) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n ) @ #t0)
                            ⇒
@@ -599,7 +599,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -627,7 +627,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -683,7 +683,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -711,7 +711,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -782,7 +782,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.16 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -842,7 +842,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.17 < #t2) ∧
                     (#t2 < #vr.35) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -908,7 +908,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.16 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -1011,7 +1011,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.40 < #t2) ∧
                                         (#t2 < #vr.57) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -1142,7 +1142,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.41 < #t2) ∧
                                         (#t2 < #vr.59) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -1292,7 +1292,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.17 < #t2) ∧
                     (#t2 < #vr.35) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -1395,7 +1395,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.42 < #t2) ∧
                                         (#t2 < #vr.59) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -1520,7 +1520,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.43 < #t2) ∧
                                         (#t2 < #vr.61) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -2184,7 +2184,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -2200,7 +2200,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -2215,7 +2215,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -2225,7 +2225,7 @@ analyzing: examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy
 analyzed: examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy
 
   output:          examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy.tmp
-  processing time: 15.00160648s
+  processing time: 25.091718s
   source (all-traces): verified (174 steps)
   reachability_left (exists-trace): verified (14 steps)
   reachability_right (exists-trace): verified (14 steps)
@@ -2239,7 +2239,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy
 
   output:          examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy.tmp
-  processing time: 15.00160648s
+  processing time: 25.091718s
   source (all-traces): verified (174 steps)
   reachability_left (exists-trace): verified (14 steps)
   reachability_right (exists-trace): verified (14 steps)

--- a/case-studies-regression/sapic/fast/statVerifLeftRight/stateverif_left_right_analyzed.spthy
+++ b/case-studies-regression/sapic/fast/statVerifLeftRight/stateverif_left_right_analyzed.spthy
@@ -71,7 +71,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -104,7 +104,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -144,7 +144,7 @@ next
                          ∧
                           (#vr.3 < #t2) ∧
                           (#t2 < #vr.22) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n ) @ #t0)
                            ⇒
@@ -367,7 +367,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.24) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, ~n ) @ #t0)
                            ⇒
@@ -599,7 +599,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -627,7 +627,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -683,7 +683,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -711,7 +711,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -782,7 +782,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.16 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -842,7 +842,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.17 < #t2) ∧
                     (#t2 < #vr.35) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -908,7 +908,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.16 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -1011,7 +1011,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.40 < #t2) ∧
                                         (#t2 < #vr.57) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -1142,7 +1142,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.41 < #t2) ∧
                                         (#t2 < #vr.59) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -1292,7 +1292,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                    ∧
                     (#vr.17 < #t2) ∧
                     (#t2 < #vr.35) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.7, ~n.5 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.5 ) @ #t0)
                      ⇒
@@ -1395,7 +1395,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.42 < #t2) ∧
                                         (#t2 < #vr.59) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -1520,7 +1520,7 @@ solve( State_11112111( x, y, s, sk ) ▶₀ #i )
                                        ∧
                                         (#vr.43 < #t2) ∧
                                         (#t2 < #vr.61) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.11, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n.8 ) @ #t0)
                                          ⇒
@@ -2184,7 +2184,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -2200,7 +2200,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -2215,7 +2215,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -2225,7 +2225,7 @@ analyzing: examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy
 analyzed: examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy
 
   output:          examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy.tmp
-  processing time: 25.091718s
+  processing time: 18.790370709s
   source (all-traces): verified (174 steps)
   reachability_left (exists-trace): verified (14 steps)
   reachability_right (exists-trace): verified (14 steps)
@@ -2239,7 +2239,7 @@ summary of summaries:
 analyzed: examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy
 
   output:          examples/sapic/fast/statVerifLeftRight/stateverif_left_right.spthy.tmp
-  processing time: 25.091718s
+  processing time: 18.790370709s
   source (all-traces): verified (174 steps)
   reachability_left (exists-trace): verified (14 steps)
   reachability_right (exists-trace): verified (14 steps)

--- a/case-studies-regression/sapic/slow/NSL/nsl-no_as-untagged_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/NSL/nsl-no_as-untagged_analyzed.spthy
@@ -1875,7 +1875,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -1885,7 +1885,7 @@ analyzing: examples/sapic/slow/NSL/nsl-no_as-untagged.spthy
 analyzed: examples/sapic/slow/NSL/nsl-no_as-untagged.spthy
 
   output:          examples/sapic/slow/NSL/nsl-no_as-untagged.spthy.tmp
-  processing time: 25.320494s
+  processing time: 24.697543152s
   source (all-traces): verified (34 steps)
   secrecy (all-traces): verified (483 steps)
 
@@ -1897,7 +1897,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/NSL/nsl-no_as-untagged.spthy
 
   output:          examples/sapic/slow/NSL/nsl-no_as-untagged.spthy.tmp
-  processing time: 25.320494s
+  processing time: 24.697543152s
   source (all-traces): verified (34 steps)
   secrecy (all-traces): verified (483 steps)
 

--- a/case-studies-regression/sapic/slow/NSL/nsl-no_as-untagged_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/NSL/nsl-no_as-untagged_analyzed.spthy
@@ -1875,7 +1875,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -1885,7 +1885,7 @@ analyzing: examples/sapic/slow/NSL/nsl-no_as-untagged.spthy
 analyzed: examples/sapic/slow/NSL/nsl-no_as-untagged.spthy
 
   output:          examples/sapic/slow/NSL/nsl-no_as-untagged.spthy.tmp
-  processing time: 18.487480526s
+  processing time: 25.320494s
   source (all-traces): verified (34 steps)
   secrecy (all-traces): verified (483 steps)
 
@@ -1897,7 +1897,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/NSL/nsl-no_as-untagged.spthy
 
   output:          examples/sapic/slow/NSL/nsl-no_as-untagged.spthy.tmp
-  processing time: 18.487480526s
+  processing time: 25.320494s
   source (all-traces): verified (34 steps)
   secrecy (all-traces): verified (483 steps)
 

--- a/case-studies-regression/sapic/slow/PKCS11/pkcs11-templates_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/PKCS11/pkcs11-templates_analyzed.spthy
@@ -271,7 +271,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -304,7 +304,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -337,7 +337,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -370,7 +370,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -403,7 +403,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -436,7 +436,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1027,7 +1027,7 @@ next
                                                    ∧
                                                     (#vr.33 < #t2) ∧
                                                     (#t2 < #vr.51) ∧
-                                                    (∀ #t0 pp.
+                                                    (∀ pp #t0.
                                                       (Unlock( pp, ~n.6, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                                     (∀ pp lpp #t0.
                                                       (Lock( pp, lpp, 'device' ) @ #t0)
@@ -1708,7 +1708,7 @@ next
                                                        ∧
                                                         (#vr.34 < #t2) ∧
                                                         (#t2 < #vr.51) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, 'device' ) @ #t0)
@@ -3534,7 +3534,7 @@ next
                                                      ∧
                                                       (#vr.35 < #t2) ∧
                                                       (#t2 < #vr.52) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4115,7 +4115,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4143,7 +4143,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4199,7 +4199,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4227,7 +4227,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4283,7 +4283,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4311,7 +4311,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4367,7 +4367,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4395,7 +4395,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4451,7 +4451,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4479,7 +4479,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4535,7 +4535,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4563,7 +4563,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4698,7 +4698,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4731,7 +4731,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4764,7 +4764,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4797,7 +4797,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4830,7 +4830,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4863,7 +4863,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4938,7 +4938,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4966,7 +4966,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5024,7 +5024,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5052,7 +5052,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5110,7 +5110,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5138,7 +5138,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5196,7 +5196,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5224,7 +5224,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5282,7 +5282,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5310,7 +5310,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5368,7 +5368,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5396,7 +5396,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5533,7 +5533,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5566,7 +5566,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5599,7 +5599,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5632,7 +5632,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5665,7 +5665,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5698,7 +5698,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5762,7 +5762,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5790,7 +5790,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5846,7 +5846,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5874,7 +5874,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5930,7 +5930,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5958,7 +5958,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6014,7 +6014,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6042,7 +6042,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6098,7 +6098,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6126,7 +6126,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6182,7 +6182,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6210,7 +6210,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6345,7 +6345,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6378,7 +6378,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6411,7 +6411,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6444,7 +6444,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6477,7 +6477,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6510,7 +6510,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6574,7 +6574,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6602,7 +6602,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6658,7 +6658,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6686,7 +6686,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6742,7 +6742,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6770,7 +6770,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6826,7 +6826,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6854,7 +6854,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6910,7 +6910,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6938,7 +6938,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6994,7 +6994,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7022,7 +7022,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7157,7 +7157,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7190,7 +7190,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7223,7 +7223,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7256,7 +7256,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7289,7 +7289,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7322,7 +7322,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7386,7 +7386,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7414,7 +7414,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7470,7 +7470,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7498,7 +7498,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7554,7 +7554,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7582,7 +7582,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7638,7 +7638,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7666,7 +7666,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7722,7 +7722,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7750,7 +7750,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7806,7 +7806,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7834,7 +7834,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7969,7 +7969,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8002,7 +8002,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8035,7 +8035,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8068,7 +8068,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8101,7 +8101,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8134,7 +8134,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8198,7 +8198,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8226,7 +8226,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8282,7 +8282,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8310,7 +8310,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8366,7 +8366,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8394,7 +8394,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8450,7 +8450,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8478,7 +8478,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8534,7 +8534,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8562,7 +8562,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8618,7 +8618,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8646,7 +8646,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8787,7 +8787,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8820,7 +8820,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8853,7 +8853,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8886,7 +8886,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8919,7 +8919,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8952,7 +8952,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10001,7 +10001,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10029,7 +10029,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10087,7 +10087,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10115,7 +10115,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10173,7 +10173,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10201,7 +10201,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10259,7 +10259,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10287,7 +10287,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10345,7 +10345,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10373,7 +10373,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10431,7 +10431,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10459,7 +10459,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10592,7 +10592,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10625,7 +10625,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10658,7 +10658,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10691,7 +10691,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10724,7 +10724,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10757,7 +10757,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -11170,7 +11170,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.44) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -11207,7 +11207,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.44) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -11937,7 +11937,7 @@ next
                                                                ∧
                                                                 (#vr.21 < #t2) ∧
                                                                 (#t2 < #vr.52) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, 'device' ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -12389,7 +12389,7 @@ next
                                                              ∧
                                                               (#vr.21 < #t2) ∧
                                                               (#t2 < #vr.53) ∧
-                                                              (∀ #t0 pp.
+                                                              (∀ pp #t0.
                                                                 (Unlock( pp, ~n.2, 'device' ) @ #t0)
                                                                ⇒
                                                                 #t0 = #t2) ∧
@@ -13519,7 +13519,7 @@ next
                                                              ∧
                                                               (#vr.21 < #t2) ∧
                                                               (#t2 < #vr.53) ∧
-                                                              (∀ #t0 pp.
+                                                              (∀ pp #t0.
                                                                 (Unlock( pp, ~n.2, 'device' ) @ #t0)
                                                                ⇒
                                                                 #t0 = #t2) ∧
@@ -15470,7 +15470,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.43) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -15507,7 +15507,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.43) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -15691,7 +15691,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15719,7 +15719,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15775,7 +15775,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15803,7 +15803,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15859,7 +15859,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15887,7 +15887,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15943,7 +15943,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15971,7 +15971,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16027,7 +16027,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16055,7 +16055,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16111,7 +16111,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16139,7 +16139,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16254,7 +16254,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16287,7 +16287,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16320,7 +16320,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16353,7 +16353,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16386,7 +16386,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16419,7 +16419,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16881,7 +16881,7 @@ next
                                          ∧
                                           (#vr.10 < #t2) ∧
                                           (#t2 < #vr.48) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -16918,7 +16918,7 @@ next
                                          ∧
                                           (#vr.10 < #t2) ∧
                                           (#t2 < #vr.48) ∧
-                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -17476,7 +17476,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17504,7 +17504,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17560,7 +17560,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17588,7 +17588,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17644,7 +17644,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17672,7 +17672,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17728,7 +17728,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17756,7 +17756,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17812,7 +17812,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17840,7 +17840,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17896,7 +17896,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17924,7 +17924,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -18021,7 +18021,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18054,7 +18054,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18087,7 +18087,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18120,7 +18120,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18153,7 +18153,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18186,7 +18186,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18231,7 +18231,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -18291,7 +18291,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -18321,7 +18321,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -18419,7 +18419,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -18470,7 +18470,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -18504,7 +18504,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -18965,7 +18965,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19025,7 +19025,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19055,7 +19055,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19153,7 +19153,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19204,7 +19204,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19238,7 +19238,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19857,7 +19857,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19917,7 +19917,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19947,7 +19947,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20115,7 +20115,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20220,7 +20220,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20254,7 +20254,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20538,7 +20538,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20598,7 +20598,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20628,7 +20628,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20796,7 +20796,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20901,7 +20901,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20935,7 +20935,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -21206,7 +21206,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21234,7 +21234,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21290,7 +21290,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21318,7 +21318,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21374,7 +21374,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21402,7 +21402,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21458,7 +21458,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21486,7 +21486,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21542,7 +21542,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21570,7 +21570,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21626,7 +21626,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21654,7 +21654,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -24877,7 +24877,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24893,7 +24893,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24909,7 +24909,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24925,7 +24925,7 @@ restriction locking_3:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_3( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24941,7 +24941,7 @@ restriction locking_4:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_4( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24957,7 +24957,7 @@ restriction locking_5:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_5( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24972,7 +24972,7 @@ restriction locking_5:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -24982,7 +24982,7 @@ analyzing: examples/sapic/slow/PKCS11/pkcs11-templates.spthy
 analyzed: examples/sapic/slow/PKCS11/pkcs11-templates.spthy
 
   output:          examples/sapic/slow/PKCS11/pkcs11-templates.spthy.tmp
-  processing time: 384.485083718s
+  processing time: 439.954759s
   dec_limits (all-traces): verified (1417 steps)
   bad_keys (all-traces): verified (319 steps)
   no_key_is_wrap_and_dec__or_unwrap_and_dec_ind (all-traces): verified (910 steps)
@@ -24998,7 +24998,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/PKCS11/pkcs11-templates.spthy
 
   output:          examples/sapic/slow/PKCS11/pkcs11-templates.spthy.tmp
-  processing time: 384.485083718s
+  processing time: 439.954759s
   dec_limits (all-traces): verified (1417 steps)
   bad_keys (all-traces): verified (319 steps)
   no_key_is_wrap_and_dec__or_unwrap_and_dec_ind (all-traces): verified (910 steps)

--- a/case-studies-regression/sapic/slow/PKCS11/pkcs11-templates_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/PKCS11/pkcs11-templates_analyzed.spthy
@@ -271,7 +271,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -304,7 +304,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -337,7 +337,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -370,7 +370,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -403,7 +403,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -436,7 +436,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1027,7 +1027,7 @@ next
                                                    ∧
                                                     (#vr.33 < #t2) ∧
                                                     (#t2 < #vr.51) ∧
-                                                    (∀ pp #t0.
+                                                    (∀ #t0 pp.
                                                       (Unlock( pp, ~n.6, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                                     (∀ pp lpp #t0.
                                                       (Lock( pp, lpp, 'device' ) @ #t0)
@@ -1708,7 +1708,7 @@ next
                                                        ∧
                                                         (#vr.34 < #t2) ∧
                                                         (#t2 < #vr.51) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, 'device' ) @ #t0)
@@ -3534,7 +3534,7 @@ next
                                                      ∧
                                                       (#vr.35 < #t2) ∧
                                                       (#t2 < #vr.52) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4115,7 +4115,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4143,7 +4143,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4199,7 +4199,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4227,7 +4227,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4283,7 +4283,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4311,7 +4311,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4367,7 +4367,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4395,7 +4395,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4451,7 +4451,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4479,7 +4479,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4535,7 +4535,7 @@ next
                 (#t2 < #t1.1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4563,7 +4563,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4698,7 +4698,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4731,7 +4731,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4764,7 +4764,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4797,7 +4797,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4830,7 +4830,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4863,7 +4863,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -4938,7 +4938,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -4966,7 +4966,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5024,7 +5024,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5052,7 +5052,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5110,7 +5110,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5138,7 +5138,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5196,7 +5196,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5224,7 +5224,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5282,7 +5282,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5310,7 +5310,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5368,7 +5368,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5396,7 +5396,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -5533,7 +5533,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5566,7 +5566,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5599,7 +5599,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5632,7 +5632,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5665,7 +5665,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5698,7 +5698,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -5762,7 +5762,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5790,7 +5790,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5846,7 +5846,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5874,7 +5874,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5930,7 +5930,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -5958,7 +5958,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6014,7 +6014,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6042,7 +6042,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6098,7 +6098,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6126,7 +6126,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6182,7 +6182,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6210,7 +6210,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6345,7 +6345,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6378,7 +6378,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6411,7 +6411,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6444,7 +6444,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6477,7 +6477,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6510,7 +6510,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6574,7 +6574,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6602,7 +6602,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6658,7 +6658,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6686,7 +6686,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6742,7 +6742,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6770,7 +6770,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6826,7 +6826,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6854,7 +6854,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6910,7 +6910,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6938,7 +6938,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -6994,7 +6994,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7022,7 +7022,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7157,7 +7157,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7190,7 +7190,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7223,7 +7223,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7256,7 +7256,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7289,7 +7289,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7322,7 +7322,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -7386,7 +7386,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7414,7 +7414,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7470,7 +7470,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7498,7 +7498,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7554,7 +7554,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7582,7 +7582,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7638,7 +7638,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7666,7 +7666,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7722,7 +7722,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7750,7 +7750,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7806,7 +7806,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7834,7 +7834,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -7969,7 +7969,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8002,7 +8002,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8035,7 +8035,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8068,7 +8068,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8101,7 +8101,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8134,7 +8134,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -8198,7 +8198,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8226,7 +8226,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8282,7 +8282,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8310,7 +8310,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8366,7 +8366,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8394,7 +8394,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8450,7 +8450,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8478,7 +8478,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8534,7 +8534,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8562,7 +8562,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8618,7 +8618,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8646,7 +8646,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, 'device' ) @ #t0)
@@ -8787,7 +8787,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8820,7 +8820,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8853,7 +8853,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8886,7 +8886,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8919,7 +8919,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -8952,7 +8952,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10001,7 +10001,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10029,7 +10029,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10087,7 +10087,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10115,7 +10115,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10173,7 +10173,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10201,7 +10201,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10259,7 +10259,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10287,7 +10287,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10345,7 +10345,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10373,7 +10373,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10431,7 +10431,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -10459,7 +10459,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -10592,7 +10592,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10625,7 +10625,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10658,7 +10658,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10691,7 +10691,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10724,7 +10724,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10757,7 +10757,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -11170,7 +11170,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.44) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -11207,7 +11207,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.44) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -11937,7 +11937,7 @@ next
                                                                ∧
                                                                 (#vr.21 < #t2) ∧
                                                                 (#t2 < #vr.52) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, 'device' ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -12389,7 +12389,7 @@ next
                                                              ∧
                                                               (#vr.21 < #t2) ∧
                                                               (#t2 < #vr.53) ∧
-                                                              (∀ pp #t0.
+                                                              (∀ #t0 pp.
                                                                 (Unlock( pp, ~n.2, 'device' ) @ #t0)
                                                                ⇒
                                                                 #t0 = #t2) ∧
@@ -13519,7 +13519,7 @@ next
                                                              ∧
                                                               (#vr.21 < #t2) ∧
                                                               (#t2 < #vr.53) ∧
-                                                              (∀ pp #t0.
+                                                              (∀ #t0 pp.
                                                                 (Unlock( pp, ~n.2, 'device' ) @ #t0)
                                                                ⇒
                                                                 #t0 = #t2) ∧
@@ -15470,7 +15470,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.43) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -15507,7 +15507,7 @@ next
                                          ∧
                                           (#vr.9 < #t2) ∧
                                           (#t2 < #vr.43) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -15691,7 +15691,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15719,7 +15719,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15775,7 +15775,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15803,7 +15803,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15859,7 +15859,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15887,7 +15887,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15943,7 +15943,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -15971,7 +15971,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16027,7 +16027,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16055,7 +16055,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16111,7 +16111,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16139,7 +16139,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -16254,7 +16254,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16287,7 +16287,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16320,7 +16320,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16353,7 +16353,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16386,7 +16386,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16419,7 +16419,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -16881,7 +16881,7 @@ next
                                          ∧
                                           (#vr.10 < #t2) ∧
                                           (#t2 < #vr.48) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -16918,7 +16918,7 @@ next
                                          ∧
                                           (#vr.10 < #t2) ∧
                                           (#t2 < #vr.48) ∧
-                                          (∀ pp #t0. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                                          (∀ #t0 pp. (Unlock( pp, ~n.4, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                                           (∀ pp lpp #t0.
                                             (Lock( pp, lpp, 'device' ) @ #t0)
                                            ⇒
@@ -17476,7 +17476,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17504,7 +17504,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17560,7 +17560,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17588,7 +17588,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17644,7 +17644,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17672,7 +17672,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17728,7 +17728,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17756,7 +17756,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17812,7 +17812,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17840,7 +17840,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17896,7 +17896,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -17924,7 +17924,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -18021,7 +18021,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18054,7 +18054,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18087,7 +18087,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18120,7 +18120,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18153,7 +18153,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18186,7 +18186,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -18231,7 +18231,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -18291,7 +18291,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -18321,7 +18321,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -18419,7 +18419,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -18470,7 +18470,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -18504,7 +18504,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -18965,7 +18965,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19025,7 +19025,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19055,7 +19055,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19153,7 +19153,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19204,7 +19204,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19238,7 +19238,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19857,7 +19857,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -19917,7 +19917,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -19947,7 +19947,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20115,7 +20115,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20220,7 +20220,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20254,7 +20254,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20538,7 +20538,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.20) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20598,7 +20598,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20628,7 +20628,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20796,7 +20796,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.21) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, 'device' ) @ #t0)
                            ⇒
@@ -20901,7 +20901,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -20935,7 +20935,7 @@ next
                        ∧
                         (#vr.4 < #t2) ∧
                         (#t2 < #vr.24) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, 'device' ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, 'device' ) @ #t0)
                          ⇒
@@ -21206,7 +21206,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21234,7 +21234,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21290,7 +21290,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21318,7 +21318,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21374,7 +21374,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21402,7 +21402,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21458,7 +21458,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21486,7 +21486,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21542,7 +21542,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21570,7 +21570,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21626,7 +21626,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, 'device' ) @ #t0)
@@ -21654,7 +21654,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, 'device' ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, 'device' ) @ #t0)
@@ -24877,7 +24877,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24893,7 +24893,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24909,7 +24909,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24925,7 +24925,7 @@ restriction locking_3:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_3( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24941,7 +24941,7 @@ restriction locking_4:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_4( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24957,7 +24957,7 @@ restriction locking_5:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_5( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -24972,7 +24972,7 @@ restriction locking_5:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -24982,7 +24982,7 @@ analyzing: examples/sapic/slow/PKCS11/pkcs11-templates.spthy
 analyzed: examples/sapic/slow/PKCS11/pkcs11-templates.spthy
 
   output:          examples/sapic/slow/PKCS11/pkcs11-templates.spthy.tmp
-  processing time: 439.954759s
+  processing time: 197.404530788s
   dec_limits (all-traces): verified (1417 steps)
   bad_keys (all-traces): verified (319 steps)
   no_key_is_wrap_and_dec__or_unwrap_and_dec_ind (all-traces): verified (910 steps)
@@ -24998,7 +24998,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/PKCS11/pkcs11-templates.spthy
 
   output:          examples/sapic/slow/PKCS11/pkcs11-templates.spthy.tmp
-  processing time: 439.954759s
+  processing time: 197.404530788s
   dec_limits (all-traces): verified (1417 steps)
   bad_keys (all-traces): verified (319 steps)
   no_key_is_wrap_and_dec__or_unwrap_and_dec_ind (all-traces): verified (910 steps)

--- a/case-studies-regression/sapic/slow/Yubikey/Yubikey_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/Yubikey/Yubikey_analyzed.spthy
@@ -88,7 +88,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -121,7 +121,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -154,7 +154,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -251,7 +251,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -281,7 +281,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -339,7 +339,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -369,7 +369,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -427,7 +427,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -457,7 +457,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -557,7 +557,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -590,7 +590,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -623,7 +623,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -746,7 +746,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -776,7 +776,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -834,7 +834,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -864,7 +864,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -922,7 +922,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -952,7 +952,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -1067,7 +1067,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -1100,7 +1100,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -1133,7 +1133,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -1194,7 +1194,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.42) ∧
-                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1290,7 +1290,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.41) ∧
-                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1448,7 +1448,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.42) ∧
-                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1544,7 +1544,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.41) ∧
-                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1701,7 +1701,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -1731,7 +1731,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -1789,7 +1789,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -1819,7 +1819,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -1877,7 +1877,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -1907,7 +1907,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2024,7 +2024,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2057,7 +2057,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2090,7 +2090,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2162,7 +2162,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2192,7 +2192,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2250,7 +2250,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2280,7 +2280,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2338,7 +2338,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2368,7 +2368,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2491,7 +2491,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2524,7 +2524,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2557,7 +2557,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2706,7 +2706,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2736,7 +2736,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -2794,7 +2794,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2824,7 +2824,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -2882,7 +2882,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2912,7 +2912,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -3051,7 +3051,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -3084,7 +3084,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -3117,7 +3117,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -3197,7 +3197,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.25 < #t2) ∧
                       (#t2 < #vr.35) ∧
-                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -3491,7 +3491,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.24 < #t2) ∧
                       (#t2 < #vr.34) ∧
-                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -3625,7 +3625,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.24 < #t2) ∧
                       (#t2 < #vr.34) ∧
-                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -3919,7 +3919,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.23 < #t2) ∧
                       (#t2 < #vr.33) ∧
-                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -4053,7 +4053,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.25 < #t2) ∧
                       (#t2 < #vr.35) ∧
-                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -4347,7 +4347,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.24 < #t2) ∧
                       (#t2 < #vr.34) ∧
-                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -5224,7 +5224,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -5240,7 +5240,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -5256,7 +5256,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -5271,7 +5271,7 @@ restriction locking_2:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -5281,7 +5281,7 @@ analyzing: examples/sapic/slow/Yubikey/Yubikey.spthy
 analyzed: examples/sapic/slow/Yubikey/Yubikey.spthy
 
   output:          examples/sapic/slow/Yubikey/Yubikey.spthy.tmp
-  processing time: 59.382953s
+  processing time: 29.963075732s
   init_server (all-traces): verified (148 steps)
   init_server_secrecy (all-traces): verified (191 steps)
   init_yubikey (all-traces): verified (63 steps)
@@ -5298,7 +5298,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/Yubikey/Yubikey.spthy
 
   output:          examples/sapic/slow/Yubikey/Yubikey.spthy.tmp
-  processing time: 59.382953s
+  processing time: 29.963075732s
   init_server (all-traces): verified (148 steps)
   init_server_secrecy (all-traces): verified (191 steps)
   init_yubikey (all-traces): verified (63 steps)

--- a/case-studies-regression/sapic/slow/Yubikey/Yubikey_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/Yubikey/Yubikey_analyzed.spthy
@@ -88,7 +88,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -121,7 +121,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -154,7 +154,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -251,7 +251,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -281,7 +281,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -339,7 +339,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -369,7 +369,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -427,7 +427,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -457,7 +457,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -557,7 +557,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -590,7 +590,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -623,7 +623,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -746,7 +746,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -776,7 +776,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -834,7 +834,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -864,7 +864,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -922,7 +922,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                  ∧
                   (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -952,7 +952,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                   ∧
                    (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -1067,7 +1067,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -1100,7 +1100,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -1133,7 +1133,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -1194,7 +1194,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.42) ∧
-                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1290,7 +1290,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.41) ∧
-                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1448,7 +1448,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.42) ∧
-                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1544,7 +1544,7 @@ next
                              ∧
                               (#vr.6 < #t2) ∧
                               (#t2 < #vr.41) ∧
-                              (∀ #t0 pp. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                              (∀ pp #t0. (Unlock( pp, ~n.2, <'Server', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                               (∀ pp lpp #t0.
                                 (Lock( pp, lpp, <'Server', ~n> ) @ #t0)
                                ⇒
@@ -1701,7 +1701,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -1731,7 +1731,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -1789,7 +1789,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -1819,7 +1819,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -1877,7 +1877,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -1907,7 +1907,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2024,7 +2024,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2057,7 +2057,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2090,7 +2090,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2162,7 +2162,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2192,7 +2192,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2250,7 +2250,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2280,7 +2280,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2338,7 +2338,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2368,7 +2368,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
@@ -2491,7 +2491,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2524,7 +2524,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2557,7 +2557,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -2706,7 +2706,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2736,7 +2736,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Server', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -2794,7 +2794,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2824,7 +2824,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -2882,7 +2882,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                ∧
                 (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
@@ -2912,7 +2912,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, <'Yubikey', L_pid> ) @ #t0)
                 ∧
                  (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
@@ -3051,7 +3051,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -3084,7 +3084,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -3117,7 +3117,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -3197,7 +3197,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.25 < #t2) ∧
                       (#t2 < #vr.35) ∧
-                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -3491,7 +3491,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.24 < #t2) ∧
                       (#t2 < #vr.34) ∧
-                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -3625,7 +3625,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.24 < #t2) ∧
                       (#t2 < #vr.34) ∧
-                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -3919,7 +3919,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.23 < #t2) ∧
                       (#t2 < #vr.33) ∧
-                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -4053,7 +4053,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.25 < #t2) ∧
                       (#t2 < #vr.35) ∧
-                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -4347,7 +4347,7 @@ solve( (#t1 = #t2)  ∥ (#t2 < #t1) )
                      ∧
                       (#vr.24 < #t2) ∧
                       (#t2 < #vr.34) ∧
-                      (∀ #t0 pp. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
+                      (∀ pp #t0. (Unlock( pp, ~n.6, <'Yubikey', ~n> ) @ #t0) ⇒ #t0 = #t2) ∧
                       (∀ pp lpp #t0.
                         (Lock( pp, lpp, <'Yubikey', ~n> ) @ #t0)
                        ⇒
@@ -5224,7 +5224,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -5240,7 +5240,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -5256,7 +5256,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -5271,7 +5271,7 @@ restriction locking_2:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -5281,7 +5281,7 @@ analyzing: examples/sapic/slow/Yubikey/Yubikey.spthy
 analyzed: examples/sapic/slow/Yubikey/Yubikey.spthy
 
   output:          examples/sapic/slow/Yubikey/Yubikey.spthy.tmp
-  processing time: 35.358788594s
+  processing time: 59.382953s
   init_server (all-traces): verified (148 steps)
   init_server_secrecy (all-traces): verified (191 steps)
   init_yubikey (all-traces): verified (63 steps)
@@ -5298,7 +5298,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/Yubikey/Yubikey.spthy
 
   output:          examples/sapic/slow/Yubikey/Yubikey.spthy.tmp
-  processing time: 35.358788594s
+  processing time: 59.382953s
   init_server (all-traces): verified (148 steps)
   init_server_secrecy (all-traces): verified (191 steps)
   init_yubikey (all-traces): verified (63 steps)

--- a/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks_analyzed.spthy
@@ -783,7 +783,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -793,7 +793,7 @@ analyzing: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy.tmp
-  processing time: 707.403334s
+  processing time: 291.638676862s
   can_obtain_key (exists-trace): verified (24 steps)
 
 ------------------------------------------------------------------------------
@@ -804,7 +804,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy.tmp
-  processing time: 707.403334s
+  processing time: 291.638676862s
   can_obtain_key (exists-trace): verified (24 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks_analyzed.spthy
@@ -783,7 +783,7 @@ restriction single_session:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -793,7 +793,7 @@ analyzing: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy.tmp
-  processing time: 560.800152319s
+  processing time: 707.403334s
   can_obtain_key (exists-trace): verified (24 steps)
 
 ------------------------------------------------------------------------------
@@ -804,7 +804,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap-nolocks.spthy.tmp
-  processing time: 560.800152319s
+  processing time: 707.403334s
   can_obtain_key (exists-trace): verified (24 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap_analyzed.spthy
@@ -114,7 +114,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -147,7 +147,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -180,7 +180,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -213,7 +213,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -246,7 +246,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -279,7 +279,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -312,7 +312,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -364,7 +364,7 @@ next
                        ∧
                         (#vr.3 < #t2) ∧
                         (#t2 < #vr.15) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, L_h ) @ #t0)
                          ⇒
@@ -449,7 +449,7 @@ next
                        ∧
                         (#vr.3 < #t2) ∧
                         (#t2 < #vr.26) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, L_h ) @ #t0)
                          ⇒
@@ -527,7 +527,7 @@ next
                        ∧
                         (#vr.3 < #t2) ∧
                         (#t2 < #vr.27) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, L_h ) @ #t0)
                          ⇒
@@ -565,7 +565,7 @@ next
                                      ∧
                                       (#vr.19 < #t2) ∧
                                       (#t2 < #vr.50) ∧
-                                      (∀ pp #t0. (Unlock( pp, ~n.3, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                      (∀ #t0 pp. (Unlock( pp, ~n.3, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                       (∀ pp lpp #t0.
                                         (Lock( pp, lpp, L_h1 ) @ #t0)
                                        ⇒
@@ -631,7 +631,7 @@ next
                                      ∧
                                       (#vr.19 < #t2) ∧
                                       (#t2 < #vr.47) ∧
-                                      (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                      (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                       (∀ pp lpp #t0.
                                         (Lock( pp, lpp, L_h1 ) @ #t0)
                                        ⇒
@@ -735,7 +735,7 @@ next
                                                            ∧
                                                             (#vr.40 < #t2) ∧
                                                             (#t2 < #vr.85) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, L_h ) @ #t0)
@@ -856,7 +856,7 @@ next
                                                          ∧
                                                           (#vr.40 < #t2) ∧
                                                           (#t2 < #vr.96) ∧
-                                                          (∀ pp #t0.
+                                                          (∀ #t0 pp.
                                                             (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                           (∀ pp lpp #t0.
                                                             (Lock( pp, lpp, L_h ) @ #t0)
@@ -927,7 +927,7 @@ next
                                                            ∧
                                                             (#vr.40 < #t2) ∧
                                                             (#t2 < #vr.86) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, L_h ) @ #t0)
@@ -1048,7 +1048,7 @@ next
                                                          ∧
                                                           (#vr.40 < #t2) ∧
                                                           (#t2 < #vr.97) ∧
-                                                          (∀ pp #t0.
+                                                          (∀ #t0 pp.
                                                             (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                           (∀ pp lpp #t0.
                                                             (Lock( pp, lpp, L_h ) @ #t0)
@@ -1166,7 +1166,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1194,7 +1194,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1250,7 +1250,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1278,7 +1278,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1334,7 +1334,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1362,7 +1362,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1418,7 +1418,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1446,7 +1446,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1502,7 +1502,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1530,7 +1530,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1586,7 +1586,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1614,7 +1614,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1670,7 +1670,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1698,7 +1698,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1858,7 +1858,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1891,7 +1891,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1924,7 +1924,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1957,7 +1957,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1990,7 +1990,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -2023,7 +2023,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -2056,7 +2056,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -2111,7 +2111,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.13) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -2241,7 +2241,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.24) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -2279,7 +2279,7 @@ next
                                        ∧
                                         (#vr.16 < #t2) ∧
                                         (#t2 < #vr.49) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -2471,7 +2471,7 @@ next
                                        ∧
                                         (#vr.16 < #t2) ∧
                                         (#t2 < #vr.67) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -2572,7 +2572,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.92) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -2608,7 +2608,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -2705,7 +2705,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -2827,7 +2827,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.103) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -2863,7 +2863,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -2959,7 +2959,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3032,7 +3032,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.93) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -3068,7 +3068,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3165,7 +3165,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3287,7 +3287,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.104) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -3323,7 +3323,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3419,7 +3419,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3588,7 +3588,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.99) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -3624,7 +3624,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3721,7 +3721,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3843,7 +3843,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.110) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -3879,7 +3879,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3975,7 +3975,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -4048,7 +4048,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.100) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -4084,7 +4084,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -4181,7 +4181,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -4303,7 +4303,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.111) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -4339,7 +4339,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -4435,7 +4435,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -4573,7 +4573,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.25) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -4611,7 +4611,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.50) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -4785,7 +4785,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.68) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -4886,7 +4886,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.93) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -4922,7 +4922,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5019,7 +5019,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5141,7 +5141,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.104) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -5177,7 +5177,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5273,7 +5273,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5346,7 +5346,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.94) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -5382,7 +5382,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5479,7 +5479,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5601,7 +5601,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.105) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -5637,7 +5637,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5733,7 +5733,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5903,7 +5903,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.23) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -6024,7 +6024,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6052,7 +6052,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6108,7 +6108,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6136,7 +6136,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6192,7 +6192,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6220,7 +6220,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6276,7 +6276,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6304,7 +6304,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6360,7 +6360,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6388,7 +6388,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6444,7 +6444,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6472,7 +6472,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6528,7 +6528,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6556,7 +6556,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6660,7 +6660,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6693,7 +6693,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6726,7 +6726,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6759,7 +6759,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6792,7 +6792,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6825,7 +6825,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6858,7 +6858,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ pp.1 #t0.
+                  (∃ #t0 pp.1.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6913,7 +6913,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.13) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -7043,7 +7043,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.24) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -7281,7 +7281,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.25) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -7319,7 +7319,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.50) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -7493,7 +7493,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.68) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -7594,7 +7594,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.93) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -7630,7 +7630,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -7727,7 +7727,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -7849,7 +7849,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.104) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -7885,7 +7885,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -7981,7 +7981,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -8054,7 +8054,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.94) ∧
-                                                        (∀ pp #t0.
+                                                        (∀ #t0 pp.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -8090,7 +8090,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -8187,7 +8187,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ pp #t0.
+                                                                  (∀ #t0 pp.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -8309,7 +8309,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.105) ∧
-                                                      (∀ pp #t0.
+                                                      (∀ #t0 pp.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -8345,7 +8345,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -8441,7 +8441,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ pp #t0.
+                                                                (∀ #t0 pp.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -8611,7 +8611,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.23) ∧
-                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -8732,7 +8732,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -8760,7 +8760,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -8816,7 +8816,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -8844,7 +8844,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -8900,7 +8900,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -8928,7 +8928,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -8984,7 +8984,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9012,7 +9012,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9068,7 +9068,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9096,7 +9096,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9152,7 +9152,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9180,7 +9180,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9236,7 +9236,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9264,7 +9264,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ pp #t0.
+          solve( (∃ #t0 pp.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9380,7 +9380,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9413,7 +9413,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9446,7 +9446,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9479,7 +9479,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9512,7 +9512,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9545,7 +9545,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9578,7 +9578,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9619,7 +9619,7 @@ next
                        ∧
                         (#vr.2 < #t2) ∧
                         (#t2 < #vr.25) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, ~n ) @ #t0)
                          ⇒
@@ -9648,7 +9648,7 @@ next
                                ∧
                                 (#vr.14 < #t2) ∧
                                 (#t2 < #vr.25) ∧
-                                (∀ pp #t0. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                (∀ #t0 pp. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                 (∀ pp lpp #t0.
                                   (Lock( pp, lpp, ~n ) @ #t0)
                                  ⇒
@@ -9671,7 +9671,7 @@ next
                                  ∧
                                   (#vr.2 < #t2) ∧
                                   (#t2 < #vr.14) ∧
-                                  (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                  (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                   (∀ pp lpp #t0.
                                     (Lock( pp, lpp, ~n ) @ #t0)
                                    ⇒
@@ -9718,7 +9718,7 @@ next
                        ∧
                         (#vr.2 < #t2) ∧
                         (#t2 < #vr.25) ∧
-                        (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, ~n ) @ #t0)
                          ⇒
@@ -9747,7 +9747,7 @@ next
                                ∧
                                 (#vr.14 < #t2) ∧
                                 (#t2 < #vr.25) ∧
-                                (∀ pp #t0. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                (∀ #t0 pp. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                 (∀ pp lpp #t0.
                                   (Lock( pp, lpp, ~n ) @ #t0)
                                  ⇒
@@ -9770,7 +9770,7 @@ next
                                  ∧
                                   (#vr.2 < #t2) ∧
                                   (#t2 < #vr.14) ∧
-                                  (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                  (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                   (∀ pp lpp #t0.
                                     (Lock( pp, lpp, ~n ) @ #t0)
                                    ⇒
@@ -9831,7 +9831,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -9859,7 +9859,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -9915,7 +9915,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -9943,7 +9943,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -9999,7 +9999,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10027,7 +10027,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10083,7 +10083,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10111,7 +10111,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10167,7 +10167,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10195,7 +10195,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10251,7 +10251,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10279,7 +10279,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10335,7 +10335,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10363,7 +10363,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10478,7 +10478,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10511,7 +10511,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10544,7 +10544,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10577,7 +10577,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10610,7 +10610,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10643,7 +10643,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10676,7 +10676,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10914,7 +10914,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -10966,7 +10966,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11015,7 +11015,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11062,7 +11062,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11106,7 +11106,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11147,7 +11147,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11318,7 +11318,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11370,7 +11370,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11419,7 +11419,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11466,7 +11466,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11510,7 +11510,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11551,7 +11551,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11722,7 +11722,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11774,7 +11774,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11823,7 +11823,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11870,7 +11870,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11914,7 +11914,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11955,7 +11955,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12126,7 +12126,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12178,7 +12178,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12227,7 +12227,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12274,7 +12274,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12318,7 +12318,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12359,7 +12359,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12530,7 +12530,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12582,7 +12582,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12631,7 +12631,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12678,7 +12678,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12722,7 +12722,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12763,7 +12763,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12934,7 +12934,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12986,7 +12986,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13035,7 +13035,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13082,7 +13082,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13126,7 +13126,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13167,7 +13167,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13338,7 +13338,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13390,7 +13390,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13439,7 +13439,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ pp #t0.
+                (∃ #t0 pp.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13486,7 +13486,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13530,7 +13530,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13571,7 +13571,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ pp #t0.
+            solve( (∃ #t0 pp.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13761,7 +13761,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13794,7 +13794,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13827,7 +13827,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13860,7 +13860,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13893,7 +13893,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13926,7 +13926,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13959,7 +13959,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ pp.1 #t0.
+                (∃ #t0 pp.1.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -14039,7 +14039,7 @@ next
                            ∧
                             (#vr.20 < #t2) ∧
                             (#t2 < #vr.40) ∧
-                            (∀ pp #t0. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                            (∀ #t0 pp. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                             (∀ pp lpp #t0.
                               (Lock( pp, lpp, L_h1 ) @ #t0)
                              ⇒
@@ -14075,7 +14075,7 @@ next
                                        ∧
                                         (#vr.28 < #t2) ∧
                                         (#t2 < #vr.1) ∧
-                                        (∀ pp #t0. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ #t0 pp. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n ) @ #t0)
                                          ⇒
@@ -14186,7 +14186,7 @@ next
                                    ∧
                                     (#vr.20 < #t2) ∧
                                     (#t2 < #vr.48) ∧
-                                    (∀ pp #t0. (Unlock( pp, ~n.7, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                    (∀ #t0 pp. (Unlock( pp, ~n.7, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                     (∀ pp lpp #t0.
                                       (Lock( pp, lpp, L_h1 ) @ #t0)
                                      ⇒
@@ -14273,7 +14273,7 @@ next
                                                    ∧
                                                     (#vr.30 < #t2) ∧
                                                     (#t2 < #vr.73) ∧
-                                                    (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                    (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                     (∀ pp lpp #t0.
                                                       (Lock( pp, lpp, L_h ) @ #t0)
                                                      ⇒
@@ -14308,7 +14308,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ pp #t0.
+                                                              (∀ #t0 pp.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14385,7 +14385,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ pp #t0.
+                                                              (∀ #t0 pp.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14489,7 +14489,7 @@ next
                                                  ∧
                                                   (#vr.30 < #t2) ∧
                                                   (#t2 < #vr.84) ∧
-                                                  (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                  (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                   (∀ pp lpp #t0.
                                                     (Lock( pp, lpp, L_h ) @ #t0)
                                                    ⇒
@@ -14523,7 +14523,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -14599,7 +14599,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -14668,7 +14668,7 @@ next
                                                    ∧
                                                     (#vr.30 < #t2) ∧
                                                     (#t2 < #vr.74) ∧
-                                                    (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                    (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                     (∀ pp lpp #t0.
                                                       (Lock( pp, lpp, L_h ) @ #t0)
                                                      ⇒
@@ -14703,7 +14703,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ pp #t0.
+                                                              (∀ #t0 pp.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14780,7 +14780,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ pp #t0.
+                                                              (∀ #t0 pp.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14884,7 +14884,7 @@ next
                                                  ∧
                                                   (#vr.30 < #t2) ∧
                                                   (#t2 < #vr.85) ∧
-                                                  (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                  (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                   (∀ pp lpp #t0.
                                                     (Lock( pp, lpp, L_h ) @ #t0)
                                                    ⇒
@@ -14918,7 +14918,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -14994,7 +14994,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ pp #t0.
+                                                            (∀ #t0 pp.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -15276,7 +15276,7 @@ next
                            ∧
                             (#vr.20 < #t2) ∧
                             (#t2 < #vr.40) ∧
-                            (∀ pp #t0. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                            (∀ #t0 pp. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                             (∀ pp lpp #t0.
                               (Lock( pp, lpp, L_h1 ) @ #t0)
                              ⇒
@@ -15530,7 +15530,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15558,7 +15558,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15614,7 +15614,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15642,7 +15642,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15698,7 +15698,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15726,7 +15726,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15782,7 +15782,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15810,7 +15810,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15866,7 +15866,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15894,7 +15894,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15950,7 +15950,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15978,7 +15978,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -16034,7 +16034,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ pp #t0.
+              (∃ #t0 pp.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -16062,7 +16062,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ pp #t0.
+        solve( (∃ #t0 pp.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -17517,7 +17517,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17533,7 +17533,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17549,7 +17549,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17565,7 +17565,7 @@ restriction locking_3:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_3( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17581,7 +17581,7 @@ restriction locking_4:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_4( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17597,7 +17597,7 @@ restriction locking_5:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_5( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17613,7 +17613,7 @@ restriction locking_6:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_6( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17628,7 +17628,7 @@ restriction locking_6:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -17638,7 +17638,7 @@ analyzing: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy.tmp
-  processing time: 282.183804s
+  processing time: 131.279208378s
   dec_limits (all-traces): verified (290 steps)
   wrap_key_origins (all-traces): verified (1236 steps)
   no_key_is_wrap_and_dec_ind (all-traces): verified (152 steps)
@@ -17654,7 +17654,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy.tmp
-  processing time: 282.183804s
+  processing time: 131.279208378s
   dec_limits (all-traces): verified (290 steps)
   wrap_key_origins (all-traces): verified (1236 steps)
   no_key_is_wrap_and_dec_ind (all-traces): verified (152 steps)

--- a/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap_analyzed.spthy
@@ -114,7 +114,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -147,7 +147,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -180,7 +180,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -213,7 +213,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -246,7 +246,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -279,7 +279,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -312,7 +312,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -364,7 +364,7 @@ next
                        ∧
                         (#vr.3 < #t2) ∧
                         (#t2 < #vr.15) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, L_h ) @ #t0)
                          ⇒
@@ -449,7 +449,7 @@ next
                        ∧
                         (#vr.3 < #t2) ∧
                         (#t2 < #vr.26) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, L_h ) @ #t0)
                          ⇒
@@ -527,7 +527,7 @@ next
                        ∧
                         (#vr.3 < #t2) ∧
                         (#t2 < #vr.27) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, L_h ) @ #t0)
                          ⇒
@@ -565,7 +565,7 @@ next
                                      ∧
                                       (#vr.19 < #t2) ∧
                                       (#t2 < #vr.50) ∧
-                                      (∀ #t0 pp. (Unlock( pp, ~n.3, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                      (∀ pp #t0. (Unlock( pp, ~n.3, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                       (∀ pp lpp #t0.
                                         (Lock( pp, lpp, L_h1 ) @ #t0)
                                        ⇒
@@ -631,7 +631,7 @@ next
                                      ∧
                                       (#vr.19 < #t2) ∧
                                       (#t2 < #vr.47) ∧
-                                      (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                      (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                       (∀ pp lpp #t0.
                                         (Lock( pp, lpp, L_h1 ) @ #t0)
                                        ⇒
@@ -735,7 +735,7 @@ next
                                                            ∧
                                                             (#vr.40 < #t2) ∧
                                                             (#t2 < #vr.85) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, L_h ) @ #t0)
@@ -856,7 +856,7 @@ next
                                                          ∧
                                                           (#vr.40 < #t2) ∧
                                                           (#t2 < #vr.96) ∧
-                                                          (∀ #t0 pp.
+                                                          (∀ pp #t0.
                                                             (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                           (∀ pp lpp #t0.
                                                             (Lock( pp, lpp, L_h ) @ #t0)
@@ -927,7 +927,7 @@ next
                                                            ∧
                                                             (#vr.40 < #t2) ∧
                                                             (#t2 < #vr.86) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, L_h ) @ #t0)
@@ -1048,7 +1048,7 @@ next
                                                          ∧
                                                           (#vr.40 < #t2) ∧
                                                           (#t2 < #vr.97) ∧
-                                                          (∀ #t0 pp.
+                                                          (∀ pp #t0.
                                                             (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                           (∀ pp lpp #t0.
                                                             (Lock( pp, lpp, L_h ) @ #t0)
@@ -1166,7 +1166,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1194,7 +1194,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1250,7 +1250,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1278,7 +1278,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1334,7 +1334,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1362,7 +1362,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1418,7 +1418,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1446,7 +1446,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1502,7 +1502,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1530,7 +1530,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1586,7 +1586,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1614,7 +1614,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1670,7 +1670,7 @@ next
               (#t2 < #t1.1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -1698,7 +1698,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -1858,7 +1858,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1891,7 +1891,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1924,7 +1924,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1957,7 +1957,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -1990,7 +1990,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -2023,7 +2023,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -2056,7 +2056,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -2111,7 +2111,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.13) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -2241,7 +2241,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.24) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -2279,7 +2279,7 @@ next
                                        ∧
                                         (#vr.16 < #t2) ∧
                                         (#t2 < #vr.49) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -2471,7 +2471,7 @@ next
                                        ∧
                                         (#vr.16 < #t2) ∧
                                         (#t2 < #vr.67) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -2572,7 +2572,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.92) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -2608,7 +2608,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -2705,7 +2705,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -2827,7 +2827,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.103) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -2863,7 +2863,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -2959,7 +2959,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3032,7 +3032,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.93) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -3068,7 +3068,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3165,7 +3165,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3287,7 +3287,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.104) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -3323,7 +3323,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3419,7 +3419,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3588,7 +3588,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.99) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -3624,7 +3624,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3721,7 +3721,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -3843,7 +3843,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.110) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -3879,7 +3879,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -3975,7 +3975,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -4048,7 +4048,7 @@ next
                                                        ∧
                                                         (#vr.26 < #t2) ∧
                                                         (#t2 < #vr.100) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -4084,7 +4084,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -4181,7 +4181,7 @@ next
                                                                  ∧
                                                                   (#vr.43 < #t2) ∧
                                                                   (#t2 < #vr.31) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -4303,7 +4303,7 @@ next
                                                      ∧
                                                       (#vr.26 < #t2) ∧
                                                       (#t2 < #vr.111) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.8, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -4339,7 +4339,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -4435,7 +4435,7 @@ next
                                                                ∧
                                                                 (#vr.43 < #t2) ∧
                                                                 (#t2 < #vr.31) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -4573,7 +4573,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.25) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -4611,7 +4611,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.50) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -4785,7 +4785,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.68) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -4886,7 +4886,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.93) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -4922,7 +4922,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5019,7 +5019,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5141,7 +5141,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.104) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -5177,7 +5177,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5273,7 +5273,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5346,7 +5346,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.94) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -5382,7 +5382,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5479,7 +5479,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -5601,7 +5601,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.105) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -5637,7 +5637,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5733,7 +5733,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -5903,7 +5903,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.23) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -6024,7 +6024,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6052,7 +6052,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6108,7 +6108,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6136,7 +6136,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6192,7 +6192,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6220,7 +6220,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6276,7 +6276,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6304,7 +6304,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6360,7 +6360,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6388,7 +6388,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6444,7 +6444,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6472,7 +6472,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6528,7 +6528,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -6556,7 +6556,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -6660,7 +6660,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6693,7 +6693,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6726,7 +6726,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6759,7 +6759,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6792,7 +6792,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6825,7 +6825,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6858,7 +6858,7 @@ next
                   (#t2 < #t1) ∨
                   (#t2 = #t3) ∨
                   (#t3 < #t2) ∨
-                  (∃ #t0 pp.1.
+                  (∃ pp.1 #t0.
                     (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                   (∃ pp.1 lpp #t0.
                     (Lock( pp.1, lpp, x ) @ #t0)
@@ -6913,7 +6913,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.13) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -7043,7 +7043,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.24) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -7281,7 +7281,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.25) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -7319,7 +7319,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.50) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.4, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -7493,7 +7493,7 @@ next
                                        ∧
                                         (#vr.17 < #t2) ∧
                                         (#t2 < #vr.68) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.10, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, L_h1 ) @ #t0)
                                          ⇒
@@ -7594,7 +7594,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.93) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -7630,7 +7630,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -7727,7 +7727,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -7849,7 +7849,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.104) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -7885,7 +7885,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -7981,7 +7981,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -8054,7 +8054,7 @@ next
                                                        ∧
                                                         (#vr.27 < #t2) ∧
                                                         (#t2 < #vr.94) ∧
-                                                        (∀ #t0 pp.
+                                                        (∀ pp #t0.
                                                           (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                         (∀ pp lpp #t0.
                                                           (Lock( pp, lpp, L_h ) @ #t0)
@@ -8090,7 +8090,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -8187,7 +8187,7 @@ next
                                                                  ∧
                                                                   (#vr.44 < #t2) ∧
                                                                   (#t2 < #vr.32) ∧
-                                                                  (∀ #t0 pp.
+                                                                  (∀ pp #t0.
                                                                     (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                    ⇒
                                                                     #t0 = #t2) ∧
@@ -8309,7 +8309,7 @@ next
                                                      ∧
                                                       (#vr.27 < #t2) ∧
                                                       (#t2 < #vr.105) ∧
-                                                      (∀ #t0 pp.
+                                                      (∀ pp #t0.
                                                         (Unlock( pp, ~n.7, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                       (∀ pp lpp #t0.
                                                         (Lock( pp, lpp, L_h ) @ #t0)
@@ -8345,7 +8345,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -8441,7 +8441,7 @@ next
                                                                ∧
                                                                 (#vr.44 < #t2) ∧
                                                                 (#t2 < #vr.32) ∧
-                                                                (∀ #t0 pp.
+                                                                (∀ pp #t0.
                                                                   (Unlock( pp, ~n.2, ~n ) @ #t0)
                                                                  ⇒
                                                                   #t0 = #t2) ∧
@@ -8611,7 +8611,7 @@ next
                          ∧
                           (#vr.4 < #t2) ∧
                           (#t2 < #vr.23) ∧
-                          (∀ #t0 pp. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                          (∀ pp #t0. (Unlock( pp, ~n.1, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                           (∀ pp lpp #t0.
                             (Lock( pp, lpp, L_h ) @ #t0)
                            ⇒
@@ -8732,7 +8732,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -8760,7 +8760,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -8816,7 +8816,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -8844,7 +8844,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -8900,7 +8900,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -8928,7 +8928,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -8984,7 +8984,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9012,7 +9012,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9068,7 +9068,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9096,7 +9096,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9152,7 +9152,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9180,7 +9180,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9236,7 +9236,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -9264,7 +9264,7 @@ next
           by contradiction /* from formulas */
         next
           case case_2
-          solve( (∃ #t0 pp.
+          solve( (∃ pp #t0.
                    (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                  (∃ pp lpp #t0.
                    (Lock( pp, lpp, x ) @ #t0)
@@ -9380,7 +9380,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9413,7 +9413,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9446,7 +9446,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9479,7 +9479,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9512,7 +9512,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9545,7 +9545,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9578,7 +9578,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -9619,7 +9619,7 @@ next
                        ∧
                         (#vr.2 < #t2) ∧
                         (#t2 < #vr.25) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, ~n ) @ #t0)
                          ⇒
@@ -9648,7 +9648,7 @@ next
                                ∧
                                 (#vr.14 < #t2) ∧
                                 (#t2 < #vr.25) ∧
-                                (∀ #t0 pp. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                (∀ pp #t0. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                 (∀ pp lpp #t0.
                                   (Lock( pp, lpp, ~n ) @ #t0)
                                  ⇒
@@ -9671,7 +9671,7 @@ next
                                  ∧
                                   (#vr.2 < #t2) ∧
                                   (#t2 < #vr.14) ∧
-                                  (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                  (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                   (∀ pp lpp #t0.
                                     (Lock( pp, lpp, ~n ) @ #t0)
                                    ⇒
@@ -9718,7 +9718,7 @@ next
                        ∧
                         (#vr.2 < #t2) ∧
                         (#t2 < #vr.25) ∧
-                        (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                        (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                         (∀ pp lpp #t0.
                           (Lock( pp, lpp, ~n ) @ #t0)
                          ⇒
@@ -9747,7 +9747,7 @@ next
                                ∧
                                 (#vr.14 < #t2) ∧
                                 (#t2 < #vr.25) ∧
-                                (∀ #t0 pp. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                (∀ pp #t0. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                 (∀ pp lpp #t0.
                                   (Lock( pp, lpp, ~n ) @ #t0)
                                  ⇒
@@ -9770,7 +9770,7 @@ next
                                  ∧
                                   (#vr.2 < #t2) ∧
                                   (#t2 < #vr.14) ∧
-                                  (∀ #t0 pp. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                  (∀ pp #t0. (Unlock( pp, ~n.2, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                   (∀ pp lpp #t0.
                                     (Lock( pp, lpp, ~n ) @ #t0)
                                    ⇒
@@ -9831,7 +9831,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -9859,7 +9859,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -9915,7 +9915,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -9943,7 +9943,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -9999,7 +9999,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10027,7 +10027,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10083,7 +10083,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10111,7 +10111,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10167,7 +10167,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10195,7 +10195,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10251,7 +10251,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10279,7 +10279,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10335,7 +10335,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3.1) ∨
               (#t3.1 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -10363,7 +10363,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -10478,7 +10478,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10511,7 +10511,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10544,7 +10544,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10577,7 +10577,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10610,7 +10610,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10643,7 +10643,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10676,7 +10676,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -10914,7 +10914,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -10966,7 +10966,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11015,7 +11015,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11062,7 +11062,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11106,7 +11106,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11147,7 +11147,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11318,7 +11318,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11370,7 +11370,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11419,7 +11419,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11466,7 +11466,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11510,7 +11510,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11551,7 +11551,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11722,7 +11722,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11774,7 +11774,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11823,7 +11823,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -11870,7 +11870,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11914,7 +11914,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -11955,7 +11955,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12126,7 +12126,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12178,7 +12178,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12227,7 +12227,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12274,7 +12274,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12318,7 +12318,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12359,7 +12359,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12530,7 +12530,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12582,7 +12582,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12631,7 +12631,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12678,7 +12678,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12722,7 +12722,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12763,7 +12763,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -12934,7 +12934,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -12986,7 +12986,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13035,7 +13035,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13082,7 +13082,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13126,7 +13126,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13167,7 +13167,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13338,7 +13338,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13390,7 +13390,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13439,7 +13439,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3.1) ∨
                 (#t3.1 < #t2) ∨
-                (∃ #t0 pp.
+                (∃ pp #t0.
                   (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp lpp #t0.
                   (Lock( pp, lpp, x ) @ #t0)
@@ -13486,7 +13486,7 @@ next
                   ∧
                    (#t0.1 < #t0) ∧ (#t1 < #t0)) )
             case case_1
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13530,7 +13530,7 @@ next
             by contradiction /* from formulas */
           next
             case case_3
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13571,7 +13571,7 @@ next
             qed
           next
             case case_4
-            solve( (∃ #t0 pp.
+            solve( (∃ pp #t0.
                      (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2.1)))  ∥
                    (∃ pp lpp #t0.
                      (Lock( pp, lpp, x ) @ #t0)
@@ -13761,7 +13761,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13794,7 +13794,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13827,7 +13827,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13860,7 +13860,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13893,7 +13893,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13926,7 +13926,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -13959,7 +13959,7 @@ next
                 (#t2 < #t1) ∨
                 (#t2 = #t3) ∨
                 (#t3 < #t2) ∨
-                (∃ #t0 pp.1.
+                (∃ pp.1 #t0.
                   (Unlock( pp.1, l, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
                 (∃ pp.1 lpp #t0.
                   (Lock( pp.1, lpp, x ) @ #t0)
@@ -14039,7 +14039,7 @@ next
                            ∧
                             (#vr.20 < #t2) ∧
                             (#t2 < #vr.40) ∧
-                            (∀ #t0 pp. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                            (∀ pp #t0. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                             (∀ pp lpp #t0.
                               (Lock( pp, lpp, L_h1 ) @ #t0)
                              ⇒
@@ -14075,7 +14075,7 @@ next
                                        ∧
                                         (#vr.28 < #t2) ∧
                                         (#t2 < #vr.1) ∧
-                                        (∀ #t0 pp. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
+                                        (∀ pp #t0. (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                         (∀ pp lpp #t0.
                                           (Lock( pp, lpp, ~n ) @ #t0)
                                          ⇒
@@ -14186,7 +14186,7 @@ next
                                    ∧
                                     (#vr.20 < #t2) ∧
                                     (#t2 < #vr.48) ∧
-                                    (∀ #t0 pp. (Unlock( pp, ~n.7, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                    (∀ pp #t0. (Unlock( pp, ~n.7, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                                     (∀ pp lpp #t0.
                                       (Lock( pp, lpp, L_h1 ) @ #t0)
                                      ⇒
@@ -14273,7 +14273,7 @@ next
                                                    ∧
                                                     (#vr.30 < #t2) ∧
                                                     (#t2 < #vr.73) ∧
-                                                    (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                    (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                     (∀ pp lpp #t0.
                                                       (Lock( pp, lpp, L_h ) @ #t0)
                                                      ⇒
@@ -14308,7 +14308,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ #t0 pp.
+                                                              (∀ pp #t0.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14385,7 +14385,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ #t0 pp.
+                                                              (∀ pp #t0.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14489,7 +14489,7 @@ next
                                                  ∧
                                                   (#vr.30 < #t2) ∧
                                                   (#t2 < #vr.84) ∧
-                                                  (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                  (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                   (∀ pp lpp #t0.
                                                     (Lock( pp, lpp, L_h ) @ #t0)
                                                    ⇒
@@ -14523,7 +14523,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -14599,7 +14599,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -14668,7 +14668,7 @@ next
                                                    ∧
                                                     (#vr.30 < #t2) ∧
                                                     (#t2 < #vr.74) ∧
-                                                    (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                    (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                     (∀ pp lpp #t0.
                                                       (Lock( pp, lpp, L_h ) @ #t0)
                                                      ⇒
@@ -14703,7 +14703,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ #t0 pp.
+                                                              (∀ pp #t0.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14780,7 +14780,7 @@ next
                                                              ∧
                                                               (#vr.36 < #t2) ∧
                                                               (#t2 < #vr.1) ∧
-                                                              (∀ #t0 pp.
+                                                              (∀ pp #t0.
                                                                 (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                               (∀ pp lpp #t0.
                                                                 (Lock( pp, lpp, ~n ) @ #t0)
@@ -14884,7 +14884,7 @@ next
                                                  ∧
                                                   (#vr.30 < #t2) ∧
                                                   (#t2 < #vr.85) ∧
-                                                  (∀ #t0 pp. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
+                                                  (∀ pp #t0. (Unlock( pp, ~n.5, L_h ) @ #t0) ⇒ #t0 = #t2) ∧
                                                   (∀ pp lpp #t0.
                                                     (Lock( pp, lpp, L_h ) @ #t0)
                                                    ⇒
@@ -14918,7 +14918,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -14994,7 +14994,7 @@ next
                                                            ∧
                                                             (#vr.36 < #t2) ∧
                                                             (#t2 < #vr.1) ∧
-                                                            (∀ #t0 pp.
+                                                            (∀ pp #t0.
                                                               (Unlock( pp, ~n.3, ~n ) @ #t0) ⇒ #t0 = #t2) ∧
                                                             (∀ pp lpp #t0.
                                                               (Lock( pp, lpp, ~n ) @ #t0)
@@ -15276,7 +15276,7 @@ next
                            ∧
                             (#vr.20 < #t2) ∧
                             (#t2 < #vr.40) ∧
-                            (∀ #t0 pp. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
+                            (∀ pp #t0. (Unlock( pp, ~n.5, L_h1 ) @ #t0) ⇒ #t0 = #t2) ∧
                             (∀ pp lpp #t0.
                               (Lock( pp, lpp, L_h1 ) @ #t0)
                              ⇒
@@ -15530,7 +15530,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15558,7 +15558,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15614,7 +15614,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15642,7 +15642,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15698,7 +15698,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15726,7 +15726,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15782,7 +15782,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15810,7 +15810,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15866,7 +15866,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15894,7 +15894,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -15950,7 +15950,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -15978,7 +15978,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -16034,7 +16034,7 @@ next
               (#t2 < #t1) ∨
               (#t2 = #t3) ∨
               (#t3 < #t2) ∨
-              (∃ #t0 pp.
+              (∃ pp #t0.
                 (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2))) ∨
               (∃ pp lpp #t0.
                 (Lock( pp, lpp, x ) @ #t0)
@@ -16062,7 +16062,7 @@ next
         by contradiction /* from formulas */
       next
         case case_2
-        solve( (∃ #t0 pp.
+        solve( (∃ pp #t0.
                  (Unlock( pp, ~n, x ) @ #t0) ∧ (¬(last(#t0))) ∧ (¬(#t0 = #t2)))  ∥
                (∃ pp lpp #t0.
                  (Lock( pp, lpp, x ) @ #t0)
@@ -17517,7 +17517,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17533,7 +17533,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17549,7 +17549,7 @@ restriction locking_2:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_2( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17565,7 +17565,7 @@ restriction locking_3:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_3( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17581,7 +17581,7 @@ restriction locking_4:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_4( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17597,7 +17597,7 @@ restriction locking_5:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_5( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17613,7 +17613,7 @@ restriction locking_6:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_6( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -17628,7 +17628,7 @@ restriction locking_6:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -17638,7 +17638,7 @@ analyzing: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy.tmp
-  processing time: 297.979840238s
+  processing time: 282.183804s
   dec_limits (all-traces): verified (290 steps)
   wrap_key_origins (all-traces): verified (1236 steps)
   no_key_is_wrap_and_dec_ind (all-traces): verified (152 steps)
@@ -17654,7 +17654,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy
 
   output:          examples/sapic/slow/encWrapDecUnwrap/encwrapdecunwrap.spthy.tmp
-  processing time: 297.979840238s
+  processing time: 282.183804s
   dec_limits (all-traces): verified (290 steps)
   wrap_key_origins (all-traces): verified (1236 steps)
   no_key_is_wrap_and_dec_ind (all-traces): verified (152 steps)

--- a/case-studies-regression/sapic/slow/feature-locations/AC_counter_with_attack_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/feature-locations/AC_counter_with_attack_analyzed.spthy
@@ -46,7 +46,7 @@ solve( State_12111111111( i2, o2, signedios, <<o, list(i, 'init')>, x>,
                    ∧
                     (#vr.4 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.2 ) @ #t0)
                      ⇒
@@ -77,7 +77,7 @@ solve( State_12111111111( i2, o2, signedios, <<o, list(i, 'init')>, x>,
                                    ∧
                                     (#vr.20 < #t2) ∧
                                     (#t2 < #vr.51) ∧
-                                    (∀ pp #t0. (Unlock( pp, ~n.9, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                    (∀ #t0 pp. (Unlock( pp, ~n.9, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                     (∀ pp lpp #t0.
                                       (Lock( pp, lpp, ~n.8 ) @ #t0)
                                      ⇒
@@ -625,7 +625,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -641,7 +641,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -656,7 +656,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -666,7 +666,7 @@ analyzing: examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy
 analyzed: examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy.tmp
-  processing time: 105.958603s
+  processing time: 57.643638829s
   attested_comput_second_step (exists-trace): verified (27 steps)
 
 ------------------------------------------------------------------------------
@@ -677,7 +677,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy.tmp
-  processing time: 105.958603s
+  processing time: 57.643638829s
   attested_comput_second_step (exists-trace): verified (27 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/slow/feature-locations/AC_counter_with_attack_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/feature-locations/AC_counter_with_attack_analyzed.spthy
@@ -46,7 +46,7 @@ solve( State_12111111111( i2, o2, signedios, <<o, list(i, 'init')>, x>,
                    ∧
                     (#vr.4 < #t2) ∧
                     (#t2 < #vr.33) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.3, ~n.2 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.2 ) @ #t0)
                      ⇒
@@ -77,7 +77,7 @@ solve( State_12111111111( i2, o2, signedios, <<o, list(i, 'init')>, x>,
                                    ∧
                                     (#vr.20 < #t2) ∧
                                     (#t2 < #vr.51) ∧
-                                    (∀ #t0 pp. (Unlock( pp, ~n.9, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                    (∀ pp #t0. (Unlock( pp, ~n.9, ~n.8 ) @ #t0) ⇒ #t0 = #t2) ∧
                                     (∀ pp lpp #t0.
                                       (Lock( pp, lpp, ~n.8 ) @ #t0)
                                      ⇒
@@ -625,7 +625,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -641,7 +641,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -656,7 +656,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -666,7 +666,7 @@ analyzing: examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy
 analyzed: examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy.tmp
-  processing time: 90.497306873s
+  processing time: 105.958603s
   attested_comput_second_step (exists-trace): verified (27 steps)
 
 ------------------------------------------------------------------------------
@@ -677,7 +677,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_counter_with_attack.spthy.tmp
-  processing time: 90.497306873s
+  processing time: 105.958603s
   attested_comput_second_step (exists-trace): verified (27 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/slow/feature-locations/AC_sid_with_attack_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/feature-locations/AC_sid_with_attack_analyzed.spthy
@@ -44,7 +44,7 @@ solve( State_112111111111111( init, ip, ipo, o, r_sid, sid, signedios,
                    ∧
                     (#vr.4 < #t2) ∧
                     (#t2 < #vr.42) ∧
-                    (∀ #t0 pp. (Unlock( pp, ~n.5, ~n.4 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ pp #t0. (Unlock( pp, ~n.5, ~n.4 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.4 ) @ #t0)
                      ⇒
@@ -78,7 +78,7 @@ solve( State_112111111111111( init, ip, ipo, o, r_sid, sid, signedios,
                                    ∧
                                     (#vr.25 < #t2) ∧
                                     (#t2 < #vr.68) ∧
-                                    (∀ #t0 pp. (Unlock( pp, ~n.13, ~n.12 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                    (∀ pp #t0. (Unlock( pp, ~n.13, ~n.12 ) @ #t0) ⇒ #t0 = #t2) ∧
                                     (∀ pp lpp #t0.
                                       (Lock( pp, lpp, ~n.12 ) @ #t0)
                                      ⇒
@@ -782,7 +782,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -798,7 +798,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -813,7 +813,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 3.0. OK.
+ checking version: 2.7.1. OK.
  checking installation: OK.
 
 
@@ -823,7 +823,7 @@ analyzing: examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy
 analyzed: examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy.tmp
-  processing time: 88.425156522s
+  processing time: 86.07398s
   attested_comput (exists-trace): verified (31 steps)
 
 ------------------------------------------------------------------------------
@@ -834,7 +834,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy.tmp
-  processing time: 88.425156522s
+  processing time: 86.07398s
   attested_comput (exists-trace): verified (31 steps)
 
 ==============================================================================

--- a/case-studies-regression/sapic/slow/feature-locations/AC_sid_with_attack_analyzed.spthy
+++ b/case-studies-regression/sapic/slow/feature-locations/AC_sid_with_attack_analyzed.spthy
@@ -44,7 +44,7 @@ solve( State_112111111111111( init, ip, ipo, o, r_sid, sid, signedios,
                    ∧
                     (#vr.4 < #t2) ∧
                     (#t2 < #vr.42) ∧
-                    (∀ pp #t0. (Unlock( pp, ~n.5, ~n.4 ) @ #t0) ⇒ #t0 = #t2) ∧
+                    (∀ #t0 pp. (Unlock( pp, ~n.5, ~n.4 ) @ #t0) ⇒ #t0 = #t2) ∧
                     (∀ pp lpp #t0.
                       (Lock( pp, lpp, ~n.4 ) @ #t0)
                      ⇒
@@ -78,7 +78,7 @@ solve( State_112111111111111( init, ip, ipo, o, r_sid, sid, signedios,
                                    ∧
                                     (#vr.25 < #t2) ∧
                                     (#t2 < #vr.68) ∧
-                                    (∀ pp #t0. (Unlock( pp, ~n.13, ~n.12 ) @ #t0) ⇒ #t0 = #t2) ∧
+                                    (∀ #t0 pp. (Unlock( pp, ~n.13, ~n.12 ) @ #t0) ⇒ #t0 = #t2) ∧
                                     (∀ pp lpp #t0.
                                       (Lock( pp, lpp, ~n.12 ) @ #t0)
                                      ⇒
@@ -782,7 +782,7 @@ restriction locking_0:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_0( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -798,7 +798,7 @@ restriction locking_1:
     ((((#t1 < #t3) ∧
        (∃ #t2.
          (((((Unlock_1( p, l, x ) @ #t2) ∧ (#t1 < #t2)) ∧ (#t2 < #t3)) ∧
-           (∀ pp.1 #t0. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
+           (∀ #t0 pp.1. (Unlock( pp.1, l, x ) @ #t0) ⇒ (#t0 = #t2))) ∧
           (∀ pp.1 lpp #t0.
             (Lock( pp.1, lpp, x ) @ #t0) ⇒
             (((#t0 < #t1) ∨ (#t0 = #t1)) ∨ (#t2 < #t0)))) ∧
@@ -813,7 +813,7 @@ restriction locking_1:
 end
 /* Output
 maude tool: 'maude'
- checking version: 2.7.1. OK.
+ checking version: 3.1. OK.
  checking installation: OK.
 
 
@@ -823,7 +823,7 @@ analyzing: examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy
 analyzed: examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy.tmp
-  processing time: 86.07398s
+  processing time: 58.385430289s
   attested_comput (exists-trace): verified (31 steps)
 
 ------------------------------------------------------------------------------
@@ -834,7 +834,7 @@ summary of summaries:
 analyzed: examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy
 
   output:          examples/sapic/slow/feature-locations/AC_sid_with_attack.spthy.tmp
-  processing time: 86.07398s
+  processing time: 58.385430289s
   attested_comput (exists-trace): verified (31 steps)
 
 ==============================================================================

--- a/examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
+++ b/examples/sapic/fast/feature-locking-restriction/locking-restriction.spthy
@@ -1,0 +1,13 @@
+theory LockingRestriction
+begin
+
+let P = lock 'P';
+        event A();
+        unlock 'P'
+
+lock 'P'; P
+
+lemma ANotReachable:
+  "not Ex #t. A()@t"
+
+end

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -248,32 +248,23 @@ resSingleSession = [QQ.r|restrictionsingle_session: // for a single session
 
 -- | Restriction for Locking. Note that LockPOS hardcodes positions that
 -- should be modified below.
-resLockingL :: String
-resLockingL  = [QQ.r|restriction locking:
-"All p pp l x lp #t1 #t3 . LockPOS(p,l,x)@t1 & Lock(pp,lp,x)@t3
-        ==>
-        ( #t1<#t3
-                 & (Ex #t2. UnlockPOS(p,l,x)@t2 & #t1<#t2 & #t2<#t3
-                 & (All #t0 pp  . Unlock(pp,l,x)@t0 ==> #t0=#t2)
-                 & (All pp lpp #t0 . Lock(pp,lpp,x)@t0 ==> #t0<#t1 | #t0=#t1 | #t2<#t0)
-                 & (All pp lpp #t0 . Unlock(pp,lpp,x)@t0 ==> #t0<#t1 | #t2<#t0 | #t2=#t0 )
-                ))
-        | #t3<#t1 | #t1=#t3"
+resLockingPOS :: String
+resLockingPOS  = [QQ.r|restriction locking:
+"All p pp l x lp #t1 #t3. LockPOS(p, l, x)@t1 & Lock(pp, lp, x)@t3 ==>
+        (#t1<#t3 & (Ex #t2. UnlockPOS(p, l, x)@t2 & #t1 < #t2 & #t2 < #t3
+                   & (All pp #t0. Unlock(pp, l, x)@t0 ==> #t0 = #t2)
+                   & (All pp lpp #t0. Lock(pp, lpp, x)@t0 ==> #t0 < #t1 | #t0 = #t1 | #t2 < #t0)
+                   & (All pp lpp #t0. Unlock(pp, lpp, x)@t0 ==> #t0 < #t1 | #t2 < #t0 | #t2 = #t0 )))
+      | #t3<#t1 | #t1=#t3"
 |]
 
 -- | Restriction for Locking where no Unlock is necessary.
-resLockingLNoUnlockPOS :: String
-resLockingLNoUnlockPOS  = [QQ.r|restriction locking:
-"All p l x #t1 . LockPOS(p,l,x)@t1
-                   ==> (All pp lp #t2. LockPOS(pp,lp,x)@t2 ==> #t1=#t2)"
+resLockingPOSNoUnlock :: String
+resLockingPOSNoUnlock = [QQ.r|restriction locking:
+"All p pp l x lp #t1 #t3. LockPOS(p, l, x)@t1 & Lock(pp, lp, x)@t3 ==>
+        #t3<#t1 | #t1=#t3"
 |]
 
--- | Restriction for Locking where no Unlock is necessary.
-resLockingNoUnlock :: String
-resLockingNoUnlock  = [QQ.r|restriction locking:
-"All p l x #t1 . Lock(p,l,x)@t1
-                   ==> (All pp lp #t2. Lock(pp,lp,x)@t2 ==> #t1=#t2)"
-|]
 
 -- | Produce locking lemma for variable v by instantiating resLockingL
 --  with (Un)Lock_pos instead of (Un)LockPOS, where pos is the variable id
@@ -281,9 +272,9 @@ resLockingNoUnlock  = [QQ.r|restriction locking:
 resLocking :: MonadThrow m => Bool -> LVar -> m SyntacticRestriction
 resLocking hasUnlock v =  do
     rest <- if hasUnlock then
-              toEx resLockingL
+              toEx resLockingPOS
             else
-              toEx resLockingLNoUnlockPOS
+              toEx resLockingPOSNoUnlock
     return $ mapName hardcode $ mapFormula (mapAtoms subst) rest
     where
         subst _ a
@@ -330,24 +321,19 @@ baseRestr anP needsInEvRes hasAccountabilityLemmaWithControl prevRestr =
               else
             [resSetInNoDelete, resSetNotInNoDelete]
          else [])
-        ++
-        addIf (contains isEq) [resEq, resNotEq]
-        ++
-        addIf hasAccountabilityLemmaWithControl [resSingleSession]
-        ++
-        addIf needsInEvRes [resInEv]
-    in
-    do
+        ++ addIf (contains isEq) [resEq, resNotEq]
+        ++ addIf hasAccountabilityLemmaWithControl [resSingleSession]
+        ++ addIf needsInEvRes [resInEv]
+    in do
         hardcoded <- mapM toEx hardcoded_l
         lockingWithUnlock <- mapM (resLocking True) (nub $ getUnlockPositions anP)
         lockingOnlyLock   <- mapM (resLocking False) ((getLockPositions anP) \\ (getUnlockPositions anP))
-        singleLocking <- toEx resLockingNoUnlock
 
         return $ prevRestr
               ++ hardcoded
               ++ lockingWithUnlock
               ++ lockingOnlyLock
-              ++ addIf ((not $ contains isUnlock) && (contains isLock)) [singleLocking]
+
     where
         addIf phi list = if phi then list else []
         contains = processContains anP

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -252,7 +252,7 @@ resLockingPOS :: String
 resLockingPOS  = [QQ.r|restriction locking:
 "All p pp l x lp #t1 #t3. LockPOS(p, l, x)@t1 & Lock(pp, lp, x)@t3 ==>
         (#t1<#t3 & (Ex #t2. UnlockPOS(p, l, x)@t2 & #t1 < #t2 & #t2 < #t3
-                   & (All pp #t0. Unlock(pp, l, x)@t0 ==> #t0 = #t2)
+                   & (All #t0 pp. Unlock(pp, l, x)@t0 ==> #t0 = #t2)
                    & (All pp lpp #t0. Lock(pp, lpp, x)@t0 ==> #t0 < #t1 | #t0 = #t1 | #t2 < #t0)
                    & (All pp lpp #t0. Unlock(pp, lpp, x)@t0 ==> #t0 < #t1 | #t2 < #t0 | #t2 = #t0 )))
       | #t3<#t1 | #t1=#t3"


### PR DESCRIPTION
The locking restriction that is added for locks that don't have unlocks
is now a simplified version of the full locking restriction.