### PR TITLE
Fix typo introduced by #484

### DIFF
--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -255,7 +255,7 @@ mkTheoryLoadOptions as = TheoryLoadOptions
      | otherwise   = throwError $ ArgumentError "output mode not supported."
 
     -- NOTE: Output mode implicitly activates parse-only mode
-    parseOnlyMode = return $ argExists "parseOnly" as || argExists "outputMode" as
+    parseOnlyMode = return $ argExists "parseOnly" as || argExists "outModule" as
 
     chain = findArg "OpenChainsLimit" as
     chainDefault = L.get oOpenChain defaultTheoryLoadOptions


### PR DESCRIPTION
The export is currently broken, due to a typo enabling the behaviour when given the argument.
@rkunnema 