### PR TITLE
Prove Minimal_HashChain lemmas

### DIFF
--- a/examples/loops/Minimal_HashChain.spthy
+++ b/examples/loops/Minimal_HashChain.spthy
@@ -79,11 +79,13 @@ lemma Loop_charn [use_induction]:
   "All lid k kOrig #i. Loop(lid, k, kOrig) @ i ==>
      Ex #j. Loop(lid, kOrig, kOrig) @ j"
 
-// Not yet provable: the problem is that we cannot express the relation
-// between the keys on two different segments of the same loop.
-// @BS: Do you have an idea on how we could use multisets to formulate a
-// strong enough invariant?
-lemma Loop_and_success [use_induction]:
+lemma Helper_Loop_and_success[use_induction,reuse]:
+  "All lid kOrig k1 k2 #x #y #z.
+      Loop(lid, k1, kOrig) @ #x & Loop(lid, k2, kOrig) @ #y & #y < #x
+      & ChainKey(k1) @ #z
+    ==> Ex #t. ChainKey(k2) @ #t"
+
+lemma Loop_and_success:
   "All lid k kOrig1 kOrig2 #i #j.
        Loop(lid, k, kOrig1) @ i
      & Success(lid, kOrig2) @ j
@@ -91,8 +93,11 @@ lemma Loop_and_success [use_induction]:
      (Ex #j. ChainKey(k) @ j)
   "
 
-// The ultimate goal! A successful check implies that the starting key is a
-// key of the chain.
+lemma Helper_Success_charn[use_induction,reuse]:
+  "All lid k kOrig #x #y.
+      ChainKey(k) @ #x & Loop(lid, k, kOrig) @ #y
+    ==> Ex #z. ChainKey(kOrig) @ #z"
+
 lemma Success_charn:
   "All lid k #i. Success(lid, k) @ i ==>
     Ex #j. ChainKey(k) @ j"


### PR DESCRIPTION
# PR Descritiption

Recently, I looked again into the `Minimal_HashChain.spthy` example some lemmas of which were marked as unprovable in comments.

After looking into why the induction failed, I managed to write two helper lemmas that can prove all lemmas within this example.

In this PR, I update the comments that the theory is indeed provable. I want to lay out my reasoning, too. We can discuss if it would be of interest to reflect the reasoning in comments or the manual (@rsasse mentioned the latter may be interesting).

## Helper Lemma Reasoning

Why couldn't the lemmas be proven initially? As Simon described in the comments, one likely concludes that the problem is tamarin being incapable to "connect different elements of a loop". One can observe this in a partial constraint system for `Success_charn` when trying to prove it inductively:

![image](https://user-images.githubusercontent.com/9728715/187186912-e406f5f0-251e-4491-9c75-10e99b4d593d.png)

Tamarin knows that the loop on the top left must exist, as it must have been started, but fails to "connect" `f(k)` witk `k.1`.

I would put the problem that tamarin encounters differently, though. The problem is not that tamarin cannot connect these facts, rather, the induction hypothesis is too weak and cannot be applied. This is solely because every trace can only have one `Success` fact, hence, any IH that includes `Success` in its precondition can never be applied fruitfully.

In this example, the IH is:
>  ∀ lid k #i.
>   (Success( lid, k ) @ #i)
>  ⇒
>   ((last(#i)) ∨ (∃ #j. (ChainKey( k ) @ #j) ∧ ¬(last(#j))))

After constructing `Success` once, there will be no other `Success` to which we could apply this all-quantified IH.

As soon as I started thinking about rephrasing these lemmas such that they do not refer to the `Success` fact, I managed to write inductive helper lemmas that were strong enough to prove the original lemmas. If I have one `Loop`, I will get another `Loop` or the base-case when proving by induction and to the new `Loop`, I can apply the all-quantified IH.