### PR TITLE
Fixed asiaccs20-eccDAA examples

### DIFF
--- a/examples/asiaccs20-eccDAA/CERTIFY/TPM_DAA_JoinCertify_with_fix_BSN.spthy
+++ b/examples/asiaccs20-eccDAA/CERTIFY/TPM_DAA_JoinCertify_with_fix_BSN.spthy
@@ -40,7 +40,7 @@ SP1 - Correctness
 SP7 - Authentication
 
   oracle_auth_aliveness_host_very_weak (all-traces): verified (4 steps)
-  oracle_auth_aliveness_host (all-traces): verified (1114 steps)
+  oracle_auth_aliveness_host (all-traces): verified (307 steps)
   oracle_auth_aliveness_issuer (all-traces): verified (4 steps)
   oracle_auth_weak_agreement_host (all-traces): verified (1789 steps)
   oracle_auth_non_injective_agreement_host_issuer (all-traces): verified (1790 steps)
@@ -179,7 +179,7 @@ equations:
 								
 			verifyCre2(
 				multp(r,P1), 			//A
-				multp(multp(~r,y),multp(f,P1)), 	//D
+				multp(multp(r,y),multp(f,P1)), 	//D
 				PkX(x,P2),				//X
 				plus(multp(x,multp(r,P1)),multp(multp(multp(r,x),y),multp(f,P1))),//C
 				P2)=accept

--- a/examples/asiaccs20-eccDAA/CERTIFY/TPM_DAA_JoinCertify_with_fix_noBSN.spthy
+++ b/examples/asiaccs20-eccDAA/CERTIFY/TPM_DAA_JoinCertify_with_fix_noBSN.spthy
@@ -38,7 +38,7 @@ SP1 - Correctness
 SP7 - Authentication
 
   oracle_auth_aliveness_host_very_weak (all-traces): verified (4 steps)
-  oracle_auth_aliveness_host (all-traces): verified (1114 steps)
+  oracle_auth_aliveness_host (all-traces): verified (307 steps)
   oracle_auth_aliveness_issuer (all-traces): verified (4 steps)
   oracle_auth_weak_agreement_host (all-traces): verified (1789 steps)
   oracle_auth_non_injective_agreement_host_issuer (all-traces): verified (1790 steps)
@@ -169,7 +169,7 @@ equations:
 								
 			verifyCre2(
 				multp(r,P1), 			//A
-				multp(multp(~r,y),multp(f,P1)), 	//D
+				multp(multp(r,y),multp(f,P1)), 	//D
 				PkX(x,P2),				//X
 				plus(multp(x,multp(r,P1)),multp(multp(multp(r,x),y),multp(f,P1))),//C
 				P2)=accept

--- a/examples/asiaccs20-eccDAA/QUOTE/TPM_DAA_JoinQuotePCR_with_fix_BSN.spthy
+++ b/examples/asiaccs20-eccDAA/QUOTE/TPM_DAA_JoinQuotePCR_with_fix_BSN.spthy
@@ -41,7 +41,7 @@ SP1 - Correctness
 SP7 - Authentication
   
   oracle_auth_aliveness_host_very_weak (all-traces): verified (4 steps)
-  oracle_auth_aliveness_host (all-traces): verified (611 steps)
+  oracle_auth_aliveness_host (all-traces): verified (213 steps)
   oracle_auth_aliveness_issuer (all-traces): verified (4 steps)
   oracle_auth_weak_agreement_host (all-traces): verified (1789 steps)
   oracle_auth_non_injective_agreement_host_issuer (all-traces): verified (1790 steps)
@@ -183,7 +183,7 @@ equations:
 								
 			verifyCre2(
 				multp(r,P1), 			//A
-				multp(multp(~r,y),multp(f,P1)), 	//D
+				multp(multp(r,y),multp(f,P1)), 	//D
 				PkX(x,P2),				//X
 				plus(multp(x,multp(r,P1)),multp(multp(multp(r,x),y),multp(f,P1))),//C
 				P2)=accept

--- a/examples/asiaccs20-eccDAA/QUOTE/TPM_DAA_JoinQuotePCR_with_fix_noBSN.spthy
+++ b/examples/asiaccs20-eccDAA/QUOTE/TPM_DAA_JoinQuotePCR_with_fix_noBSN.spthy
@@ -36,7 +36,7 @@ SP1 - Correctness
 SP7 - Authentication
   
   oracle_auth_aliveness_host_very_weak (all-traces): verified (4 steps)
-  oracle_auth_aliveness_host (all-traces): verified (611 steps)
+  oracle_auth_aliveness_host (all-traces): verified (213 steps)
   oracle_auth_aliveness_issuer (all-traces): verified (4 steps)
   oracle_auth_weak_agreement_host (all-traces): verified (1789 steps)
   oracle_auth_non_injective_agreement_host_issuer (all-traces): verified (1790 steps)
@@ -157,7 +157,7 @@ equations:
 								
 			verifyCre2(
 				multp(r,P1), 			//A
-				multp(multp(~r,y),multp(f,P1)), 	//D
+				multp(multp(r,y),multp(f,P1)), 	//D
 				PkX(x,P2),				//X
 				plus(multp(x,multp(r,P1)),multp(multp(multp(r,x),y),multp(f,P1))),//C
 				P2)=accept

--- a/examples/asiaccs20-eccDAA/SIGN/TPM_DAA_JoinSign_withFix_BSN.spthy
+++ b/examples/asiaccs20-eccDAA/SIGN/TPM_DAA_JoinSign_withFix_BSN.spthy
@@ -37,7 +37,7 @@ SP1 - Correctness
   
 SP7 - Authentication
   oracle_auth_aliveness_host_very_weak (all-traces): verified (4 steps)
-  oracle_auth_aliveness_host (all-traces): verified (611 steps)
+  oracle_auth_aliveness_host (all-traces): verified (213 steps)
   oracle_auth_aliveness_issuer (all-traces): verified (4 steps)
   oracle_auth_weak_agreement_host (all-traces): verified (1945 steps)
   oracle_auth_non_injective_agreement_host_issuer (all-traces): verified (1946 steps)
@@ -48,10 +48,10 @@ SP2 - User Controlled Linkability
   auto_SP2_UserControlledLinkability (all-traces): verified (2 steps)
 
 SP3 - Unforgeability
-  oracle_SP3_Unforgeability (all-traces): verified (1326 steps)
+  oracle_SP3_Unforgeability (all-traces): verified (1328 steps)
   
 SP4 - Non-frameability
-  oracle_SP4_NonFrameability (all-traces): verified (1206 steps)
+  oracle_SP4_NonFrameability (all-traces): verified (830 steps)
 
 ==============================================================================
 
@@ -193,7 +193,7 @@ equations:
 								
 			verifyCre2(
 				multp(r,P1), 			//A
-				multp(multp(~r,y),multp(f,P1)), 	//D
+				multp(multp(r,y),multp(f,P1)), 	//D
 				PkX(x,P2),				//X
 				plus(multp(x,multp(r,P1)),multp(multp(multp(r,x),y),multp(f,P1))),//C
 				P2)=accept

--- a/examples/asiaccs20-eccDAA/SIGN/TPM_DAA_JoinSign_withFix_noBSN.spthy
+++ b/examples/asiaccs20-eccDAA/SIGN/TPM_DAA_JoinSign_withFix_noBSN.spthy
@@ -36,7 +36,7 @@ SP1 - Correctness
 SP7 - Authentication
 
   oracle_auth_aliveness_host_very_weak (all-traces): verified (4 steps)
-  oracle_auth_aliveness_host (all-traces): verified (611 steps)
+  oracle_auth_aliveness_host (all-traces): verified (213 steps)
   oracle_auth_aliveness_issuer (all-traces): verified (4 steps)
   oracle_auth_weak_agreement_host (all-traces): verified (1945 steps)
   oracle_auth_non_injective_agreement_host_issuer (all-traces): verified (1946 steps)
@@ -45,7 +45,7 @@ SP7 - Authentication
 
 SP3 - Unforgeability
 
-  oracle_SP3_Unforgeability (all-traces): verified (1093 steps)
+  oracle_SP3_Unforgeability (all-traces): verified (1095 steps)
 ==============================================================================
 
 */
@@ -183,7 +183,7 @@ equations:
 								
 			verifyCre2(
 				multp(r,P1), 			//A
-				multp(multp(~r,y),multp(f,P1)), 	//D
+				multp(multp(r,y),multp(f,P1)), 	//D
 				PkX(x,P2),				//X
 				plus(multp(x,multp(r,P1)),multp(multp(multp(r,x),y),multp(f,P1))),//C
 				P2)=accept


### PR DESCRIPTION
The main examples from the `asiaccs20-eccDAA` folder (i.e. the ones without observational equivalence) each used `~` inside an equation, which doesn't seem to make much sense at that point. This PR fixes that error.

All lemmas still get the same results, but for some the number of steps differs:

- For the `CERTIFY` examples, the lemma `oracle_auth_aliveness_host` now takes 307 steps (was 1114 before)
- For the `QUOTE` examples, the same lemma now takes 213 steps (was 611 before)
- For the `SIGN` examples, the same lemma now also takes 213 steps (also 611 before). Additionally, the lemma `oracle_SP3_Unforgeability` takes two steps more in each example, and the lemma `oracle_SP4_NonFrameability` in the BSN example now takes 830 steps (was 1206 before)