### PR TITLE
Refactor of TheoryLoader / Batch / Interactive

### DIFF
--- a/lib/accountability/src/Accountability.hs
+++ b/lib/accountability/src/Accountability.hs
@@ -7,7 +7,8 @@
 -- Translation from OpenTheories to OpenTheories with accountability lemmas
 
 module Accountability (
-       translate
+       module Accountability.Generation
+     , translate
 ) where
 import Control.Monad.Catch (MonadThrow (throwM), MonadCatch, Exception)
 import Theory (OpenTheory, CaseIdentifier, theoryAccLemmas, aCaseIdentifiers, cName, aName, aCaseTests, AccLemma)

--- a/lib/accountability/src/Accountability.hs
+++ b/lib/accountability/src/Accountability.hs
@@ -11,7 +11,7 @@ module Accountability (
      , translate
 ) where
 import Control.Monad.Catch (MonadThrow (throwM), MonadCatch, Exception)
-import Theory (OpenTheory, CaseIdentifier, theoryAccLemmas, aCaseIdentifiers, cName, aName, aCaseTests, AccLemma)
+import Theory (OpenTheory, CaseIdentifier, theoryAccLemmas, aCaseIdentifiers, cName, aName, aCaseTests, AccLemma, caseTestToPredicate, theoryCaseTests)
 import Data.Data (Typeable)
 import Control.Applicative (Alternative)
 import qualified Data.Label as L
@@ -19,7 +19,8 @@ import Data.List (intercalate, (\\))
 import Data.Maybe (mapMaybe)
 import Control.Monad (unless, guard, foldM)
 import Accountability.Generation (generateAccountabilityLemmas)
-import Theory.Text.Parser
+import Theory.Text.Parser (liftedAddLemma)
+import Theory.Text.Parser.Signature (liftedAddPredicate)
 
 
 ------------------------------------------------------------------------------
@@ -43,7 +44,10 @@ translate thy = do
     let undef = mapMaybe undefinedCaseTests (theoryAccLemmas thy)
     unless (null undef) (throwM (CaseTestsUndefined undef :: AccException))
     accLemmas <- mapM generateAccountabilityLemmas (theoryAccLemmas thy)
-    foldM liftedAddLemma thy (concat accLemmas)
+    thy' <- foldM liftedAddLemma thy (concat accLemmas)
+    let casePredicates = mapMaybe caseTestToPredicate (theoryCaseTests thy)
+    foldM liftedAddPredicate thy' casePredicates
+
 
 -- | Checks if the case tests requiered by an accountability lemma are present
 undefinedCaseTests :: Alternative f => AccLemma -> f (String, [CaseIdentifier])

--- a/lib/accountability/src/Accountability/Generation.hs
+++ b/lib/accountability/src/Accountability/Generation.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
--- Copyright   : (c) 2019-2021 Robert Künnemann, Kevin Morio & Yavor Ivanov
+-- Copyright   : (c) 2019-2022 Robert Künnemann, Kevin Morio & Yavor Ivanov
 -- License     : GPL v3 (see LICENSE)
 --
 -- Maintainer  : Robert Künnemann <robert@kunnemann.de>
@@ -8,7 +8,7 @@
 -- Compute translation-specific restrictions
 module Accountability.Generation (
         generateAccountabilityLemmas
-      , checkPreTransWellformedness
+      , checkWellformedness
 ) where
 
 import           Control.Monad.Catch         (MonadThrow)
@@ -332,5 +332,5 @@ accRPReport thy
                           $-$ text "and the parties corrupted in t’’ are the same as the parties"
                           $-$ text "corrupted in t’ renamed from rng(ρ’) to rng(ρ)."
 
-checkPreTransWellformedness :: OpenTheory -> WfErrorReport
-checkPreTransWellformedness thy = if null $ theoryAccLemmas thy then [] else accRPReport thy
+checkWellformedness :: OpenTheory -> WfErrorReport
+checkWellformedness thy = if null $ theoryAccLemmas thy then [] else accRPReport thy

--- a/lib/sapic/src/Sapic/Warnings.hs
+++ b/lib/sapic/src/Sapic/Warnings.hs
@@ -29,5 +29,5 @@ throwWarningsProcess p = traverse_ throwM capture_warnings >> return p -- search
 warnings :: (Monad m, MonadThrow m) => Theory sig c r p TranslationElement -> m (Theory sig c r p TranslationElement)
 warnings = mapMProcesses throwWarningsProcess
 
-checkWellformednessSapic :: OpenTheory  -> WfErrorReport
-checkWellformednessSapic = concatMap (toWfErrorReport . warnProcess) . theoryProcesses
+checkWellformedness :: OpenTheory  -> WfErrorReport
+checkWellformedness = concatMap (toWfErrorReport . warnProcess) . theoryProcesses

--- a/lib/theory/src/Items/AccLemmaItem.hs
+++ b/lib/theory/src/Items/AccLemmaItem.hs
@@ -11,12 +11,12 @@ module Items.AccLemmaItem (
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Data.Binary (Binary)
+import Data.List
 import Data.Label as L
 import Text.PrettyPrint.Highlight
 import Theory.Text.Pretty
 import Theory.Model
 import Lemma
-
 import Items.CaseTestItem
 
 ------------------------------------------------------------------------------
@@ -48,6 +48,10 @@ prettyAccLemma :: HighlightDocument d => AccLemma -> d
 prettyAccLemma alem =
     kwLemma <-> prettyAccLemmaName alem <> colon $-$
     (nest 2 $
+      text (intercalate ", " (L.get aCaseIdentifiers alem)) <-> account $-$
       sep [  doubleQuotes $ prettySyntacticLNFormula $ L.get aFormula alem
           ]
     )
+    where
+        account | length (L.get aCaseIdentifiers alem) == 1 = text "accounts for"
+                | otherwise                                 = text "accounts for"

--- a/lib/theory/src/Items/CaseTestItem.hs
+++ b/lib/theory/src/Items/CaseTestItem.hs
@@ -14,6 +14,7 @@ import Data.Binary (Binary)
 import Data.Label as L
 import Theory.Model
 import Theory.Syntactic.Predicate
+import Text.PrettyPrint.Highlight (HighlightDocument, Document (nest, (<->), ($-$), text, sep), colon, doubleQuotes)
 
 ------------------------------------------------------------------------------
 -- Case Tests
@@ -35,3 +36,11 @@ caseTestToPredicate caseTest = fmap (Predicate fact) formula
     fact = protoFact Linear name (frees formula)
     name = L.get cName caseTest
     formula = toLNFormula (L.get cFormula caseTest)
+
+prettyCaseTest :: HighlightDocument d => CaseTest -> d
+prettyCaseTest caseTest =
+    text "test" <-> text (L.get cName caseTest) <> colon $-$
+    (nest 2 $
+      sep [  doubleQuotes $ prettySyntacticLNFormula $ L.get cFormula caseTest
+          ]
+    )

--- a/lib/theory/src/Items/LemmaItem.hs
+++ b/lib/theory/src/Items/LemmaItem.hs
@@ -3,11 +3,15 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds #-}
 
 module Items.LemmaItem (
     module Items.LemmaItem
 ) where
 
+import GHC.Records
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Data.Binary (Binary)
@@ -73,8 +77,12 @@ data DiffLemma p = DiffLemma
        deriving( Eq, Ord, Show, Generic, NFData, Binary )
 $(mkLabels [''DiffLemma])
 
+type HasLemmaName l = HasField "lName" l String
 
-
+instance HasField "lName" (ProtoLemma f p) String where
+  getField = _lName
+instance HasField "lName" (DiffLemma p) String where
+  getField = _lDiffName
 
 
 -- Instances

--- a/lib/theory/src/Items/LemmaItem.hs
+++ b/lib/theory/src/Items/LemmaItem.hs
@@ -84,6 +84,13 @@ instance HasField "lName" (ProtoLemma f p) String where
 instance HasField "lName" (DiffLemma p) String where
   getField = _lDiffName
 
+type HasLemmaAttributes l = HasField "lAttributes" l [LemmaAttribute]
+
+instance HasField "lAttributes" (ProtoLemma f p) [LemmaAttribute] where
+  getField = _lAttributes
+instance HasField "lAttributes" (DiffLemma p) [LemmaAttribute] where
+  getField = _lDiffAttributes
+
 
 -- Instances
 ------------

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -17,6 +17,8 @@ module Theory.Text.Parser (
   , parseOpenTheoryString
   , parseOpenDiffTheory
   , parseOpenDiffTheoryString
+  , theory
+  , diffTheory
   , parseLemma
   , parseRestriction
   , parseIntruderRules

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -236,8 +236,8 @@ theory inFile = do
            addItems inFile0 thy'
            -- add legacy deprecation warning output
       , do test <- caseTest
-           thy <- liftedAddCaseTest thy test
-           addItems inFile0 thy
+           thy' <- liftedAddCaseTest thy test
+           addItems inFile0 thy'
       , do accLem <- lemmaAcc workDir
            let tests = mapMaybe (flip lookupCaseTest $ thy) (get aCaseIdentifiers accLem)
            thy' <- liftedAddAccLemma thy (defineCaseTests accLem tests)

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -236,9 +236,8 @@ theory inFile = do
            addItems inFile0 thy'
            -- add legacy deprecation warning output
       , do test <- caseTest
-           thy1 <- liftedAddCaseTest thy test
-           thy2 <- maybe (return thy1) (liftedAddPredicate thy1) (caseTestToPredicate test)
-           addItems inFile0 thy2
+           thy <- liftedAddCaseTest thy test
+           addItems inFile0 thy
       , do accLem <- lemmaAcc workDir
            let tests = mapMaybe (flip lookupCaseTest $ thy) (get aCaseIdentifiers accLem)
            thy' <- liftedAddAccLemma thy (defineCaseTests accLem tests)

--- a/lib/theory/src/Theory/Text/Parser/Exceptions.hs
+++ b/lib/theory/src/Theory/Text/Parser/Exceptions.hs
@@ -49,6 +49,8 @@ instance Show (ParsingException) where
     show (DuplicateItem (TranslationItem (SignatureBuiltin s))) = "duplicate BuiltIn signature: " ++ show s
     show (DuplicateItem (TranslationItem (DiffEquivLemma _))) = "duplicate diff equiv lemma item"
     show (DuplicateItem (TranslationItem (EquivLemma _ _))) = "duplicate equiv lemma item"    
+    show (DuplicateItem (TranslationItem (AccLemmaItem _))) = "duplicate accountability lemma item"
+    show (DuplicateItem (TranslationItem (CaseTestItem _))) = "duplicate case test item"
     show TryingToAddFreshRule = "The fresh rule is implicitely contained in the theory and does not need to be added."
 
 instance Catch.Exception ParsingException

--- a/lib/theory/src/Theory/Tools/AbstractInterpretation.hs
+++ b/lib/theory/src/Theory/Tools/AbstractInterpretation.hs
@@ -85,6 +85,7 @@ interpretAbstractly unifyFactEqs initState addFact stateFacts rus =
 
 -- | How to report on performing a partial evaluation.
 data EvaluationStyle = Silent | Summary | Tracing
+  deriving Show
 
 -- | Concrete partial evaluator activated with flag: --partial-evaluation
 partialEvaluation :: EvaluationStyle

--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -59,9 +59,7 @@ module Theory.Tools.Wellformedness (
   -- * Wellformedness checking
     WfErrorReport
   , checkWellformedness
-  , noteWellformedness
   , checkWellformednessDiff
-  , noteWellformednessDiff
 
   , prettyWfErrorReport
 
@@ -993,33 +991,3 @@ checkWellformedness thy sig = concatMap ($ thy)
     , lemmaAttributeReport
     , multRestrictedReport
     ]
-
--- | Adds a note to the end of the theory, if it is not well-formed.
-noteWellformedness :: WfErrorReport -> OpenTranslatedTheory -> Bool -> OpenTranslatedTheory
-noteWellformedness report thy quitOnWarning =
-    addComment wfErrorReport thy
-  where
-    wfErrorReport
-      | null report = text "All well-formedness checks were successful."
-      | otherwise   = if quitOnWarning
-                      then error ("quit-on-warning mode selected - aborting on following wellformedness errors.\n"
-                                 ++ (render (prettyWfErrorReport report)))
-                      else vsep
-          [ text "WARNING: the following wellformedness checks failed!"
-          , prettyWfErrorReport report
-          ]
-
--- | Adds a note to the end of the theory, if it is not well-formed.
-noteWellformednessDiff :: WfErrorReport -> OpenDiffTheory -> Bool -> OpenDiffTheory
-noteWellformednessDiff report thy quitOnWarning =
-    addDiffComment wfErrorReport thy
-  where
-    wfErrorReport
-      | null report = text "All well-formedness checks were successful."
-      | otherwise   = if quitOnWarning
-                      then error ("quit-on-warning mode selected - aborting on following wellformedness errors.\n"
-                                 ++ (render (prettyWfErrorReport report)))
-                      else vsep
-          [ text "WARNING: the following wellformedness checks failed!"
-          , prettyWfErrorReport report
-          ]

--- a/lib/theory/src/TheoryObject.hs
+++ b/lib/theory/src/TheoryObject.hs
@@ -154,6 +154,8 @@ import Items.ExportInfo
 import qualified Data.Set as S
 import Theory.Syntactic.Predicate
 import Data.ByteString.Char8 (unpack)
+import Items.AccLemmaItem (prettyAccLemma)
+import Items.CaseTestItem (prettyCaseTest)
 
 
 -- | A theory contains a single set of rewriting rules modeling a protocol
@@ -612,6 +614,8 @@ prettyTranslationElement :: HighlightDocument d => TranslationElement -> d
 prettyTranslationElement (ProcessItem p) = text "process" <> colon $-$ (nest 2 $ prettyProcess p)
 prettyTranslationElement (DiffEquivLemma p) = text "diffEquivLemma" <> colon $-$ (nest 2 $ prettyProcess p)
 prettyTranslationElement (EquivLemma p1 p2) = text "equivLemma" <> colon $-$ (nest 2 $ prettyProcess p1) $$ (nest 2 $ prettyProcess p2)
+prettyTranslationElement (AccLemmaItem a) = prettyAccLemma a
+prettyTranslationElement (CaseTestItem c) = prettyCaseTest c
 prettyTranslationElement (ProcessDefItem p) =
     (text "let ")
     <->
@@ -625,7 +629,6 @@ prettyTranslationElement (ProcessDefItem p) =
     (text "=")
     <->
     nest 2 (prettyProcess $ L.get pBody p)
-
 prettyTranslationElement (FunctionTypingInfo ((fsn,(_,priv,_)), intypes, outtype)) =
     (text "function:")
     <->
@@ -648,7 +651,6 @@ prettyTranslationElement (ExportInfoItem eInfo) =
     text (L.get eTag eInfo)
     <->
     nest 2 (doubleQuotes $ text $ L.get eText eInfo)
-
 prettyTranslationElement (SignatureBuiltin s) = (text "builtin ")<->(text s)
 
 prettyPredicate :: HighlightDocument d => Predicate -> d

--- a/lib/theory/tamarin-prover-theory.cabal
+++ b/lib/theory/tamarin-prover-theory.cabal
@@ -109,6 +109,7 @@ library
       Theory.Text.Parser
       Theory.Text.Parser.Token
       Theory.Text.Parser.Restriction
+      Theory.Text.Parser.Signature
 
       Theory.Tools.AbstractInterpretation
       Theory.Tools.EquationStore
@@ -146,7 +147,6 @@ library
       Theory.Text.Parser.Proof
       Theory.Text.Parser.Rule
       Theory.Text.Parser.Sapic
-      Theory.Text.Parser.Signature
       Theory.Text.Parser.Term
       Theory.Sapic.PlainProcess
       Theory.Sapic.Substitution

--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -38,9 +38,6 @@ module Main.Console (
   , findArg
   , argExists
 
-  -- ** Utility Functions
-  , getOutputModule
-
   -- * Pretty printing and console output
   , lineWidth
   , shortLineWidth
@@ -154,20 +151,6 @@ updateArg a v = Right . addArg a v
 -- | Add the help flag.
 helpFlag :: Flag Arguments
 helpFlag = flagHelpSimple (addEmptyArg "help")
-
-------------------------------------------------------------------------------
--- Utility Functions
-------------------------------------------------------------------------------
-
-getOutputModule ::  Arguments -> ModuleType
-getOutputModule as
-     | Nothing <-  findArg "outModule" as
-     , [] /= findArg "prove" as = ModuleMsr -- when proving, we act like we chose the Msr Output module.
-     | Nothing <-  findArg "outModule" as = ModuleSpthy -- default
-     | Just string <-  findArg "outModule" as
-     , Just modCon <- find (\x -> show x  == string) (enumFrom minBound)
-      = modCon
-     | otherwise = error "output mode not supported."
 
 ------------------------------------------------------------------------------
 -- Modes for using the Tamarin prover

--- a/src/Main/Mode/Batch.hs
+++ b/src/Main/Mode/Batch.hs
@@ -12,10 +12,9 @@ module Main.Mode.Batch (
   ) where
 
 import           Control.Basics
-import           Control.DeepSeq                 (force)
-import           Control.Exception               (evaluate)
 import           Data.List
 import           Data.Maybe
+import           Data.Bitraversable              (bisequence)
 import           System.Console.CmdArgs.Explicit as CmdArgs
 import           System.FilePath
 import           System.Timing                   (timed)
@@ -24,7 +23,6 @@ import           Extension.Data.Label
 import qualified Text.PrettyPrint.Class          as Pretty
 
 import           Theory
-import           Theory.Tools.Wellformedness     (checkWellformednessDiff)
 
 import qualified Sapic
 import qualified Export
@@ -35,9 +33,8 @@ import           Main.TheoryLoader
 import           Main.Utils
 
 import           Theory.Module
-import           Control.Monad.Except (MonadIO(liftIO), runExcept, runExceptT)
+import           Control.Monad.Except (MonadIO(liftIO), runExceptT)
 import           System.Exit (die)
--- import           Debug.Trace
 
 -- | Batch processing mode.
 batchMode :: TamarinMode
@@ -83,32 +80,59 @@ run :: TamarinMode -> Arguments -> IO ()
 run thisMode as
   | null inFiles = helpAndExit thisMode (Just "no input files given")
   | argExists "parseOnly" as || argExists "outModule" as = do
-      mapM_ processThyNew inFiles
+      res <- mapM processThy inFiles
+      let (thys, _) = unzip res
+
+      mapM_ (putStrLn . renderDoc) thys
       putStrLn ""
-  | otherwise  = do
+  | otherwise = do
       _ <- ensureMaude as
-      putStrLn ""
-      summaries <- mapM processThyNew inFiles
-      putStrLn ""
-      putStrLn $ replicate 78 '='
-      putStrLn "summary of summaries:"
-      putStrLn ""
-      putStrLn $ renderDoc $ Pretty.vcat $ intersperse (Pretty.text "") summaries
-      putStrLn ""
-      putStrLn $ replicate 78 '='
+      res <- mapM (timed . processThy) inFiles
+      let (thys, times) = unzip res
+      let (docs, reps) = unzip thys
+
+      if writeOutput then do
+        let outFiles = mkOutPath <$> inFiles
+        let repsWithInfo = ppRep <$> zip4 inFiles (Just <$> outFiles) times reps
+        let summary = Pretty.vcat $ intersperse (Pretty.text "") repsWithInfo
+
+        mapM_ (\(o, d) -> writeFileWithDirs o (renderDoc d)) (zip outFiles docs)
+        putStrLn $ renderDoc $ ppSummary summary
+      else do
+        let repsWithInfo = ppRep <$> zip4 inFiles (repeat Nothing) times reps
+        let summary = Pretty.vcat $ intersperse (Pretty.text "") repsWithInfo
+
+        mapM_ (putStrLn . renderDoc) docs
+        putStrLn $ renderDoc $ ppSummary summary
   where
+    ppSummary summary = Pretty.vcat [ Pretty.text $ ""
+                                    , Pretty.text $ replicate 78 '='
+                                    , Pretty.text $ "summary of summaries:"
+                                    , Pretty.text $ ""
+                                    , summary
+                                    , Pretty.text $ ""
+                                    , Pretty.text $ replicate 78 '=' ]
+    ppRep (inFile, outFile, time, summary)=
+      Pretty.vcat [ Pretty.text $ "analyzed: " ++ inFile
+                  , Pretty.text $ ""
+                  , Pretty.text $ ""
+                  , Pretty.nest 2 $ Pretty.vcat [
+                      maybe Pretty.emptyDoc (\o -> Pretty.text $ "output:          " ++ o) outFile
+                    , Pretty.text $ "processing time: " ++ show time
+                    , Pretty.text $ ""
+                    , summary ] ]
+
     -- handles to arguments
     -----------------------
     inFiles    = reverse $ findArg "inFile" as
 
-    thyLoadOptions = case (mkTheoryLoadOptions as) of
+    thyLoadOptions = case mkTheoryLoadOptions as of
       Left (ArgumentError e) -> error e
-      Right opts               -> opts
+      Right opts             -> opts
 
     -- output generation
     --------------------
-
-    dryRun = not (argExists "outFile" as || argExists "outDir" as)
+    writeOutput = argExists "outFile" as || argExists "outDir" as
 
     mkOutPath :: FilePath  -- ^ Input file name.
               -> FilePath  -- ^ Output file name.
@@ -129,100 +153,38 @@ run thisMode as
 
     -- theory processing functions
     ------------------------------
-    processThyNew :: FilePath -> IO Pretty.Doc
-    processThyNew inFile = either (die . show) return <=< runExceptT $ do
+    processThy :: FilePath -> IO (Pretty.Doc, Pretty.Doc)
+    processThy inFile = either (die . show) return <=< runExceptT $ do
       srcThy <- liftIO $ readFile inFile
-      res <- loadTheory thyLoadOptions srcThy inFile
-      either (return . prettyOpenTheory) (return . prettyOpenDiffTheory) res
+      thy    <- loadTheory thyLoadOptions srcThy inFile
 
-    processThy :: FilePath -> IO Pretty.Doc
-    processThy inFile
-      | argExists "parseOnly" as && argExists "diff" as =
-          out (const Pretty.emptyDoc) (return . prettyOpenDiffTheory)   (loadOpenDiffThy thyLoadOptions inFile)
-      | argExists "parseOnly" as || argExists "outModule" as =
-          out (const Pretty.emptyDoc) choosePretty                      (loadOpenThy thyLoadOptions inFile)
-      | argExists "diff" as =
-          out ppWfAndSummaryDiff      (return . prettyClosedDiffTheory) (loadClosedDiffThy thyLoadOptions inFile)
-      | otherwise = do
-          (thy, report) <- loadClosedThyWf thyLoadOptions inFile
-          out (ppWfAndSummary report) (return . prettyClosedTheory)     (return thy)
+      if isParseOnlyMode then do
+        either (\t -> bisequence (liftIO $ choosePretty t, return Pretty.emptyDoc))
+               (\d -> return (prettyOpenDiffTheory d, Pretty.emptyDoc)) thy
+      else do
+        let sig = either (get thySignature) (get diffThySignature) thy
+        sig'   <- liftIO $ toSignatureWithMaude (get oMaudePath thyLoadOptions) sig
+
+        (report, thy') <- closeTheory' thyLoadOptions sig' thy
+        either (\t -> return (prettyClosedTheory t,     ppWf report Pretty.$--$ prettyClosedSummary t))
+               (\d -> return (prettyClosedDiffTheory d, ppWf report Pretty.$--$ prettyClosedDiffSummary d)) thy'
       where
-        ppAnalyzed = Pretty.text $ "analyzed: " ++ inFile
-        ppWfAndSummary report thy = do
-            report
-            Pretty.$--$ prettyClosedSummary thy
+        isParseOnlyMode = get oParseOnlyMode thyLoadOptions
 
-        ppWfAndSummaryDiff thy = do
-            reportWellformednessDoc $ checkWellformednessDiff (openDiffTheory thy) (get diffThySignature thy)
-            Pretty.$--$ prettyClosedDiffSummary thy
+        -- FIXME: Does it make sense to print the warning even though not in prove mode?
+        ppWf []  = Pretty.emptyDoc
+        ppWf rep = Pretty.vcat [ Pretty.text $ "WARNING: " ++ show (length rep) ++ " wellformedness check failed!"
+                               , Pretty.text   "         The analysis results might be wrong!" ]
 
-        choosePretty = case (get oOutputModule thyLoadOptions) of
-          ModuleSpthy      -> return . prettyOpenTheory  <=< Sapic.warnings -- output as is, including SAPIC elements
-          ModuleSpthyTyped -> return . prettyOpenTheory <=< Sapic.typeTheory <=< Sapic.warnings  -- additionally type
-          ModuleMsr        -> return . prettyOpenTranslatedTheory
-            <=< (return . (filterLemma $ lemmaSelector thyLoadOptions))
+        choosePretty = case get oOutputModule thyLoadOptions of
+          Nothing               -> return . prettyOpenTheory  <=< Sapic.warnings -- output as is, including SAPIC elements
+          Just ModuleSpthy      -> return . prettyOpenTheory  <=< Sapic.warnings -- output as is, including SAPIC elements
+          Just ModuleSpthyTyped -> return . prettyOpenTheory <=< Sapic.typeTheory <=< Sapic.warnings  -- additionally type
+          Just ModuleMsr        -> return . prettyOpenTranslatedTheory
+            <=< (return . filterLemma (lemmaSelector thyLoadOptions))
             <=< (return . removeTranslationItems)
             <=< Sapic.typeTheory
             <=< Sapic.warnings
-          ModuleProVerif              -> Export.prettyProVerifTheory (lemmaSelector thyLoadOptions) <=< Sapic.typeTheoryEnv <=< Sapic.warnings
-          ModuleProVerifEquivalence   -> Export.prettyProVerifEquivTheory <=< Sapic.typeTheoryEnv <=< Sapic.warnings
-          ModuleDeepSec               -> Export.prettyDeepSecTheory <=< Sapic.typeTheory <=< Sapic.warnings
-
-        out :: (a -> Pretty.Doc) -> (a -> IO Pretty.Doc) -> IO a -> IO Pretty.Doc
-        out summaryDoc fullDoc load
-          | dryRun    = do
-              thy <- load
-              doc <- fullDoc thy
-              putStrLn $ renderDoc doc
-              return $ ppAnalyzed Pretty.$--$ Pretty.nest 2 (summaryDoc thy)
-          | otherwise = do
-              putStrLn $ ""
-              putStrLn $ "analyzing: " ++ inFile
-              putStrLn $ ""
-              let outFile = mkOutPath inFile
-              (thySummary, t) <- timed $ do
-                  thy <- load
-                  doc <- fullDoc thy
-                  writeFileWithDirs outFile $ renderDoc doc
-                  -- ensure that the summary is in normal form
-                  evaluate $ force $ summaryDoc thy
-              let summary = Pretty.vcat
-                    [ ppAnalyzed
-                    , Pretty.text $ ""
-                    , Pretty.text $ "  output:          " ++ outFile
-                    , Pretty.text $ "  processing time: " ++ show t
-                    , Pretty.text $ ""
-                    , Pretty.nest 2 thySummary
-                    ]
-              putStrLn $ replicate 78 '-'
-              putStrLn $ renderDoc summary
-              putStrLn $ ""
-              putStrLn $ replicate 78 '-'
-              return summary
-
-    {- TO BE REACTIVATED once infrastructure from interactive mode can be used
-
-    -- static html generation
-    -------------------------
-
-    generateHtml :: FilePath      -- ^ Input file
-                 -> ClosedTheory  -- ^ Theory to pretty print
-                 -> IO ()
-    generateHtml inFile thy = do
-      cmdLine  <- getCommandLine
-      time     <- getCurrentTime
-      cpu      <- getCpuModel
-      template <- getHtmlTemplate
-      theoryToHtml $ GenerationInput {
-          giHeader      = "Generated by " ++ htmlVersionStr
-        , giTime        = time
-        , giSystem      = cpu
-        , giInputFile   = inFile
-        , giTemplate    = template
-        , giOutDir      = mkOutPath inFile
-        , giTheory      = thy
-        , giCmdLine     = cmdLine
-        , giCompress    = not $ argExists "noCompress" as
-        }
-
-    -}
+          Just ModuleProVerif              -> Export.prettyProVerifTheory (lemmaSelector thyLoadOptions) <=< Sapic.typeTheoryEnv <=< Sapic.warnings
+          Just ModuleProVerifEquivalence   -> Export.prettyProVerifEquivTheory <=< Sapic.typeTheoryEnv <=< Sapic.warnings
+          Just ModuleDeepSec               -> Export.prettyDeepSecTheory <=< Sapic.typeTheory <=< Sapic.warnings

--- a/src/Main/Mode/Batch.hs
+++ b/src/Main/Mode/Batch.hs
@@ -22,7 +22,7 @@ import           Extension.Data.Label
 
 import qualified Text.PrettyPrint.Class          as Pretty
 
-import           Theory
+import           Theory hiding (closeTheory)
 
 import qualified Sapic
 import qualified Export
@@ -165,7 +165,7 @@ run thisMode as
         let sig = either (get thySignature) (get diffThySignature) thy
         sig'   <- liftIO $ toSignatureWithMaude (get oMaudePath thyLoadOptions) sig
 
-        (report, thy') <- closeTheory' thyLoadOptions sig' thy
+        (report, thy') <- closeTheory thyLoadOptions sig' thy
         either (\t -> return (prettyClosedTheory t,     ppWf report Pretty.$--$ prettyClosedSummary t))
                (\d -> return (prettyClosedDiffTheory d, ppWf report Pretty.$--$ prettyClosedDiffSummary d)) thy'
       where

--- a/src/Main/Mode/Batch.hs
+++ b/src/Main/Mode/Batch.hs
@@ -183,10 +183,9 @@ run thisMode as
                                              , Pretty.text "" ]
           die "quit-on-warning mode selected - aborting on wellformedness errors."
 
-        -- FIXME: Does it make sense to print the warning even though not in prove mode?
         ppWf []  = Pretty.emptyDoc
-        ppWf rep = Pretty.vcat [ Pretty.text $ "WARNING: " ++ show (length rep) ++ " wellformedness check failed!"
-                               , Pretty.text   "         The analysis results might be wrong!" ]
+        ppWf rep = Pretty.vcat $ Pretty.text ("WARNING: " ++ show (length rep) ++ " wellformedness check failed!")
+                             : [ Pretty.text   "         The analysis results might be wrong!" | get oProveMode thyLoadOptions ]
 
         choosePretty = case get oOutputModule thyLoadOptions of
           Nothing               -> return . prettyOpenTheory  <=< Sapic.warnings -- output as is, including SAPIC elements

--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -30,6 +30,7 @@ import qualified Web.Settings
 import           Main.Console
 import           Main.Environment
 import           Main.TheoryLoader
+import qualified Data.Label as L
 
 
 -- | Batch processing mode.
@@ -93,18 +94,18 @@ run thisMode as = case findArg "workDir" as of
             , ""
             , "Loading the security protocol theories '" ++ workDir </> "*.spthy"  ++ "' ..."
             ]
-          if (argExists "diff" as)
+          if (L.get oDiffMode thyLoadOptions)
             then do 
               withWebUIDiff
                 ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
                 cacheDir
                 workDir (argExists "loadstate" as) (argExists "autosave" as)
 
-                (loadClosedDiffThyWfReport as) (loadClosedDiffThyString as)
-                (reportOnClosedDiffThyStringWellformedness as)
+                (loadClosedDiffThyWfReport thyLoadOptions) (loadClosedDiffThyString thyLoadOptions)
+                (reportOnClosedDiffThyStringWellformedness thyLoadOptions)
 
                 (argExists "debug" as) (dotPath as) readImageFormat
-                (constructAutoProver as)
+                (constructAutoProver thyLoadOptions)
                 (runWarp port)
             else do 
               withWebUI
@@ -112,16 +113,19 @@ run thisMode as = case findArg "workDir" as of
                 cacheDir
                 workDir (argExists "loadstate" as) (argExists "autosave" as)
 
-                (loadClosedThyWfReport as) (loadClosedThyString as)
-                (reportOnClosedThyStringWellformedness as)
+                (loadClosedThyWfReport thyLoadOptions) (loadClosedThyString thyLoadOptions)
+                (reportOnClosedThyStringWellformedness thyLoadOptions)
 
                 (argExists "debug" as) (graphPath as) readImageFormat
-                (constructAutoProver as)
+                (constructAutoProver thyLoadOptions)
                 (runWarp port)
         else
           helpAndExit thisMode
             (Just $ "directory '" ++ workDir ++ "' does not exist.")
   where
+    thyLoadOptions = case (mkTheoryLoadOptions as) of
+      Left (ArgumentError e) -> error e
+      Right opts             -> opts
 
     -- Port argument
     ----------------

--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -30,7 +30,6 @@ import qualified Web.Settings
 import           Main.Console
 import           Main.Environment
 import           Main.TheoryLoader
-import qualified Data.Label as L
 
 
 -- | Batch processing mode.
@@ -93,32 +92,21 @@ run thisMode as = case findArg "workDir" as of
             , "Browse to " ++ webUrl ++ " once the server is ready."
             , ""
             , "Loading the security protocol theories '" ++ workDir </> "*.spthy"  ++ "' ..."
+            , ""
             ]
-          if (L.get oDiffMode thyLoadOptions)
-            then do 
-              withWebUIDiff
-                ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
-                cacheDir
-                workDir (argExists "loadstate" as) (argExists "autosave" as)
+          withWebUI
+            ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
+            cacheDir
+            workDir (argExists "loadstate" as) (argExists "autosave" as)
 
-                (loadClosedDiffThyWfReport thyLoadOptions) (loadClosedDiffThyString thyLoadOptions)
-                (reportOnClosedDiffThyStringWellformedness thyLoadOptions)
+            thyLoadOptions
 
-                (argExists "debug" as) (dotPath as) readImageFormat
-                (constructAutoProver thyLoadOptions)
-                (runWarp port)
-            else do 
-              withWebUI
-                ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
-                cacheDir
-                workDir (argExists "loadstate" as) (argExists "autosave" as)
+            (loadTheory thyLoadOptions)
+            (closeTheory' thyLoadOptions)
 
-                (loadClosedThyWfReport thyLoadOptions) (loadClosedThyString thyLoadOptions)
-                (reportOnClosedThyStringWellformedness thyLoadOptions)
-
-                (argExists "debug" as) (graphPath as) readImageFormat
-                (constructAutoProver thyLoadOptions)
-                (runWarp port)
+            (argExists "debug" as) (graphPath as) readImageFormat
+            (constructAutoProver thyLoadOptions)
+            (runWarp port)
         else
           helpAndExit thisMode
             (Just $ "directory '" ++ workDir ++ "' does not exist.")

--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -102,7 +102,7 @@ run thisMode as = case findArg "workDir" as of
             thyLoadOptions
 
             (loadTheory thyLoadOptions)
-            (closeTheory' thyLoadOptions)
+            (closeTheory thyLoadOptions)
 
             (argExists "debug" as) (graphPath as) readImageFormat
             (constructAutoProver thyLoadOptions)

--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -99,18 +99,22 @@ run thisMode as = case findArg "workDir" as of
                 ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
                 cacheDir
                 workDir (argExists "loadstate" as) (argExists "autosave" as)
+
                 (loadClosedDiffThyWfReport as) (loadClosedDiffThyString as)
                 (reportOnClosedDiffThyStringWellformedness as)
+
                 (argExists "debug" as) (dotPath as) readImageFormat
-                (constructAutoDiffProver as)
+                (constructAutoProver as)
                 (runWarp port)
             else do 
               withWebUI
                 ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
                 cacheDir
                 workDir (argExists "loadstate" as) (argExists "autosave" as)
+
                 (loadClosedThyWfReport as) (loadClosedThyString as)
                 (reportOnClosedThyStringWellformedness as)
+
                 (argExists "debug" as) (graphPath as) readImageFormat
                 (constructAutoProver as)
                 (runWarp port)

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -59,7 +59,7 @@ module Main.TheoryLoader (
   , lemmaSelector
   ) where
 
-import           Debug.Trace
+-- import           Debug.Trace
 
 import           Prelude                             hiding (id, (.))
 
@@ -73,7 +73,7 @@ import           Control.Category
 
 import           System.Console.CmdArgs.Explicit
 
-import           Theory
+import           Theory hiding (transReport)
 import           Theory.Text.Parser                  (parseIntruderRules, parseOpenTheory, parseOpenTheoryString, parseOpenDiffTheory, parseOpenDiffTheoryString, theory, diffTheory)
 import           Theory.Tools.AbstractInterpretation (EvaluationStyle(..))
 import           Theory.Tools.IntruderRules          (specialIntruderRules, subtermIntruderRules

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -24,6 +24,7 @@ module Main.TheoryLoader (
   , ArgumentError(..)
   , mkTheoryLoadOptions
 
+  , TheoryLoadError(..)
   , loadTheory
   , closeTheory'
 
@@ -31,10 +32,8 @@ module Main.TheoryLoader (
   , loadOpenThy
 
   -- ** Loading and closing theories
-  , closeThy
   , loadClosedThyWf
   , loadClosedThyWfReport
-  , loadClosedThyString
   , reportOnClosedThyStringWellformedness
   , reportWellformednessDoc
 
@@ -449,15 +448,15 @@ loadClosedDiffThyWfReport thyOpts inFile = do
     -- return closed theory
     return $ closeDiffThyWithMaude sig thyOpts thy1
 
-loadClosedThyString :: TheoryLoadOptions -> String -> IO (Either String ClosedTheory)
-loadClosedThyString thyOpts input =
-    case parseOpenTheoryString (toParserFlags thyOpts) input of
-        Left err  -> return $ Left $ "parse error: " ++ show err
-        Right thy -> do
-            thy' <-  Sapic.typeTheory thy
-                  >>= Sapic.translate
-                  >>= Acc.translate
-            Right <$> closeThy thyOpts thy (removeTranslationItems thy') -- No "return" because closeThy gives IO (ClosedTheory)
+-- loadClosedThyString :: TheoryLoadOptions -> String -> IO (Either String ClosedTheory)
+-- loadClosedThyString thyOpts input =
+--     case parseOpenTheoryString (toParserFlags thyOpts) input of
+--         Left err  -> return $ Left $ "parse error: " ++ show err
+--         Right thy -> do
+--             thy' <-  Sapic.typeTheory thy
+--                   >>= Sapic.translate
+--                   >>= Acc.translate
+--             Right <$> closeThy thyOpts thy (removeTranslationItems thy') -- No "return" because closeThy gives IO (ClosedTheory)
 
 
 loadClosedDiffThyString :: TheoryLoadOptions -> String -> IO (Either String ClosedDiffTheory)
@@ -512,11 +511,11 @@ reportOnClosedDiffThyStringWellformedness thyOpts input = do
             return $ " WARNING: ignoring the following wellformedness errors: " ++(renderDoc $ prettyWfErrorReport report)
 
 -- | Close a theory according to arguments.
-closeThy :: TheoryLoadOptions -> OpenTheory -> OpenTranslatedTheory -> IO ClosedTheory
-closeThy thyOpts openThy transThy = do
-  transThy' <- return $ addMessageDeductionRuleVariants transThy
-  sig <- toSignatureWithMaude (L.get oMaudePath thyOpts) $ get thySignature transThy'
-  return $ closeThyWithMaude sig thyOpts openThy transThy'
+-- closeThy :: TheoryLoadOptions -> OpenTheory -> OpenTranslatedTheory -> IO ClosedTheory
+-- closeThy thyOpts openThy transThy = do
+--   transThy' <- return $ addMessageDeductionRuleVariants transThy
+--   sig <- toSignatureWithMaude (L.get oMaudePath thyOpts) $ get thySignature transThy'
+--   return $ closeThyWithMaude sig thyOpts openThy transThy'
 
 -- | Close a theory according to arguments.
 closeThyWithMaude :: SignatureWithMaude -> TheoryLoadOptions -> OpenTheory -> OpenTranslatedTheory -> ClosedTheory

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -17,12 +17,9 @@ module Main.TheoryLoader (
 
   -- ** Loading open theories
   , loadOpenThy
-  , loadOpenTranslatedThy
-  , loadOpenAndTranslatedThy
 
   -- ** Loading and closing theories
   , closeThy
-  , loadClosedThy
   , loadClosedThyWf
   , loadClosedThyWfReport
   , loadClosedThyString
@@ -177,14 +174,6 @@ lemmaSelector as lem
 loadOpenThy :: Arguments -> FilePath -> IO OpenTheory
 loadOpenThy as inFile = parseOpenTheory (diff as ++ defines as ++ quitOnWarning as) inFile
 
--- | Load an open theory from a file. Returns the open translated theory.
-loadOpenTranslatedThy :: Arguments -> FilePath -> IO OpenTranslatedTheory
-loadOpenTranslatedThy as inFile =  do
-    thy <- loadOpenThy as inFile
-    thy' <- Sapic.translate thy
-    thy'' <- Acc.translate thy'
-    return (removeTranslationItems thy'')
-
 -- | Load an open theory from a file. Returns the open and the translated theory.
 loadOpenAndTranslatedThy :: Arguments -> FilePath -> IO (OpenTheory, OpenTranslatedTheory)
 loadOpenAndTranslatedThy as inFile =  do
@@ -194,12 +183,6 @@ loadOpenAndTranslatedThy as inFile =  do
       >>= Sapic.translate
       >>= Acc.translate
     return (thy, removeTranslationItems transThy)
-
--- | Load a closed theory from a file.
-loadClosedThy :: Arguments -> FilePath -> IO ClosedTheory
-loadClosedThy as inFile = do
-  (openThy, transThy) <- loadOpenAndTranslatedThy as inFile
-  closeThy as openThy transThy
 
 -- | Load an open diff theory from a file.
 loadOpenDiffThy :: Arguments -> FilePath -> IO OpenDiffTheory

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -18,6 +18,7 @@ module Main.TheoryLoader (
   , lemmaSelector
 
   , TheoryLoadOptions(..)
+  , oProveMode
   , oDiffMode
   , oOutputModule
   , oMaudePath

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright   : (c) 2010, 2011 Benedikt Schmidt & Simon Meier
@@ -78,6 +79,7 @@ import           Data.Bitraversable (Bitraversable(bitraverse))
 import           Control.Monad.Catch (MonadCatch)
 import qualified Accountability as Acc
 import qualified Accountability.Generation as Acc
+import GHC.Records (HasField(getField))
 
 ------------------------------------------------------------------------------
 -- Theory loading: shared between interactive and batch mode
@@ -234,7 +236,7 @@ lemmaSelectorByModule thyOpt lem = case lemmaModules of
       Just outMod -> outMod `elem` lemmaModules
       Nothing     -> ModuleSpthy `elem` lemmaModules
     where
-        lemmaModules = concat [ m | LemmaModule m <- lem.lAttributes]
+        lemmaModules = concat [ m | LemmaModule m <- getField @"lAttributes" lem]
 
 -- | Select lemmas for proving
 lemmaSelector :: HasLemmaName l => TheoryLoadOptions -> l -> Bool
@@ -249,8 +251,8 @@ lemmaSelector thyOpts lem
 
       lemmaMatches :: String -> Bool
       lemmaMatches pattern
-        | lastMay pattern == Just '*' = init pattern `isPrefixOf` lem.lName
-        | otherwise = lem.lName == pattern
+        | lastMay pattern == Just '*' = init pattern `isPrefixOf` getField @"lName" lem
+        | otherwise = getField @"lName" lem == pattern
 
 data TheoryLoadError =
     ParserError ParseError

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -53,7 +53,7 @@ import           Control.Category
 
 import           System.Console.CmdArgs.Explicit
 
-import           Theory hiding (closeTheory)
+import           Theory hiding (transReport, closeTheory)
 import           Theory.Text.Parser                  (parseIntruderRules, theory, diffTheory)
 import           Theory.Tools.AbstractInterpretation (EvaluationStyle(..))
 import           Theory.Tools.IntruderRules          (specialIntruderRules, subtermIntruderRules
@@ -159,9 +159,9 @@ defaultTheoryLoadOptions = TheoryLoadOptions {
 
 toParserFlags :: TheoryLoadOptions -> [String]
 toParserFlags thyOpts = concat
-  [ [ "diff" |  _oDiffMode thyOpts ]
-  , _oDefines thyOpts
-  , [ "quit-on-warning" | _oQuitOnWarning thyOpts ] ]
+  [ [ "diff" |  L.get oDiffMode thyOpts ]
+  , L.get oDefines thyOpts
+  , [ "quit-on-warning" | L.get oQuitOnWarning thyOpts ] ]
 
 data ArgumentError = ArgumentError String
 
@@ -224,7 +224,7 @@ mkTheoryLoadOptions as = TheoryLoadOptions
      , Just modCon <- find (\x -> show x  == str) (enumFrom minBound) = return $ Just modCon
      | otherwise   = throwError $ ArgumentError "output mode not supported."
 
-    -- Note: Output mode implicitly activates parse-only mode
+    -- NOTE: Output mode implicitly activates parse-only mode
     parseOnlyMode = return $ argExists "parseOnly" as || argExists "outputMode" as
 
 lemmaSelectorByModule :: HasLemmaAttributes l => TheoryLoadOptions -> l -> Bool
@@ -258,8 +258,8 @@ data TheoryLoadError =
 
 instance Show TheoryLoadError
   where
-    show (ParserError e) = "ParserError " ++ show e
-    show (WarningError e) = "WarningError " ++ Pretty.render (prettyWfErrorReport e)
+    show (ParserError e) = show e
+    show (WarningError e) = Pretty.render (prettyWfErrorReport e)
 
 -- FIXME: How can we avoid the MonadCatch here?
 loadTheory :: MonadCatch m => TheoryLoadOptions -> String -> FilePath -> ExceptT TheoryLoadError m (Either OpenTheory OpenDiffTheory)

--- a/src/Test/ParserTests.hs
+++ b/src/Test/ParserTests.hs
@@ -59,7 +59,7 @@ testParseFile optionalProver inpFile = TestLabel inpFile $ TestCase $ do
     parse msg str = case parseOpenTheoryString [] str  of
         Left err  -> do _ <- assertFailure $ withLineNumbers $ indent $ show err
                         return (error "testParseFile: dead code")
-        Right thy -> normalizeTheory <$> openTranslatedTheory <$> addMessageDeductionRuleVariants (removeTranslationItems thy)
+        Right thy -> normalizeTheory <$> openTranslatedTheory <$> (return $ addMessageDeductionRuleVariants (removeTranslationItems thy))
       where
         withLineNumbers err =
             unlines $ zipWith (\i l -> nr (show i) ++ l) [(1::Int)..] ls

--- a/src/Web/Dispatch.hs
+++ b/src/Web/Dispatch.hs
@@ -23,7 +23,6 @@ Portability :  non-portable
 
 module Web.Dispatch
   ( withWebUI
-  , withWebUIDiff
   , ImageFormat(..)
   )
 where
@@ -52,6 +51,12 @@ import           Data.Time.LocalTime
 
 import           System.Directory
 import           System.FilePath
+import Control.Monad.Except (ExceptT, runExceptT)
+import Main.TheoryLoader (TheoryLoadError (ParserError, WarningError), TheoryLoadOptions, oMaudePath)
+import Theory.Tools.Wellformedness
+import qualified Data.Label as L
+import Main.Console (renderDoc)
+import qualified Text.PrettyPrint.Class          as Pretty
 -- import           System.Process
 
 -- | Create YesodDispatch instance for the interface.
@@ -81,11 +86,11 @@ withWebUI :: String                          -- ^ Message to output once the sev
           -> FilePath                        -- ^ Working directory.
           -> Bool                            -- ^ Load last proof state if present
           -> Bool                            -- ^ Automatically save proof state
-          -> (FilePath -> IO ClosedTheory)   -- ^ Theory loader (from file).
-          -> (String -> IO (Either String ClosedTheory))
+          -> TheoryLoadOptions               -- ^ Options for loading theories
+          -> (String -> FilePath -> ExceptT TheoryLoadError IO (Either OpenTheory OpenDiffTheory))  
           -- ^ Theory loader (from string).
-          -> (String -> IO String)           -- ^ Report on wellformedness.
-          -- -> (OpenTheory -> IO ClosedTheory) -- ^ Theory closer.
+          -> (SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> ExceptT TheoryLoadError IO (WfErrorReport, Either ClosedTheory ClosedDiffTheory))
+          -- ^ Theory closer.
           -> Bool                            -- ^ Show debugging messages?
           -> (String, FilePath)              -- ^ Path to graph rendering binary (dot or json)
                                              -- ^ together with indication of choice "dot", "json", ...
@@ -93,7 +98,7 @@ withWebUI :: String                          -- ^ Message to output once the sev
           -> AutoProver                      -- ^ The default autoprover.
           -> (Application -> IO b)           -- ^ Function to execute
           -> IO b
-withWebUI readyMsg cacheDir_ thDir loadState autosave thLoader thParser thWellformed debug'
+withWebUI readyMsg cacheDir_ thDir loadState autosave thOpts thLoad thClose debug'
           graphCmd' imgFormat' defaultAutoProver' f
   = do
     thy    <- getTheos
@@ -108,9 +113,9 @@ withWebUI readyMsg cacheDir_ thDir loadState autosave thLoader thParser thWellfo
       f =<< toWaiApp WebUI
         { workDir            = thDir
         , cacheDir           = cacheDir_
-        , diffParseThy       = error "not in diff mode!"
-        , parseThy           = liftIO . thParser
-        , thyWf              = liftIO . thWellformed
+        , thyOpts            = thOpts
+        , loadThy            = thLoad
+        , closeThy           = thClose
         , getStatic          = staticFiles
         , theoryVar          = thyVar
         , threadVar          = thrVar
@@ -119,7 +124,6 @@ withWebUI readyMsg cacheDir_ thDir loadState autosave thLoader thParser thWellfo
         , imageFormat        = imgFormat'
         , defaultAutoProver  = defaultAutoProver'
         , debug              = debug'
-        , isDiffTheory       = False
         }
   where
     autosaveDir = thDir++"/"++autosaveSubdir
@@ -137,77 +141,7 @@ withWebUI readyMsg cacheDir_ thDir loadState autosave thLoader thParser thWellfo
                      _            -> return Nothing
          return $ M.fromList $ catMaybes thys
 
-       else loadTheories readyMsg thDir thLoader defaultAutoProver' 
-
-    shutdownThreads thrVar = do
-      m <- modifyMVar thrVar $ \m -> return (M.empty, m)
-      putStrLn $ "Server shutdown: " ++ show (M.size m) ++ " threads still running"
-      forM (M.toList m) $ \(str, tid) -> do
-         putStrLn $ "killing: " ++ T.unpack str
-         killThread tid
-
--- | Initialization function for the web application.
-withWebUIDiff :: String                      -- ^ Message to output once the sever is ready.
-          -> FilePath                        -- ^ Cache directory.
-          -> FilePath                        -- ^ Working directory.
-          -> Bool                            -- ^ Load last proof state if present
-          -> Bool                            -- ^ Automatically save proof state
-          -> (FilePath -> IO ClosedDiffTheory)   -- ^ Theory loader (from file).
-          -> (String -> IO (Either String ClosedDiffTheory))
-          -- ^ Theory loader (from string).
-          -> (String -> IO String)           -- ^ Report on wellformedness.
-          -- -> (OpenTheory -> IO ClosedTheory) -- ^ Theory closer.
-          -> Bool                            -- ^ Show debugging messages?
-          -> FilePath                        -- ^ Path to dot binary
-          -> ImageFormat                     -- ^ The preferred image format
-          -> AutoProver                      -- ^ The default autoprover.
-          -> (Application -> IO b)           -- ^ Function to execute
-          -> IO b
-withWebUIDiff readyMsg cacheDir_ thDir loadState autosave thLoader thParser thWellformed debug'
-          dotCmd' imgFormat' defaultAutoProver' f
-  = do
-    thy    <- getTheos
-    thrVar <- newMVar M.empty
-    thyVar <- newMVar thy
-    -- NOTE (SM): uncomment this line to load the assets dynamically.
-    -- staticFiles     <- Yesod.Static.static "data"
-    when autosave $ createDirectoryIfMissing False autosaveDir
-    -- Don't create parent dirs, as temp-dir should be created by OS.
-    createDirectoryIfMissing False cacheDir_
-    (`E.finally` shutdownThreads thrVar) $
-      f =<< toWaiApp WebUI
-        { workDir            = thDir
-        , cacheDir           = cacheDir_
-        , parseThy           = error "in diff mode!"
-        , diffParseThy       = liftIO . thParser
-        , thyWf              = liftIO . thWellformed
-        , getStatic          = staticFiles
-        , theoryVar          = thyVar
-        , threadVar          = thrVar
-        , autosaveProofstate = autosave
-        , graphCmd           = ("dot",dotCmd')
-        , imageFormat        = imgFormat'
-        , defaultAutoProver  = defaultAutoProver'
-        , debug              = debug'
-        , isDiffTheory       = True
-        }
-  where
-    autosaveDir = thDir++"/"++autosaveSubdir
-    getTheos = do
-      existsAutosave <- doesDirectoryExist autosaveDir
-      if loadState && existsAutosave
-       then do
-         putStrLn "Using persistent server state ... server ready."
-         files <- getDirectoryContents autosaveDir
-         thys <- (`mapM` files) $ \fn ->
-                   case break (`notElem` ['0'..'9']) fn of
-                     (idx,".img") -> do
-                       let file = thDir++"/"++autosaveSubdir++fn
-                       Just . (read idx,) <$> Bin.decodeFile file
-                     _            -> return Nothing
-         return $ M.fromList $ catMaybes thys
-
-       else loadDiffTheories readyMsg thDir thLoader defaultAutoProver'
+       else loadTheories thOpts readyMsg thDir thLoad thClose defaultAutoProver' 
 
     shutdownThreads thrVar = do
       m <- modifyMVar thrVar $ \m -> return (M.empty, m)
@@ -217,12 +151,14 @@ withWebUIDiff readyMsg cacheDir_ thDir loadState autosave thLoader thParser thWe
          killThread tid
 
 -- | Load theories from the current directory, generate map.
-loadTheories :: String
+loadTheories :: TheoryLoadOptions
+             -> String
              -> FilePath
-             -> (FilePath -> IO ClosedTheory)
+             -> (String -> FilePath -> ExceptT TheoryLoadError IO (Either OpenTheory OpenDiffTheory))
+             -> (SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> ExceptT TheoryLoadError IO (WfErrorReport, Either ClosedTheory ClosedDiffTheory))
              -> AutoProver
              -> IO TheoryMap
-loadTheories readyMsg thDir thLoader autoProver = do
+loadTheories thOpts readyMsg thDir thLoad thClose autoProver = do
     thPaths <- filter (\n -> (".spthy" `isSuffixOf` n) || (".sapic" `isSuffixOf` n)) <$> getDirectoryContents thDir
     theories <- catMaybes <$> mapM loadThy (zip [1..] (map (thDir </>) thPaths))
     putStrLn readyMsg
@@ -230,22 +166,48 @@ loadTheories readyMsg thDir thLoader autoProver = do
   where
     -- Load theories
     loadThy (idx, path) = E.handle catchEx $ do
-        thy <- thLoader path
-        time <- getZonedTime
-        return $ Just
-          ( idx
-          , Trace $ TheoryInfo idx thy time Nothing True (Local path) autoProver
-          )
+      srcThy <- liftIO $ readFile path
+
+      result <- liftIO $ runExceptT $ do
+        openThy <- thLoad srcThy path
+        let sig = either (L.get thySignature) (L.get diffThySignature) openThy
+        sig'   <- liftIO $ toSignatureWithMaude (L.get oMaudePath thOpts) sig
+        thClose sig' openThy
+
+      case result of
+        Left (ParserError e) -> 
+          error (show e)
+        Left (WarningError report) -> do
+          putStrLn $ renderDoc $ ppInteractive report path
+          error "quit-on-warning mode selected - aborting on wellformedness errors."
+        Right (report, thy) -> do
+          time <- getZonedTime
+          putStrLn $ renderDoc $ ppInteractive report path
+          return $ Just
+             ( idx
+             , either (\t -> Trace $ TheoryInfo idx t time Nothing True (Local path) autoProver)
+                      (\t -> Diff $ DiffTheoryInfo idx t time Nothing True (Local path) autoProver) thy
+             )
       where
         -- Exception handler (if loading theory fails)
         catchEx :: E.SomeException -> IO (Maybe (TheoryIdx, EitherTheoryInfo))
         catchEx e = do
-          putStrLn ""
           putStrLn $ replicate 78 '-'
           putStrLn $ "Unable to load theory file `" ++ path ++ "'"
           putStrLn $ replicate 78 '-'
           print e
           return Nothing
+
+        ppInteractive report inFile = Pretty.vcat [ Pretty.text $ replicate 78 '-'
+                                                  , Pretty.text $ "Theory file '" ++ inFile ++ "'"
+                                                  , Pretty.text $ replicate 78 '-'
+                                                  , Pretty.text $ ""
+                                                  , Pretty.text $ "WARNING: ignoring the following wellformedness errors"
+                                                  , Pretty.text $ ""
+                                                  , prettyWfErrorReport report
+                                                  , Pretty.text $ replicate 78 '-'
+                                                  , Pretty.text $ "" ]
+
 
 -- | Load theories from the current directory, generate map.
 loadDiffTheories :: String

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -67,7 +67,7 @@ import           Theory                       (
     sorryDiffProver, runAutoDiffProver,
     prettyClosedTheory, prettyOpenTheory,
     openDiffTheory,
-    prettyClosedDiffTheory, prettyOpenDiffTheory, getLemmas, lName, lDiffName, getDiffLemmas, getEitherLemmas
+    prettyClosedDiffTheory, prettyOpenDiffTheory, getLemmas, lName, lDiffName, getDiffLemmas, getEitherLemmas, thySignature, diffThySignature, toSignatureWithMaude
   )
 import           Theory.Proof (AutoProver(..), SolutionExtractor(..), Prover, DiffProver)
 import           Text.PrettyPrint.Html
@@ -112,6 +112,10 @@ import           Data.Time.LocalTime
 import           System.Directory
 
 import           Debug.Trace                  (trace)
+import Control.Monad.Except (runExceptT)
+import Main.TheoryLoader
+import Main.Console (renderDoc)
+import Theory.Tools.Wellformedness (prettyWfErrorReport)
 
 -- Quasi-quotation syntax changed from GHC 6 to 7,
 -- so we need this switch in order to support both
@@ -486,27 +490,25 @@ postRootR = do
           content <- liftIO $ runResourceT $ C.runConduit (fileSource fileinfo C..| consume)
           if null content
             then setMessage "No theory file given."
-            else do
-              yesod <- getYesod
-              if isDiffTheory yesod
-                 then do
-                    closedThy <- liftIO $ diffParseThy yesod (T.unpack $ T.decodeUtf8 $ BS.concat content)
-                    case closedThy of
-                      Left err -> setMessage $ "Theory loading failed:\n" <> toHtml err
-                      Right thy -> do
-                          void $ putDiffTheory Nothing
-                                  (Just $ Upload $ T.unpack $ fileName fileinfo) thy
-                          wfReport <- liftIO $ thyWf yesod (T.unpack $ T.decodeUtf8 $ BS.concat content)
-                          setMessage $ toHtml $ "Loaded new theory!" ++  wfReport
-                 else do
-                    closedThy <- liftIO $ parseThy yesod (T.unpack $ T.decodeUtf8 $ BS.concat content)
-                    case closedThy of
-                      Left err -> setMessage $ "Theory loading failed:\n" <> toHtml err
-                      Right thy -> do
-                          void $ putTheory Nothing
-                                  (Just $ Upload $ T.unpack $ fileName fileinfo) thy
-                          wfReport <- liftIO $ thyWf yesod (T.unpack $ T.decodeUtf8 $ BS.concat content)
-                          setMessage $ toHtml $ "Loaded new theory!" ++ wfReport
+          else do
+            yesod <- getYesod
+            result <- liftIO $ runExceptT $ do
+              openThy <- loadThy yesod (T.unpack $ T.decodeUtf8 $ BS.concat content) (T.unpack $ fileName fileinfo)
+
+              let sig = either (get thySignature) (get diffThySignature) openThy
+              sig'   <- liftIO $ toSignatureWithMaude (get oMaudePath (thyOpts yesod)) sig
+
+              closeThy yesod sig' openThy
+
+            case result of
+              Left err -> setMessage $ "Theory loading failed:\n" <> toHtml (show err)
+              Right (report, thy) -> do
+                void $ either (putTheory Nothing (Just $ Upload $ T.unpack $ fileName fileinfo))
+                              (putDiffTheory Nothing (Just $ Upload $ T.unpack $ fileName fileinfo)) thy
+                setMessage $ toHtml $ "Loaded new theory!" ++
+                                      " WARNING: ignoring the following wellformedness errors: " ++
+                                      renderDoc (prettyWfErrorReport report)
+
     theories <- getTheories
     defaultLayout $ do
       setTitle "Welcome to the Tamarin prover"

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -492,7 +492,7 @@ postRootR = do
             then setMessage "No theory file given."
           else do
             yesod <- getYesod
-            result <- liftIO $ runExceptT $ do
+            thyWithRep <- liftIO $ runExceptT $ do
               openThy <- loadThy yesod (T.unpack $ T.decodeUtf8 $ BS.concat content) (T.unpack $ fileName fileinfo)
 
               let sig = either (get thySignature) (get diffThySignature) openThy
@@ -500,7 +500,7 @@ postRootR = do
 
               closeThy yesod sig' openThy
 
-            case result of
+            case thyWithRep of
               Left err -> setMessage $ "Theory loading failed:\n" <> toHtml (show err)
               Right (report, thy) -> do
                 void $ either (putTheory Nothing (Just $ Upload $ T.unpack $ fileName fileinfo))

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -40,7 +40,6 @@ module Web.Theory
   )
 where
 
-import qualified Accountability               as Acc
 
 import           Debug.Trace                  (trace)
 

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -40,7 +40,7 @@ module Web.Theory
   )
 where
 
-import           Accountability.Generation    (checkPreTransWellformedness)
+import qualified Accountability               as Acc
 
 import           Debug.Trace                  (trace)
 
@@ -84,6 +84,7 @@ import           Theory.Tools.Wellformedness
 
 import           Web.Settings
 import           Web.Types
+import qualified Accountability.Generation as Acc
 
 
 ------------------------------------------------------------------------------
@@ -1056,7 +1057,7 @@ htmlThyPath renderUrl info path =
                              [] -> ""
                              _  -> "<div class=\"wf-warning\">\nWARNING: the following wellformedness checks failed!<br /><br />\n" ++ (renderHtmlDoc . htmlDoc $ prettyWfErrorReport report) ++ "\n</div>"
              report = checkWellformedness (removeTranslationItems (openTheory thy)) (get thySignature thy)
-                   ++ checkPreTransWellformedness (openTheory thy) -- FIXME: openTheory doesn't contain translated items, hence no warning is shown in the interactive mode
+                   ++ Acc.checkWellformedness (openTheory thy) -- FIXME: openTheory doesn't contain translated items, hence no warning is shown in the interactive mode
 
 -- | Render the item in the given theory given by the supplied path.
 htmlDiffThyPath :: RenderUrl    -- ^ The function for rendering Urls.

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -76,6 +76,9 @@ import           Yesod.Core
 import           Yesod.Static
 
 import           Theory
+import Control.Monad.Except (ExceptT)
+import Main.TheoryLoader
+import Theory.Tools.Wellformedness (WfErrorReport)
 
 
 ------------------------------------------------------------------------------
@@ -121,13 +124,12 @@ data WebUI = WebUI
     -- ^ The caching directory (for storing rendered graphs).
   , workDir            :: FilePath
     -- ^ The working directory (for storing/loading theories).
-  -- , parseThy    :: MonadIO m => String -> GenericHandler m ClosedTheory
-  , parseThy           :: String -> IO (Either String (ClosedTheory))
+  , thyOpts            :: TheoryLoadOptions
+    -- ^ Options for loading theories
+  , loadThy            :: String -> FilePath -> ExceptT TheoryLoadError IO (Either OpenTheory OpenDiffTheory)
+    -- ^ Load a theory according to command-line arguments.
+  , closeThy           :: SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> ExceptT TheoryLoadError IO (WfErrorReport, Either ClosedTheory ClosedDiffTheory)
     -- ^ Close an open theory according to command-line arguments.
-  , diffParseThy       :: String -> IO (Either String (ClosedDiffTheory))
-    -- ^ Close an open theory according to command-line arguments.
-  , thyWf              :: String -> IO String
-    -- ^ Report on the wellformedness of a theory according to command-line arguments.
   , theoryVar          :: MVar (TheoryMap)
     -- ^ MVar that holds the theory map
   , threadVar          :: MVar ThreadMap
@@ -141,8 +143,6 @@ data WebUI = WebUI
   , defaultAutoProver  :: AutoProver
     -- ^ The default prover to use for automatic proving.
   , debug              :: Bool
-    -- ^ Output debug messages
-  , isDiffTheory       :: Bool
     -- ^ Output debug messages
   }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
 - lib/sapic/
 - lib/export/
 - lib/accountability/
-resolver: nightly-2022-06-01
+resolver: lts-19.16
 ghc-options:
   "$everything": -Wall
 nix:

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,8 @@ packages:
 - lib/sapic/
 - lib/export/
 - lib/accountability/
-resolver: lts-19.2
+resolver: nightly-2022-06-01
+ghc-options:
+  "$everything": -Wall
 nix:
   packages: [ zlib ]

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -136,6 +136,7 @@ executable tamarin-prover
       , containers
       , deepseq
       , directory
+      , exceptions
       , fclabels
       , file-embed
       , filepath


### PR DESCRIPTION
This PR refactors (besides other fixes)

- `src/Main/TheoryLoader.hs` 
- `src/Main/Mode/Batch.hs`
- `src/Main/Mode/Interactive.hs`

with the following goals:

- Avoid duplication of code (especially between diff and non-diff mode)
- Avoid repeated and unnecessary wellformedness checks
- Avoid separate functions for loading theories from strings and files
- Unified validation of command line flags (partially)
- Consistent reporting of wellformedness warnings

`TheoryLoader.hs` now provides two main functions for loading open theories from string (`loadTheory`) and closing open theories (`closeTheory`) which work with diff and non-diff theories.
Due to the sequential nature of `closeTheory`, the wellformedness checks can now be done at the correct steps.

This fixes #458.

## Other fixes

- Don't print wellformedness warnings again in the summary of summaries
- Always include the processing time in the summary of summaries
- Fix pretty printing of non-translated theory
- Terminate the interactive mode when `quit-on-warning` is enabled and a wellfromedness warning occurs in a theory
- Use `die` instead of `error` for user-facing termination criteria (fixes #415)
- Fix several warnings during compilation

## Comments for review

- All regression tests pass including `obseq-case-studies`