### PR TITLE
Revert "Semi Persistence"

### DIFF
--- a/lib/accountability/src/Accountability/Generation.hs
+++ b/lib/accountability/src/Accountability/Generation.hs
@@ -38,7 +38,7 @@ quantifyFrees :: ((String, LSort) -> LVar -> SyntacticLNFormula -> SyntacticLNFo
 quantifyFrees quan fm = quantifyVars quan (frees fm) fm
 
 protoFactFormula :: String -> [VTerm Name (BVar LVar)] -> VTerm Name (BVar LVar) -> SyntacticLNFormula
-protoFactFormula name terms at = Ato $ Action at $ protoFact Consume name terms
+protoFactFormula name terms at = Ato $ Action at $ protoFact Linear name terms
 
 tempTerm :: String -> VTerm Name (BVar LVar)
 tempTerm name = varTerm $ Free $ LVar name LSortNode 0

--- a/lib/sapic/src/Sapic/Basetranslation.hs
+++ b/lib/sapic/src/Sapic/Basetranslation.hs
@@ -238,7 +238,7 @@ baseTransComb c an p tildex
         else
                     throw $ WFUnbound (freevars_f `difference` tildex) 
     | CondEq t1 t2 <- c =
-        let fa = toLNFact (protoFact Consume "Eq" [t1,t2]) in
+        let fa = toLNFact (protoFact Linear "Eq" [t1,t2]) in
         let vars_f = fromList $ getFactVariables fa in
         if vars_f `isSubsetOf` tildex then
                 ([ ([def_state],  [PredicateA fa], [def_state1 tildex], []),
@@ -414,12 +414,12 @@ resLocking hasUnlock v =  do
     where
         subst _ a
             | (Action t f) <- a,
-              Fact {factTag = ProtoFact Consume "LockPOS" 3} <- f
+              Fact {factTag = ProtoFact Linear "LockPOS" 3} <- f
             =
-              Action t (f {factTag = ProtoFact Consume (hardcode "Lock") 3})
+              Action t (f {factTag = ProtoFact Linear (hardcode "Lock") 3})
             | (Action t f) <- a,
-              Fact {factTag = ProtoFact Consume "UnlockPOS" 3} <- f =
-              Action t (f {factTag = ProtoFact Consume (hardcode "Unlock") 3})
+              Fact {factTag = ProtoFact Linear "UnlockPOS" 3} <- f =
+              Action t (f {factTag = ProtoFact Linear (hardcode "Unlock") 3})
             | otherwise = a
         hardcode s = s ++ "_" ++ show (lvarIdx v)
         mapFormula = L.modify rstrFormula

--- a/lib/sapic/src/Sapic/Compression.hs
+++ b/lib/sapic/src/Sapic/Compression.hs
@@ -114,7 +114,7 @@ mergeRules compEvents leftrules rightrules =
   -- Given a fact and an msr, compress the msr with respect to this fact, and return the new msr, and the new facts (facts reachable in one step from the fact) that we may try to compress
 compressOne :: Bool -> Fact LNTerm -> [Rule ProtoRuleEInfo] -> ([Rule ProtoRuleEInfo], S.Set (Fact LNTerm))
 compressOne compEvents fact msr
-  | isReadOnlyFact fact =  (msr, new_facts)
+  | isPersistentFact fact =  (msr, new_facts)
   | otherwise =  (msr3 ++ new_rules, new_facts)
   where (prem_rules,msr2) = getPremRules fact msr
         (concs_rules,msr3) =  getConcsRules fact msr2

--- a/lib/sapic/src/Sapic/Facts.hs
+++ b/lib/sapic/src/Sapic/Facts.hs
@@ -150,10 +150,10 @@ addVarToState v' (State kind pos vs)  = State kind pos (v' `S.insert` vs)
 addVarToState _ x = x
 
 multiplicity :: StateKind -> Multiplicity
-multiplicity LState = Consume
-multiplicity LSemiState = Consume
-multiplicity PState = ReadOnly
-multiplicity PSemiState = ReadOnly
+multiplicity LState = Linear
+multiplicity LSemiState = Linear
+multiplicity PState = Persistent
+multiplicity PSemiState = Persistent
 
 -- | map f to the name of a fact
 mapFactName :: (String -> String) -> Fact t -> Fact t
@@ -193,26 +193,26 @@ varMsgId p = LVar n s i
           i = 0
 
 actionToFact :: TransAction -> Fact LNTerm
-actionToFact InitEmpty = protoFact Consume "Init" []
+actionToFact InitEmpty = protoFact Linear "Init" []
   --  | StopId
   --  | EventEmpty
   --  | EventId
-actionToFact (Send p t) = protoFact Consume "Send" [varTerm $ varMsgId p, t]
-actionToFact (Receive p t) = protoFact Consume "Receive" [varTerm $ varMsgId p ,t]
-actionToFact (IsIn t v)   =  protoFact Consume "IsIn" [t,varTerm v]
-actionToFact (IsNotSet t )   =  protoFact Consume "IsNotSet" [t]
-actionToFact (InsertA t1 t2)   =  protoFact Consume "Insert" [t1,t2]
-actionToFact (DeleteA t )   =  protoFact Consume "Delete" [t]
-actionToFact (ChannelIn t)   =  protoFact Consume "ChannelIn" [t]
-actionToFact (EventEmpty)   =   protoFact Consume "Event" []
+actionToFact (Send p t) = protoFact Linear "Send" [varTerm $ varMsgId p, t]
+actionToFact (Receive p t) = protoFact Linear "Receive" [varTerm $ varMsgId p ,t]
+actionToFact (IsIn t v)   =  protoFact Linear "IsIn" [t,varTerm v]
+actionToFact (IsNotSet t )   =  protoFact Linear "IsNotSet" [t]
+actionToFact (InsertA t1 t2)   =  protoFact Linear "Insert" [t1,t2]
+actionToFact (DeleteA t )   =  protoFact Linear "Delete" [t]
+actionToFact (ChannelIn t)   =  protoFact Linear "ChannelIn" [t]
+actionToFact (EventEmpty)   =   protoFact Linear "Event" []
 actionToFact (PredicateA f)   =  mapFactName (\s -> "Pred_" ++ s) f
 actionToFact (NegPredicateA f)   =  mapFactName (\s -> "Pred_Not_" ++ s) f
-actionToFact (LockNamed t v)   = protoFact Consume (lockFactName v) [lockPubTerm v,varTerm v, t ]
-actionToFact (LockUnnamed t v)   = protoFact Consume "Lock" [lockPubTerm v, varTerm v, t ]
-actionToFact (UnlockNamed t v) = protoFact Consume (unlockFactName v) [lockPubTerm v,varTerm v,t]
-actionToFact (UnlockUnnamed t v) = protoFact Consume "Unlock" [lockPubTerm v,varTerm v,t]
-actionToFact (ProgressFrom p) = protoFact Consume ("ProgressFrom_"++prettyPosition p) [varTerm $ varProgress p]
-actionToFact (ProgressTo p pf) = protoFact Consume ("ProgressTo_"++prettyPosition p) $ [varTerm $ varProgress pf]
+actionToFact (LockNamed t v)   = protoFact Linear (lockFactName v) [lockPubTerm v,varTerm v, t ]
+actionToFact (LockUnnamed t v)   = protoFact Linear "Lock" [lockPubTerm v, varTerm v, t ]
+actionToFact (UnlockNamed t v) = protoFact Linear (unlockFactName v) [lockPubTerm v,varTerm v,t]
+actionToFact (UnlockUnnamed t v) = protoFact Linear "Unlock" [lockPubTerm v,varTerm v,t]
+actionToFact (ProgressFrom p) = protoFact Linear ("ProgressFrom_"++prettyPosition p) [varTerm $ varProgress p]
+actionToFact (ProgressTo p pf) = protoFact Linear ("ProgressTo_"++prettyPosition p) $ [varTerm $ varProgress pf]
 actionToFact (TamarinAct f) = f
 
 toFreeMsgVariable :: LVar -> BVar LVar
@@ -235,27 +235,27 @@ factToFact :: TransFact -> Fact LNTerm
 factToFact (Fr v) = freshFact $ varTerm (v)
 factToFact (In t) = inFact t
 factToFact (Out t) = outFact t
-factToFact (FLet p t vars) = protoFact Consume ("Let"++ "_" ++ prettyPosition p) (t:ts)
+factToFact (FLet p t vars) = protoFact Linear ("Let"++ "_" ++ prettyPosition p) (t:ts)
       where
         ts = map varTerm (S.toList vars)
-factToFact (Message t t') = protoFact Consume "Message" [t, t']
-factToFact (Ack t t') = protoFact Consume "Ack" [t, t']
-factToFact (MessageIDSender p) = protoFact Consume "MID_Sender" [ varTerm $ varMID p ]
-factToFact (MessageIDReceiver p) = protoFact Consume "MID_Receiver" [ varTerm$ varMID p ]
+factToFact (Message t t') = protoFact Linear "Message" [t, t']
+factToFact (Ack t t') = protoFact Linear "Ack" [t, t']
+factToFact (MessageIDSender p) = protoFact Linear "MID_Sender" [ varTerm $ varMID p ]
+factToFact (MessageIDReceiver p) = protoFact Linear "MID_Receiver" [ varTerm$ varMID p ]
 factToFact (State kind p vars) = protoFact (multiplicity kind) (name kind ++ "_" ++ prettyPosition p) ts
     where
         name k = if isSemiState k then "Semistate" else "State"
         ts = map varTerm (S.toList vars)
 factToFact (TamarinFact f) = f
-factToFact (PureCell t1 t2) = protoFact Consume ("L_PureState") [t1, t2]
-factToFact (CellLocked t1 t2) = protoFact Consume ("L_CellLocked") [t1, t2]
+factToFact (PureCell t1 t2) = protoFact Linear ("L_PureState") [t1, t2]
+factToFact (CellLocked t1 t2) = protoFact Linear ("L_CellLocked") [t1, t2]
 
 
 pureStateFactTag :: FactTag
-pureStateFactTag =  ProtoFact Consume ("L_PureState") 2
+pureStateFactTag =  ProtoFact Linear ("L_PureState") 2
 
 pureStateLockFactTag :: FactTag
-pureStateLockFactTag =  ProtoFact Consume ("L_CellLocked") 2
+pureStateLockFactTag =  ProtoFact Linear ("L_CellLocked") 2
 
 
 isOutFact :: Fact t -> Bool

--- a/lib/sapic/src/Sapic/Report.hs
+++ b/lib/sapic/src/Sapic/Report.hs
@@ -41,8 +41,8 @@ reportInit anP (initrules,initTx) = return (reportrule : initrules, initTx)
         var s = LVar s LSortMsg 0
         x = var "x"
         loc = var "loc"
-        -- protFact =  Syntactic . Pred $ (protoFact Consume "Report" [varTerm x, varTerm loc])
-        protFact =  Syntactic . Pred $ (protoFact Consume "Report" [varTerm (Free x), varTerm (Free loc)])
+        -- protFact =  Syntactic . Pred $ (protoFact Linear "Report" [varTerm x, varTerm loc])
+        protFact =  Syntactic . Pred $ (protoFact Linear "Report" [varTerm (Free x), varTerm (Free loc)])
 
 -- | This rules use the builtin restriction system to bind the Report predicate (which must be defined by the user), to this rule.
 opt_loc :: Maybe SapicTerm -> ProcessAnnotation v -> Maybe SapicTerm

--- a/lib/theory/src/Items/CaseTestItem.hs
+++ b/lib/theory/src/Items/CaseTestItem.hs
@@ -33,7 +33,7 @@ $(mkLabels [''CaseTest])
 caseTestToPredicate :: CaseTest -> Maybe Predicate
 caseTestToPredicate caseTest = fmap (Predicate fact) formula
   where
-    fact = protoFact Consume name (frees formula)
+    fact = protoFact Linear name (frees formula)
     name = L.get cName caseTest
     formula = toLNFormula (L.get cFormula caseTest)
 

--- a/lib/theory/src/OpenTheory.hs
+++ b/lib/theory/src/OpenTheory.hs
@@ -278,16 +278,16 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
               return (rout, fout))
 
         -- construct action facts for the rule annotations and formula
-        inputFactTerm pos ru terms var = Fact {factTag = ProtoFact Consume
+        inputFactTerm pos ru terms var = Fact {factTag = ProtoFact Linear
               ("AUTO_IN_TERM_" ++ printPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (1 + length terms),
               factAnnotations = S.empty, factTerms = terms ++[var]}
-        inputFactFact pos ru terms = Fact {factTag = ProtoFact Consume
+        inputFactFact pos ru terms = Fact {factTag = ProtoFact Linear
               ("AUTO_IN_FACT_" ++ printFactPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (length terms),
               factAnnotations = S.empty, factTerms = terms}
-        outputFactTerm pos ru terms = Fact {factTag = ProtoFact Consume
+        outputFactTerm pos ru terms = Fact {factTag = ProtoFact Linear
               ("AUTO_OUT_TERM_" ++ printPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (length terms),
               factAnnotations = S.empty, factTerms = terms}
-        outputFactFact pos ru terms = Fact {factTag = ProtoFact Consume
+        outputFactFact pos ru terms = Fact {factTag = ProtoFact Linear
               ("AUTO_OUT_FACT_" ++ printFactPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (length terms),
               factAnnotations = S.empty, factTerms = terms}
 

--- a/lib/theory/src/Rule.hs
+++ b/lib/theory/src/Rule.hs
@@ -46,7 +46,6 @@ equalOpenRuleUpToDiffAnnotation (OpenProtoRule ruE1 ruAC1) (OpenProtoRule ruE2 r
   equalRuleUpToDiffAnnotationSym ruE1 ruE2 && length ruAC1 == length ruAC2 &&
   all (uncurry equalRuleUpToDiffAnnotationSym) (zip ruAC1 ruAC2)
 
-
 -- Relation between open and closed rule sets
 ---------------------------------------------
 

--- a/lib/theory/src/Theory/Constraint/Solver/Contradictions.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Contradictions.hs
@@ -161,8 +161,6 @@ substCreatesNonNormalTerms hnd sys fsubst =
 
 
 -- | Compute all contradictions to injective fact instances.
--- CAREFUL: this is DUPLICATED CODE from Simplify.hs
--- FIXME: We can probably remove this function without replacement
 --
 -- Formally, they are computed as follows. Let 'f' be a fact symbol with
 -- injective instances. Let i, j, and k be temporal variables ordered
@@ -171,10 +169,11 @@ substCreatesNonNormalTerms hnd sys fsubst =
 --   i < j < k
 --
 -- and let there be an edge from (i,u) to (k,w) for some indices u and v,
--- as well as an injective fact `f(t,...)` in the conclusion (i,u).
+-- as well as an injectif fact `f(t,...)` in the conclusion (i,u).
 --
 -- Then, we have a contradiction either if:
---  1) both the premises (k,w) and (j,v) are consuming and require a fact 'f(t,...)'.
+--  1) both the premises (k,w) and (j,v) requires a
+-- fact 'f(t,...)'.
 --  2) both the conclusions (i,u) and (j,v) produce a fact `f(t,..)`.
 --
 -- In the first case, (k,w) and (j,v) would have to be merged, and in the second
@@ -191,11 +190,12 @@ nonInjectiveFactInstances ctxt se = do
     guard (kTag `S.member` L.get pcInjectiveFactInsts ctxt)
     j <- S.toList $ D.reachableSet [i] less
 
-    let consumePrems ru = [p | p <- L.get rPrems ru, isConsumeFact p]
     let isCounterExample = (j /= i) && (j /= k) &&
                            maybe False checkRule (M.lookup j $ L.get sNodes se)
 
-        checkRule jRu    = any conflictingFact (consumePrems jRu ++ L.get rConcs jRu) &&
+        -- FIXME: There should be a weaker version of the rule that just
+        -- introduces the constraint 'k < j || k == j' here.
+        checkRule jRu    = any conflictingFact (L.get rPrems jRu ++ L.get rConcs jRu) &&
                            (k `S.member` D.reachableSet [j] less
                              || isLast se k)
 

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -24,7 +24,7 @@ module Theory.Constraint.Solver.Goals (
   , plainOpenGoals
   ) where
 
---import           Debug.Trace
+-- import           Debug.Trace
 
 import           Prelude                                 hiding (id, (.))
 

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -113,7 +113,7 @@ msgPremise (ActionG _ fa) = do (UpK, m) <- kFactView fa; return m
 msgPremise _              = Nothing
 
 isProgressFact :: Fact t -> Bool
-isProgressFact (factTag -> ProtoFact Consume name 1) = isPrefixOf "ProgressTo_" name
+isProgressFact (factTag -> ProtoFact Linear name 1) = isPrefixOf "ProgressTo_" name
 isProgressFact _ = False
 
 isProgressDisj :: Goal -> Bool
@@ -380,7 +380,7 @@ execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ sho
       $ L.set dsProofType (Just RuleEquivalence) sys
       
     formula :: String -> LNFormula
-    formula rulename = Qua Ex ("i", LSortNode) (Ato (Action (LIT (Var (Bound 0))) (Fact (ProtoFact Consume ("Diff" ++ rulename) 0) S.empty [])))
+    formula rulename = Qua Ex ("i", LSortNode) (Ato (Action (LIT (Var (Bound 0))) (Fact (ProtoFact Linear ("Diff" ++ rulename) 0) S.empty [])))
     
     ruleEquivalenceCase :: M.Map CaseName DiffSystem -> RuleAC -> M.Map CaseName DiffSystem
     ruleEquivalenceCase m rule = M.insert ("Rule_" ++ (getRuleName rule) ++ "") (ruleEquivalenceSystem (getRuleNameDiff rule)) m

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ViewPatterns       #-}
 {-# LANGUAGE TupleSections      #-}
-{-# LANGUAGE LambdaCase         #-}
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -34,9 +33,7 @@ import           Data.List
 import qualified Data.Map                           as M
 -- import           Data.Monoid                        (Monoid(..))
 import qualified Data.Set                           as S
-import           Data.Maybe                         (mapMaybe, listToMaybe, maybeToList, fromJust)
-import           Data.Bifunctor                     (bimap)
-import           Safe                               (atMay, headMay)
+import           Data.Maybe                         (mapMaybe)
 
 import           Control.Basics
 import           Control.Category
@@ -55,7 +52,6 @@ import           Theory.Constraint.Solver.Reduction
 import           Theory.Constraint.System
 import           Theory.Model
 import           Theory.Text.Pretty
-import           Theory.Tools.InjectiveFactInstances
 
 
 -- | Apply CR-rules that don't result in case splitting until the constraint
@@ -72,10 +68,10 @@ simplifySystem = do
        else do
         -- Add all ordering constraint implied by CR-rule *N6*.
         exploitUniqueMsgOrder
-        -- Remove equation split goals that do not exist anymore        
+        -- Remove equation split goals that do not exist anymore
         removeSolvedSplitGoals
         -- Add ordering constraint from injective facts
-        addNonInjectiveFactInstances        
+        addNonInjectiveFactInstances
   where
     go n changes0
       -- We stop as soon as all simplification steps have been run without
@@ -93,7 +89,7 @@ simplifySystem = do
           if isdiff
             then do
               (c1,c3) <- enforceFreshAndKuNodeUniqueness
-              c4 <- enforceEdgeConstraints
+              c4 <- enforceEdgeUniqueness
               c5 <- solveUniqueActions
               c6 <- reduceFormulas
               c7 <- evalFormulaAtoms
@@ -102,15 +98,15 @@ simplifySystem = do
 
               -- Report on looping behaviour if necessary
               let changes = filter ((Changed ==) . snd) $
-                    [ ("unique fresh instances (DG4)",                 c1)
---                     , ("unique K↓-facts (N5↓)",                        c2)
-                    , ("unique K↑-facts (N5↑)",                        c3)
-                    , ("readonly & consume edges (DG2, DG3' and DG5)", c4)
-                    , ("solve unambiguous actions (S_@)",              c5)
-                    , ("decompose trace formula",                      c6)
-                    , ("propagate atom valuation to formula",          c7)
-                    , ("saturate under ∀-clauses (S_∀)",               c8)
-                    , ("orderings for ~vars (S_fresh-order)",          c9)
+                    [ ("unique fresh instances (DG4)",        c1)
+--                     , ("unique K↓-facts (N5↓)",               c2)
+                    , ("unique K↑-facts (N5↑)",               c3)
+                    , ("unique (linear) edges (DG2 and DG3)", c4)
+                    , ("solve unambiguous actions (S_@)",     c5)
+                    , ("decompose trace formula",             c6)
+                    , ("propagate atom valuation to formula", c7)
+                    , ("saturate under ∀-clauses (S_∀)",      c8)
+                    , ("orderings for ~vars (S_fresh-order)", c9)
                     ]
                   traceIfLooping
                     | n <= 10   = id
@@ -125,7 +121,7 @@ simplifySystem = do
               traceIfLooping $ go (n + 1) (map snd changes)
             else do
               (c1,c2,c3) <- enforceNodeUniqueness
-              c4 <- enforceEdgeConstraints
+              c4 <- enforceEdgeUniqueness
               c5 <- solveUniqueActions
               c6 <- reduceFormulas
               c7 <- evalFormulaAtoms
@@ -134,15 +130,15 @@ simplifySystem = do
 
               -- Report on looping behaviour if necessary
               let changes = filter ((Changed ==) . snd) $
-                    [ ("unique fresh instances (DG4)",                 c1)
-                    , ("unique K↓-facts (N5↓)",                        c2)
-                    , ("unique K↑-facts (N5↑)",                        c3)
-                    , ("readonly & consume edges (DG2, DG3' and DG5)", c4)
-                    , ("solve unambiguous actions (S_@)",              c5)
-                    , ("decompose trace formula",                      c6)
-                    , ("propagate atom valuation to formula",          c7)
-                    , ("saturate under ∀-clauses (S_∀)",               c8)
-                    , ("orderings for ~vars (S_fresh-order)",          c9)
+                    [ ("unique fresh instances (DG4)",        c1)
+                    , ("unique K↓-facts (N5↓)",               c2)
+                    , ("unique K↑-facts (N5↑)",               c3)
+                    , ("unique (linear) edges (DG2 and DG3)", c4)
+                    , ("solve unambiguous actions (S_@)",     c5)
+                    , ("decompose trace formula",             c6)
+                    , ("propagate atom valuation to formula", c7)
+                    , ("saturate under ∀-clauses (S_∀)",      c8)
+                    , ("orderings for ~vars (S_fresh-order)", c9)
                     ]
                   traceIfLooping
                     | n <= 10   = id
@@ -237,23 +233,25 @@ enforceFreshAndKuNodeUniqueness =
         mergers ((_,(xKeep, iKeep)):remove) =
             mappend <$> solver         (map (Equal xKeep . fst . snd) remove)
                     <*> solveNodeIdEqs (map (Equal iKeep . snd . snd) remove)
-                    
 
--- | CR-rules *DG2_1*, *DG3'* and *DG5*: merge multiple incoming edges to all facts
+
+-- | CR-rules *DG2_1* and *DG3*: merge multiple incoming edges to all facts
 -- and multiple outgoing edges from linear facts.
-enforceEdgeConstraints :: Reduction ChangeIndicator
-enforceEdgeConstraints = do
-    nodes <- getM sNodes
-    edges <- S.toList <$> getM sEdges
-    foldl1 (liftM2 (<>)) [mergeNodes eSrc eTgt edges,  -- DG2 uniqueness (no two sources for a single premise)
-                          mergeNodes eTgt eSrc (filter (isConsumeEdge nodes) edges),  -- DG3' (no two consumes from the same source)
-                          readBeforeConsume]  -- DG5 (ReadOnly before Consume)
+enforceEdgeUniqueness :: Reduction ChangeIndicator
+enforceEdgeUniqueness = do
+    se <- gets id
+    let edges = S.toList (get sEdges se)
+    (<>) <$> mergeNodes eSrc eTgt edges
+         <*> mergeNodes eTgt eSrc (filter (proveLinearConc se . eSrc) edges)
   where
-    -- | @isConsumeEdge se (Edge _ (v,i))@ checks wether the @i@-th
-    -- premise of node @v@ is a consume fact, i.e., the edge is not used for a ReadOnly premise
-    isConsumeEdge nodes (Edge _ (v, i)) = maybe False (isConsumeFact . get (rPrem i)) $ M.lookup v nodes
+    -- | @proveLinearConc se (v,i)@ tries to prove that the @i@-th
+    -- conclusion of node @v@ is a linear fact.
+    proveLinearConc se (v, i) =
+        maybe False (isLinearFact . (get (rConc i))) $
+            M.lookup v $ get sNodes se
 
-    -- | merge the nodes on the 'mergeEnd' for edges that are equal on the 'compareEnd'
+    -- merge the nodes on the 'mergeEnd' for edges that are equal on the
+    -- 'compareEnd'
     mergeNodes mergeEnd compareEnd edges
       | null eqs  = return Unchanged
       | otherwise = do
@@ -266,37 +264,6 @@ enforceEdgeConstraints = do
 
         merge _    []            = error "exploitEdgeProps: impossible"
         merge proj (keep:remove) = map (Equal (proj keep) . proj) remove
-
-    -- | DG5 (a value has to be read before it is consumed):
-    --   (k,w) ↣ (i,u), (k,w) ↣ (j,v), k:rk, i:ri, j:rj
-    --   -- insert --
-    --   i≤j
-    -- if prems(ri)u is read-only
-    -- if prems(rj)v is consuming
-    readBeforeConsume :: Reduction ChangeIndicator
-    readBeforeConsume = do
-      nodes <- getM sNodes
-      consumeEdges <- filter (isConsumeEdge nodes) . S.toList <$> getM sEdges
-      readOnlyEdges <- filter (not . isConsumeEdge nodes) . S.toList <$> getM sEdges
-      let readOnlyEdgeMap = M.fromListWith (++) [(a,[i]) | (Edge a (i, _)) <- readOnlyEdges]  -- a map giving for a node all nodeId's to which a read-only edge points
-      let getConsumeOrd (Edge src (j, _)) = [(i,j) | i <- concat $ M.lookup src readOnlyEdgeMap]  -- for a consume-Edge k↣j: find all nodeId's i which read from the same fact
-      let orderings = concatMap getConsumeOrd consumeEdges  -- all orderings i≤j that have to be inserted
-      changes <- forM orderings $ (\(i,j) -> do  -- for all such orderings
-              before <- gets alwaysBefore  -- the ordering relation as is
-              if i `before` j
-                then return Unchanged  -- if i<j already holds, nothing is to be done
-                else do
-                  ctxt <- ask
-                  let runMaude = (`runReader` get pcMaudeHandle ctxt)
-                  let unifiable = maybe True runMaude $ unifiableRuleACInsts <$> M.lookup i nodes <*> M.lookup j nodes  -- if i and j might be the same
-                  if unifiable then
-                      insertFormula $ gnot $ GAto $ Less (varTerm $ Free j) (varTerm $ Free i) -- then insert i≤j by inserting ¬j<i
-                    else insertLess i j                                                        -- else insert i<j
-                  return Changed
-              )
-      return $ foldl (<>) Unchanged changes
-
-
 
 -- | Special version of CR-rule *S_at*, which is only applied to solve actions
 -- that are guaranteed not to result in case splits.
@@ -364,8 +331,6 @@ evalFormulaAtoms = do
 --
 -- The interpretation for @Just False@ is analogous. @Nothing@ is used to
 -- represent *unknown*.
---
--- FIXME this function is almost identical to System>safePartial evaluation -> join them
 --
 partialAtomValuation :: ProofContext -> System -> LNAtom -> Maybe Bool
 partialAtomValuation ctxt sys =
@@ -479,27 +444,21 @@ freshOrdering = do
                                       = concatMap (extractFreshNotBelowReducible reducible) as
       extractFreshNotBelowReducible _ t | isFreshVar t = [t]
       extractFreshNotBelowReducible _ _                = []
-
+      
 
 -- | Compute all less relations implied by injective fact instances.
--- CAREFUL: this is DUPLICATED CODE from Contradictions.hs
 --
 -- Formally, they are computed as follows. Let 'f' be a fact symbol with
--- injective instances. Let i, j, and k be temporal variables ordered
+-- injective instances. Let i and k be temporal variables ordered
 -- according to
 --
---   i < j < k
+--   i < k
 --
--- and let there be an edge from (i,u) to (k,w) for some indices u and v,
--- as well as an injective fact `f(t,...)` in the conclusion (i,u).
---
--- Then, we have a contradiction either if:
---  1) both the premises (k,w) and (j,v) are consuming and require a fact 'f(t,...)'.
---  2) both the conclusions (i,u) and (j,v) produce a fact `f(t,..)`.
---
--- In the first case, (k,w) and (j,v) would have to be merged, and in the second
--- case (i,u) and (j,v) would have to be merged, but the merging contradicts the
--- temporal orderings.
+-- and let there be an edge from (i,u) to (k,w) for some indices u and w
+-- corresponding to fact f(t,...).
+-- If:
+--    -  j<k & f(t,...) occurs at j in prems, then j<i (j<>i as in i f occurs in concs).
+--    -  i<j & f(t,...) occurs at j concs, then k<j.
 nonInjectiveFactInstances :: ProofContext -> System -> [(NodeId, NodeId)]
 nonInjectiveFactInstances ctxt se = do
     Edge c@(i, _) (k, _) <- S.toList $ get sEdges se
@@ -507,24 +466,23 @@ nonInjectiveFactInstances ctxt se = do
         kTag               = factTag kFaPrem
         kTerm              = firstTerm kFaPrem
         conflictingFact fa = factTag fa == kTag && firstTerm fa == kTerm
-        injFacts           = get pcInjectiveFactInsts ctxt
-    guard (kTag `S.member` {- S.map fst -} injFacts)  --TODO-Subterm when enabling subterms, add the map fst
+
+    guard (kTag `S.member` get pcInjectiveFactInsts ctxt)
 --    j <- S.toList $ D.reachableSet [i] less
     (j, _) <- M.toList $ get sNodes se
     -- check that j<k
     guard  (k `S.member` D.reachableSet [j] less)
-    let consumePrems ru = [p | p <- get rPrems ru, isConsumeFact p]
     let isCounterExample checkRule = (j /= i) && (j /= k) &&
                            maybe False checkRule (M.lookup j $ get sNodes se)
         checkRuleJK jRu    = (
                            -- check that f(t,...) occurs at j in prems and j<k
-                           any conflictingFact (consumePrems jRu ++ get rConcs jRu) &&
+                           any conflictingFact (get rPrems jRu ++ get rConcs jRu) &&
                            (k `S.member` D.reachableSet [j] less) &&
                             nonUnifiableNodes j i
                            )
         checkRuleIJ jRu    = (
                            -- check that f(t,...) occurs at j in concs and i<j
-                           any conflictingFact (consumePrems jRu ++ get rConcs jRu) &&
+                           any conflictingFact (get rPrems jRu ++  get rConcs jRu) &&
                            (j `S.member` D.reachableSet [i] less) &&
                             nonUnifiableNodes k j
                            )
@@ -551,4 +509,3 @@ addNonInjectiveFactInstances = do
   ctxt <- ask
   let list = nonInjectiveFactInstances ctxt se
   mapM_ (uncurry insertLess) list
-

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -136,7 +136,7 @@ dotNode v = dotOnce dsNodes v $ do
         nameAndActs =
             ruleInfo (prettyProtoRuleName . get praciName) prettyIntrRuleACInfo (get rInfo ru) <->
             brackets (vcat $ punctuate comma $ map prettyLNFact $ filter isNotDiffAnnotation $ get rActs ru)
-        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Consume ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
+        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
 
 -- | An edge from a rule node to its premises or conclusions.
 dotIntraRuleEdge :: D.NodeId -> D.NodeId -> SeDot ()
@@ -373,7 +373,7 @@ dotNodeCompact boringStyle v = dotOnce dsNodes v $ do
             (brackets $ vcat $ punctuate comma $
                 map prettyLNFact $ filter isNotDiffAnnotation $ get rActs ru)
 
-        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Consume ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
+        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
 
         renderRow annDocs =
           zipWith (\(ann, _) lbl -> (ann, lbl)) annDocs $
@@ -422,7 +422,7 @@ dotSystemCompact boringStyle se =
                       maybe False p (resolveNodeConcFact src se)
             attrs | check isProtoFact =
                       [("style","bold"),("weight","10.0")] ++
-                      (guard (check isReadOnlyFact) >> [("color","gray50")])
+                      (guard (check isPersistentFact) >> [("color","gray50")])
                   | check isKFact     = [("color","orangered2")]
                   | otherwise         = [("color","gray30")]
         dotGenEdge attrs src tgt

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -79,7 +79,7 @@ data JSONGraphNodeFact = JSONGraphNodeFact
       jgnFactId    :: String
     , jgnFactTag   :: String  -- ^ ProtoFact, FreshFact, OutFact, InFact, KUFact, KDFact, DedFact
     , jgnFactName  :: String  -- ^ Fr, Out, In, !KU, ...
-    , jgnFactMult  :: String  -- ^ "!" = readOnly, "" = consume
+    , jgnFactMult  :: String  -- ^ "!" = persistent, "" = linear
     , jgnFactTerms :: [JSONGraphNodeTerm]
     , jgnFactShow  :: String
     } deriving (Show)
@@ -216,8 +216,8 @@ itemToJSONGraphNodeFact pretty id' f =
                                           False -> show (factTag f)
                        , jgnFactName  = showFactTag $ factTag f
                        , jgnFactMult  = case factTagMultiplicity $ factTag f of
-                                          Consume  -> ""
-                                          ReadOnly -> "!"
+                                          Linear     -> ""
+                                          Persistent -> "!"
                        , jgnFactTerms = map (lntermToJSONGraphNodeTerm pretty) (factTerms f)
                        , jgnFactShow  = case pretty of
                                           True  -> pps $ prettyLNFact f
@@ -258,7 +258,7 @@ getRelationType src tgt se =
     let check p = maybe False p (resolveNodePremFact tgt se) ||
                   maybe False p (resolveNodeConcFact src se)
         relationType | check isKFact          = "KFact"
-                     | check isReadOnlyFact   = "ReadOnlyFact"
+                     | check isPersistentFact = "PersistentFact"
                      | check isProtoFact      = "ProtoFact"
                      | otherwise              = "default"
     in

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -29,8 +29,8 @@ module Theory.Model.Fact (
   , normFact
 
   -- ** Queries
-  , isConsumeFact
-  , isReadOnlyFact
+  , isLinearFact
+  , isPersistentFact
   , isProtoFact
   , isInFact
 
@@ -127,12 +127,12 @@ import           Text.PrettyPrint.Class
 -- Fact
 ------------------------------------------------------------------------------
 
-data Multiplicity = ReadOnly | Consume
+data Multiplicity = Persistent | Linear
                   deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
 
 -- | Fact tags/symbols
 data FactTag = ProtoFact Multiplicity String Int
-               -- ^ A protocol fact together with its multiplicity, name, and arity.
+               -- ^ A protocol fact together with its arity and multiplicity.
              | FreshFact  -- ^ Freshly generated value.
              | OutFact    -- ^ Sent by the protocol
              | InFact     -- ^ Officially known by the intruder/network.
@@ -142,7 +142,8 @@ data FactTag = ProtoFact Multiplicity String Int
                           -- a message using a construction rule.
              | TermFact   -- ^ internal fact, only used to convert terms to facts
                           -- to simplify computations. should never occur in a graph.
-    deriving( Show, Typeable, Data, Generic, NFData, Binary )
+    deriving( Eq, Ord, Show, Typeable, Data, Generic, NFData, Binary )
+
 
 -- | Annotations are properties thhat might be used elsewhere (e.g. in
 --   dot rendering, or for sorting by heuristics) but do not affect
@@ -161,39 +162,6 @@ data Fact t = Fact
 
 -- Instances
 ------------
-
--- Ignore "multiplicity" in equality and ord testing
-instance Eq FactTag where
-    (==) (ProtoFact _ name arity) (ProtoFact _ name' arity') = (name == name') && (arity == arity')
-    (==) FreshFact FreshFact = True
-    (==) OutFact   OutFact   = True
-    (==) InFact    InFact    = True
-    (==) KUFact    KUFact    = True
-    (==) KDFact    KDFact    = True
-    (==) DedFact   DedFact   = True
-    (==) TermFact  TermFact  = True
-    (==) _         _         = False
-
-instance Ord FactTag where
-    compare a b | a == b        = EQ
-    compare (ProtoFact _ name arity) (ProtoFact _ name' arity') = compare name name' <> compare arity arity'
-    compare ProtoFact{} _           = GT
-    compare _           ProtoFact{} = LT
-    compare FreshFact   _           = GT
-    compare _           FreshFact   = LT
-    compare OutFact     _           = GT
-    compare _           OutFact     = LT
-    compare InFact      _           = GT
-    compare _           InFact      = LT
-    compare KUFact      _           = GT
-    compare _           KUFact      = LT
-    compare KDFact      _           = GT
-    compare _           KDFact      = LT
-    compare DedFact     _           = GT
-    compare _           DedFact     = LT
-    compare TermFact    _           = GT
-    --compare _           TermFact    = LT  --redundant;)
-    
 
 -- Ignore annotations in equality and ord testing
 instance Eq t => Eq (Fact t) where
@@ -312,7 +280,7 @@ inFactAnn an = Fact InFact an . return
 
 -- | A fact logging that the intruder knows a message.
 kLogFact :: t -> Fact t
-kLogFact = protoFact Consume "K" . return
+kLogFact = protoFact Linear "K" . return
 
 -- | A fact logging that the intruder deduced a message using a construction
 -- rule. We use this to formulate invariants over normal dependency graphs.
@@ -366,21 +334,21 @@ protoOrOutFactView fa = case fa of
     Fact OutFact           _  _  -> errMalformed "protoOrOutFactView" fa
     _                            -> Nothing
 
--- | True if the fact is a Consume fact.
-isConsumeFact :: Fact t -> Bool
-isConsumeFact = (Consume ==) . factMultiplicity
+-- | True if the fact is a linear fact.
+isLinearFact :: Fact t -> Bool
+isLinearFact = (Linear ==) . factMultiplicity
 
--- | True if the fact is a ReadOnly fact.
-isReadOnlyFact :: Fact t -> Bool
-isReadOnlyFact = (ReadOnly ==) . factMultiplicity
+-- | True if the fact is a persistent fact.
+isPersistentFact :: Fact t -> Bool
+isPersistentFact = (Persistent ==) . factMultiplicity
 
 -- | The multiplicity of a 'FactTag'.
 factTagMultiplicity :: FactTag -> Multiplicity
 factTagMultiplicity tag = case tag of
     ProtoFact multi _ _ -> multi
-    KUFact              -> ReadOnly
-    KDFact              -> ReadOnly
-    _                   -> Consume
+    KUFact              -> Persistent
+    KDFact              -> Persistent
+    _                   -> Linear
 
 -- | The arity of a 'FactTag'.
 factTagArity :: FactTag -> Int
@@ -544,8 +512,8 @@ factTagName tag = case tag of
 showFactTag :: FactTag -> String
 showFactTag tag =
     (++ factTagName tag) $ case factTagMultiplicity tag of
-                             Consume  -> ""
-                             ReadOnly -> "!"
+                             Linear     -> ""
+                             Persistent -> "!"
 
 -- | Show a fact tag together with its aritiy.
 showFactTagArity :: FactTag -> String

--- a/lib/theory/src/Theory/Model/Restriction.hs
+++ b/lib/theory/src/Theory/Model/Restriction.hs
@@ -154,4 +154,4 @@ fromRuleRestriction rname f =
                 getBVarTerms =  map (varTerm . Free) . L.delete varNow . freesList
                 getVarTerms subst =   map (apply subst . varTerm) . L.delete varNow . freesList
                 -- produce fact from set of terms
-                mkFact = protoFactAnn Consume (restrPrefix ++ rname) S.empty
+                mkFact = protoFactAnn Linear (restrPrefix ++ rname) S.empty

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -960,7 +960,7 @@ someRuleACInstAvoidingFixing r s subst =
 addDiffLabel :: Rule a -> String -> Rule a
 addDiffLabel (Rule info prems concs acts nvs) name =
   Rule info prems concs
-    (acts ++ [Fact {factTag = ProtoFact Consume name 0,
+    (acts ++ [Fact {factTag = ProtoFact Linear name 0,
                     factAnnotations = S.empty, factTerms = []}]) nvs
 
 -- | Remove the diff label from a rule
@@ -969,7 +969,7 @@ removeDiffLabel (Rule info prems concs acts nvs) name =
     Rule info prems concs (filter isNotDiffAnnotation acts) nvs
   where
     isNotDiffAnnotation fa =
-      fa /= Fact {factTag = ProtoFact Consume name 0,
+      fa /= Fact {factTag = ProtoFact Linear name 0,
                   factAnnotations = S.empty, factTerms = []}
 
 -- | Add an action label to a rule
@@ -1030,7 +1030,7 @@ equalRuleUpToDiffAnnotation ru1@(Rule rn1 pr1 co1 ac1 nvs1) (Rule rn2 pr2 co2 ac
   rn1 == rn2 && pr1 == pr2 && co1 == co2 && nvs1 == nvs2 &&
   ac1 == filter isNotDiffAnnotation ac2
   where
-    isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Consume ("Diff" ++ getRuleNameDiff ru1) 0, factAnnotations = S.empty, factTerms = []})
+    isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Linear ("Diff" ++ getRuleNameDiff ru1) 0, factAnnotations = S.empty, factTerms = []})
 
 -- | Are these two rule instances equal up to an added diff annotation in @ac2@ or @ac1@?
 equalRuleUpToDiffAnnotationSym :: (HasRuleName (Rule a), Eq a) => Rule a -> Rule a -> Bool
@@ -1067,6 +1067,8 @@ equalRuleUpToDiffAnnotationSym ru1 ru2 = equalRuleUpToDiffAnnotation ru1 ru2
 -- A Fr fact is described
 --
 -- We track which symbols are not globally fresh.
+--
+-- All persistent facts are not globally fresh.
 --
 -- Adding a rule ru.
 --   All fact symbols that occur twice in the conclusion
@@ -1178,7 +1180,7 @@ prettyNamedRule prefix ppInfo ru =
     nest 2 (ppInfo $ L.get rInfo ru) --- $-$
     where
     acts             = filter isNotDiffAnnotation (L.get rActs ru)
-    isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Consume ("Diff" ++ getRuleNameDiff ru) 0, factAnnotations = S.empty, factTerms = []})
+    isNotDiffAnnotation fa = (fa /= Fact {factTag = ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0, factAnnotations = S.empty, factTerms = []})
     facts proj     = L.get proj ru
     ppAttributes = case ruleAttributes ru of
         []    -> text ""

--- a/lib/theory/src/Theory/Syntactic/Predicate.hs
+++ b/lib/theory/src/Theory/Syntactic/Predicate.hs
@@ -42,7 +42,7 @@ $(mkLabels [''Predicate])
 smallerFact :: t -> t -> Fact t
 smallerFact t1 t2 =
   Fact
-    { factTag = ProtoFact Consume "Smaller" 2,
+    { factTag = ProtoFact Linear "Smaller" 2,
       factAnnotations = S.empty,
       factTerms = [t1, t2]
     }

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -43,7 +43,6 @@ import           Text.Parsec                hiding ((<|>))
 import           Text.PrettyPrint.Class     (render)
 import           Theory
 import           Theory.Text.Parser.Token
-import           Rule
 
 import           Theory.Text.Parser.Accountability
 import           Theory.Text.Parser.Lemma

--- a/lib/theory/src/Theory/Text/Parser/Fact.hs
+++ b/lib/theory/src/Theory/Text/Parser/Fact.hs
@@ -39,11 +39,11 @@ factAnnotation = asum
 -- | Parse a fact that does not necessarily have a term in it.
 fact' :: Parser t -> Parser (Fact t)
 fact' pterm = try (
-    do multi <- option Consume (opBang *> pure ReadOnly)
+    do multi <- option Linear (opBang *> pure Persistent)
        i     <- identifier
        case i of
          []                -> fail "empty identifier"
-         (c:_) | isUpper c -> if (map toUpper i == "FR") && multi == ReadOnly then fail "fresh facts are not classified as ReadOnly or Consume" else return ()
+         (c:_) | isUpper c -> if (map toUpper i == "FR") && multi == Persistent then fail "fresh facts cannot be persistent" else return ()
                | otherwise -> fail "facts must start with upper-case letters"
        ts    <- parens (commaSep pterm)
        ann   <- option [] $ list factAnnotation

--- a/lib/theory/src/Theory/Text/Parser/Formula.hs
+++ b/lib/theory/src/Theory/Text/Parser/Formula.hs
@@ -35,7 +35,7 @@ smallerp varp = do
     unless mset (fail "Need builtins: multiset to use multiset comparisson operator.")
     a <- try (termp <* opLessTerm)
     b <- termp
-    return $ (Syntactic . Pred) $ protoFact Consume "Smaller" [a,b]
+    return $ (Syntactic . Pred) $ protoFact Linear "Smaller" [a,b]
   where
     termp =  msetterm False (vlit varp)
 

--- a/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
+++ b/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- |
 -- Copyright   : (c) 2012 Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -11,48 +9,22 @@
 -- Computate an under-approximation to the set of all facts with unique
 -- instances, i.e., fact whose instances never occur more than once in a
 -- state. We use this information to reason about protocols that exploit
--- exclusivity of facts.
+-- exclusivity of linear facts.
 module Theory.Tools.InjectiveFactInstances (
 
   -- * Computing injective fact instances.
-  MonotonicBehaviour(..)
-  , simpleInjectiveFactInstances
+  simpleInjectiveFactInstances
   ) where
 
 import           Extension.Prelude   (sortednub)
 
 -- import           Control.Applicative
 import           Control.Monad.Fresh
-import           Control.DeepSeq
-
-import           GHC.Generics        (Generic)
-import           Data.Label          as L
+import           Data.Label
 import qualified Data.Set            as S
-import qualified Data.Map            as M
-import           Data.List
-import           Data.Maybe
-import           Data.Binary
 import           Safe                (headMay)
-import           Control.Applicative (empty)
-import           Debug.Trace
 
 import           Theory.Model
---import Control.DeepSeq (NFData)
-
--- unspecified = there is no rule using this fact
--- unstable = increasing and decreasing or not at all related inputs and outputs
-data MonotonicBehaviour = Constant | Increasing | Decreasing | StrictlyIncreasing | StrictlyDecreasing | Unstable | Unspecified
-  deriving( Eq, Ord, Generic, NFData, Binary )
-
-instance Show MonotonicBehaviour where
-    show Constant = "="
-    show Increasing = "≤"
-    show Decreasing = "≥"
-    show StrictlyIncreasing = "<"
-    show StrictlyDecreasing = ">"
-    show Unstable = "."
-    show Unspecified = "?"
-
 
 -- | Compute a simple under-approximation to the set of facts with injective
 -- instances. A fact-tag is has injective instances, if there is no state of
@@ -60,140 +32,40 @@ instance Show MonotonicBehaviour where
 -- argument of the fact-tag.
 --
 -- We compute the under-approximation by checking that
--- for each occurrence of the fact-tag in a rule:
--- there is no other occurrence with the same first term and
---   (a) either there is a Fr-fact of the first term as a premise
---   (b) or there is exactly one consume fact-tag with the same first term in a premise
---
--- Additionally, we determine the term positions that are
--- - Constant
--- - Increasing/Decreasing according to `elemNotBelowReducible` and equality
--- - Strictly Increasing/Decreasing according to `elemNotBelowReducible`
---
--- Positions can also be inside tuples if these tuples are always explicitly used in the rules.
+-- (1) the fact-tag is linear,
+-- (2) every introduction of such a fact-tag is protected by a Fr-fact of the
+--     first term, and
+-- (3) every rule has at most one copy of this fact-tag in the conclusion and
+--     the first term arguments agree.
 --
 -- We exclude facts that are not copied in a rule, as they are already handled
 -- properly by the naive backwards reasoning.
-simpleInjectiveFactInstances :: [ProtoRuleE] -> S.Set FactTag  --TODO-Subterm when enabling subterms, change it to  FunSig -> [ProtoRuleE] -> S.Set (FactTag, [[MonotonicBehaviour]])
-simpleInjectiveFactInstances rules = S.fromList $ do  --TODO-Subterm when enabling subterms, add reducible before rules
-    tag <- M.keys shapes
-    let resultTag = combineAll (map (getInjectiveMon tag) rules) tag
-    case resultTag of
-      Just behaviours -> return tag --(tag, behaviours)  -- remove the 0-position from eqPos as this is the ~fr
-      Nothing -> empty
+simpleInjectiveFactInstances :: [ProtoRuleE] -> S.Set FactTag
+simpleInjectiveFactInstances rules = S.fromList $ do
+    tag <- candidates
+    guard (all (guardedSingletonCopy tag) rules)
+    return tag
   where
-
-    getPairTerms :: LNTerm -> [LNTerm]
-    getPairTerms (viewTerm2 -> FPair t1 t2) = t1 : getPairTerms t2
-    getPairTerms t = [t]
-
-    shapes :: M.Map FactTag [[MonotonicBehaviour]]  -- basic filtering and finding shape (the more fine-grained filtering one comes later)
-    shapes = M.fromListWith combineShapes $ do
+    candidates = sortednub $ do
         ru  <- rules
-        prem <- L.get rPrems ru
-        guard (not (null $ factTerms prem))
-        let tag = factTag prem
-        if factTagMultiplicity tag == ReadOnly
-          then return (tag, getShape prem)
-          else do
-            conc <- L.get rConcs ru
-            guard (factTag conc == tag)
-            return (tag, combineShapes (getShape conc) (getShape prem))
+        tag <- factTag <$> get rConcs ru
+        guard $    (factTagMultiplicity tag == Linear)
+                && (tag `elem` (factTag <$> get rPrems ru))
+        return tag
 
-        where
-          getShape :: LNFact -> [[MonotonicBehaviour]]
-          getShape (factTerms->_:terms) = map (flip replicate Unspecified . length . getPairTerms) terms
-          getShape _ = error "a fact without terms cannot be injective (as id is missing)"
-
-          combineShapes :: [[MonotonicBehaviour]] -> [[MonotonicBehaviour]] -> [[MonotonicBehaviour]]
-          combineShapes behaviours behaviours1 = map (map fst) $ zipWith zip behaviours behaviours1  -- zip automatically orients itself on the shorter list
-
-
-
-    combineAll :: [Maybe [[MonotonicBehaviour]]] -> FactTag -> Maybe [[MonotonicBehaviour]]
-    combineAll list _ | any isNothing list = Nothing  -- if any of the elements say that the tag is not injective, then return nothing
-    combineAll (Just behaviours : Just behaviours1 : rest) tag = --trace (show("combineAll", behaviours, behaviours1, (map (map combine) $ zipWith zip behaviours behaviours1))) $
-                                                                 combineAll (Just (map (map combine) $ zipWith zip behaviours behaviours1):rest) tag
-    combineAll [x] _ = x
-    combineAll [] tag = M.lookup tag shapes  --start with the empty shape of Unspecified
-    combineAll _ _ = error "the haskell compiler is too dumb to know that the pattern matching is actually exhaustive"
-
-    combine :: (MonotonicBehaviour, MonotonicBehaviour) -> MonotonicBehaviour
-    combine (x, y) | x == y = x
-    combine (Unstable, _) = Unstable
-    combine (_, Unstable) = Unstable
-    combine (Unspecified, y) = y
-    combine (x, Unspecified) = x
-    combine (StrictlyIncreasing, y) | y `elem` [Increasing, Constant] = Increasing
-    combine (StrictlyDecreasing, y) | y `elem` [Decreasing, Constant] = Decreasing
-    combine (StrictlyIncreasing, _) = Unstable  -- with [Strictly]Decreasing
-    combine (StrictlyDecreasing, _) = Unstable  -- with [Strictly]Increasing
-    combine (Increasing, Decreasing) = Unstable
-    combine (Increasing, Constant) = Increasing
-    combine (Decreasing, Constant) = Decreasing
-    combine (x, y) = combine (y, x)
-
-    -- | returns Nothing if the fact $tag$ violates injectivity guidelines in rule $ru$
-    -- otherwise, a list of MonotonicBehaviour is returned
-    --   - the list is nested such that it can capture terms in tuples
-    --   - i.e., if there are no tuples, a list of singletons is returned
-    -- all conclusions of the given FactTag have to fulfill that
-    getInjectiveMon :: FactTag -> ProtoRuleE -> Maybe [[MonotonicBehaviour]]
-    getInjectiveMon tag ru = --trace (show ("getInjectiveMon", tag, ru, map getInjectiveMonConc concs, map getInjectiveMonPrem prems)) $
-        combineAll (map getInjectiveMonConc concs {- ++ map getInjectiveMonPrem prems -}) tag
+    guardedSingletonCopy tag ru =
+        length copies <= 1 && all guardedCopy copies
       where
-        prems              = filter ((tag ==) . factTag) $ L.get rPrems ru
-        freshPrems         = filter ((FreshFact ==) . factTag) $ L.get rPrems ru
-        concs              = filter ((tag ==) . factTag) $ L.get rConcs ru
+        prems              = get rPrems ru
+        copies             = filter ((tag ==) . factTag) (get rConcs ru)
         firstTerm          = headMay . factTerms
 
-        -- duplicateFirstTerms are the first terms that appear at least twice - i.e. the corresponding fact cannot be injective
-        allFirstTerms = sort [t | c <- concs, let Just t = firstTerm c]
-        duplicateFirstTerms = S.fromList [a | (a, b) <- zip (drop 1 allFirstTerms) (take (length allFirstTerms - 1) allFirstTerms), a==b]
+        -- True if there is a first term and a premise guarding it
+        guardedCopy faConc = case firstTerm faConc of
+            Nothing    -> False
+            Just tConc -> freshFact tConc `elem` prems || guardedInPrems tConc
 
-        {-
-        -- DISABLED as we only concern the writing-chain for any injectiveness simplifications/contradictions)
-        -- advantage of disabling: we can often have a strictly increasing < instead of just increasing ≤
-        getInjectiveMonPrem :: LNFact -> Maybe [[MonotonicBehaviour]]
-        getInjectiveMonPrem (Fact t@(ProtoFact ReadOnly _ _) _ _) | tag == t = map (map $ const Constant) <$> M.lookup tag shapes
-        getInjectiveMonPrem _                                                = M.lookup tag shapes
-        -}
-
-        -- behaves like getInjectiveMon, but specific to one conclusion instead of all conclusions
-        getInjectiveMonConc :: LNFact -> Maybe [[MonotonicBehaviour]]
-        getInjectiveMonConc faConc = case firstTerm faConc of
-            Nothing                                           -> Nothing  -- cannot be an injective fact if it has no arguments
-            Just tConc | tConc `S.member` duplicateFirstTerms -> Nothing  -- violating (2)
-            Just tConc | freshFact tConc `elem` freshPrems    -> M.lookup tag shapes  -- applying (2)(a)
-            Just tConc -> case getPrem tConc of
-              Nothing                                         -> Nothing  -- violating (2)(b)
-              Just faPrem                                     -> Just behaviours
-                where
-                  shape = fromJust $ M.lookup tag shapes
-                  
-                  shapeTerm :: LNTerm -> Int -> [LNTerm]
-                  shapeTerm (viewTerm2 -> FPair t1 t2) x | x>1 = t1 : shapeTerm t2 (x-1)
-                  shapeTerm _ x | x>1 = error "shapeTerm: the term does not have enough pairs"
-                  shapeTerm t x | x==1 = [t]
-                  shapeTerm _ _ = error "shapeTerm: cannot take an integer with size less than 1" 
-                  
-                  trimmedPairTerms :: LNFact -> [[LNTerm]]
-                  trimmedPairTerms (factTerms->_:terms) = zipWith shapeTerm terms (map length shape)
-                  trimmedPairTerms _ = error "a fact with no terms cannot be injective"
-
-                  zipped = zipWith zip (trimmedPairTerms faPrem) (trimmedPairTerms faConc)
-
-                  getBehaviour :: (LNTerm, LNTerm) -> MonotonicBehaviour
-                  getBehaviour (t1, t2) | t1 == t2 = Constant
-                  --getBehaviour (t1, t2) | elemNotBelowReducible reducible t1 t2 = StrictlyIncreasing
-                  --getBehaviour (t1, t2) | elemNotBelowReducible reducible t2 t1 = StrictlyDecreasing  --TODO-Subterm when enabling subterms, uncomment these two lines
-                  getBehaviour _ = Unstable
-
-                  behaviours = --trace (show("zipped,final", zipped, map (map getBehaviour) zipped)) $
-                               map (map getBehaviour) zipped
-
-        -- get the corresponding fact in the premise
-        getPrem tConc = case (`filter` prems) (\faPrem -> factMultiplicity faPrem == Consume && Just tConc == firstTerm faPrem) of
-            [g] -> Just g
-            _   -> Nothing  -- if there are multiple such guards, the rule cannot be executed
+        -- True if there is a premise with the same tag and first term
+        guardedInPrems tConc = (`any` prems) $ \faPrem ->
+            factTag faPrem == tag && maybe False (tConc ==) (firstTerm faPrem)
 


### PR DESCRIPTION
Reverts tamarin-prover/tamarin-prover#481

@cascremers came up with an incompatibility with the traditional tamarin semantics:
```
 rule A: [ ]-->[ F('a') ] and B: [ !F(x) ]-->[] 
 ```
 Fires with the new semantics, but never with the old. This needs further discussion.