### PR TITLE
[FIX] Aesthetic : Not showing empty Wellformedness Error in CLI

### DIFF
--- a/src/Web/Dispatch.hs
+++ b/src/Web/Dispatch.hs
@@ -183,7 +183,7 @@ loadTheories thOpts readyMsg thDir thLoad thClose autoProver = do
           die "quit-on-warning mode selected - aborting on wellformedness errors."
         Right (report, thy) -> do
           time <- getZonedTime
-          putStrLn $ renderDoc $ ppInteractive report path
+          unless (null report) $ putStrLn $ renderDoc $ ppInteractive report path
           return $ Just
              ( idx
              , either (\t -> Trace $ TheoryInfo idx t time Nothing True (Local path) autoProver)


### PR DESCRIPTION
Hello,

Following the recent code refactorisation, I have noticed that the wellformedness error where always showing in the cli (in interactive mode), even when there was no error, hence creating sometimes a lot of text.

I have just added `unless (null report) $ ... ` to prevent an empty report from being shown.

This is what happens otherwise:
```
------------------------------------------------------------------------------
Theory file '...'
------------------------------------------------------------------------------

WARNING: ignoring the following wellformedness errors

------------------------------------------------------------------------------
```

I have tested with a wellformedness error, and seems to work as expected.