### PR TITLE
Update docker images and convenience script

### DIFF
--- a/etc/docker/Dockerfile-benchmarks
+++ b/etc/docker/Dockerfile-benchmarks
@@ -1,4 +1,4 @@
-FROM protocolplatform/protocolplatform
+FROM robertkuennemann/sapicplusplatform
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/etc/docker/Dockerfile-platform
+++ b/etc/docker/Dockerfile-platform
@@ -1,5 +1,5 @@
 FROM ocaml/opam as build-ocaml
-# MAINTAINER Protocol Platform <protocolplatform@protonmail.com>
+MAINTAINER Robert Künnemann <robert.kuennemann@cispa.de>
 USER root
 RUN opam install -y ocamlfind ocamlbuild
 

--- a/etc/docker/build-benchs.sh
+++ b/etc/docker/build-benchs.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # call in top-level dir...
-docker build -t protocolplatform/protocolplatformbench -f etc/docker/Dockerfile-benchmarks .
+docker build -t robertkuennemann/sapicplusplatformbench -f etc/docker/Dockerfile-benchmarks .

--- a/etc/docker/build-instructions.md
+++ b/etc/docker/build-instructions.md
@@ -23,14 +23,14 @@ etc/docker/Dockerfile-benchmark -> performs some benchmarks for the tamarin-plat
 (For Dockerfile-platform)
 
 ```
-docker pull protocolplatform/protocolplatform:latest
+docker pull robertkuennemann/sapicplusplatform:latest
 ```
 
 ## Run instructions
 
 1. Execute
 ```
-docker run protocolplatform/protocolplatform:latest
+docker run robertkuennemann/sapicplusplatform:latest
 ```
 
 2. Follow instructions.

--- a/etc/docker/build-platform.sh
+++ b/etc/docker/build-platform.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # call in top-level dir...
-DOCKER_BUILDKIT=1 docker build -t protocolplatform/protocolplatform -f etc/docker/Dockerfile-platform .
+DOCKER_BUILDKIT=1 docker build -t robertkuennemann/sapicplusplatform -f etc/docker/Dockerfile-platform .

--- a/etc/docker/res/README-platform
+++ b/etc/docker/res/README-platform
@@ -1,8 +1,8 @@
-Hi! This is the protocolplatform Docker image. You can now:
+Hi! This is the sapicplusplatform Docker image. You can now:
 
 1. Browse the image interactively:
 
-docker run -it protocolplatform/protocolplatform:latest bash
+docker run -it robertkuennemann/sapicplusplatform:latest bash
 
 You should obtain a shell that reads like that: `root@976d3bce69f8:/opt/protocolplatform#`.
 
@@ -54,7 +54,7 @@ We refer to `examples/README.md` for details about the case studies and some usa
 - set up the following alias to give the image access to your host's current working
   dir (at the time of calling) and forward port 3001:
 
-alias pp='docker run -p 3001:3001 -v "$PWD:$PWD" -w "$PWD" protocolplatform/protocolplatform'
+alias pp='docker run -p 3001:3001 -v "$PWD:$PWD" -w "$PWD" robertkuennemann/sapicplusplatform'
 
 - run, e.g., "pp tamarin-prover" to run tamarin-prover from the docker
 - remember to use the "-i" flag in tamarin's interactive mode to accept clients

--- a/etc/docker/res/proverif-tamarin-diff
+++ b/etc/docker/res/proverif-tamarin-diff
@@ -2,4 +2,4 @@
 
 set -x # print what we do
 temp=$(mktemp -d)/$(basename "$1")
-tamarin-prover "$1" --diff -m=proverif -D=PROVERIFEQUIV > "$temp.pv"; proverif "$temp.pv"
+tamarin-prover "$1" --diff -m=proverifequiv > "$temp.pv"; proverif "$temp.pv"


### PR DESCRIPTION
This PR updates the docker images names to the non-anonymous one `robertkuennemann/sapicplusplatformbench` and fixes a bug in `etc/docker/res/proverif-tamarin-diff` which used an obsolete way of calling the translation to diff mode.