### PR TITLE
Assume output mode to be msr when --prove is given.

### DIFF
--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -159,15 +159,15 @@ helpFlag = flagHelpSimple (addEmptyArg "help")
 -- Utility Functions
 ------------------------------------------------------------------------------
 
-getOutputModule ::  Arguments -> ModuleType 
+getOutputModule ::  Arguments -> ModuleType
 getOutputModule as
+     | Nothing <-  findArg "outModule" as
+     , [] /= findArg "prove" as = ModuleMsr -- when proving, we act like we chose the Msr Output module.
      | Nothing <-  findArg "outModule" as = ModuleSpthy -- default
      | Just string <-  findArg "outModule" as
      , Just modCon <- find (\x -> show x  == string) (enumFrom minBound)
       = modCon
      | otherwise = error "output mode not supported."
-
-
 
 ------------------------------------------------------------------------------
 -- Modes for using the Tamarin prover


### PR DESCRIPTION
Hi!

This fixes a bug where a lemma with msr output:
```
lemma sanity[output=[msr]]: exists-trace
    "Ex #i #j m. (Sent(m)@i & Received(m)@j)"
```
Is not proven when `--prove` is given.