### PR TITLE
Allow Maude 3.2.2

### DIFF
--- a/src/Main/Environment.hs
+++ b/src/Main/Environment.hs
@@ -218,7 +218,7 @@ ensureMaude as = do
 
 --  Maude versions prior to 2.7.1 are no longer supported,
 --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1"]
+    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
All self tests are passing. Below are the results of regression tests:

```
$ python regressionTests.py -noi
running 'make -j 1 fast-case-studies FAST=y 2>/dev/null' ...
The time changed from         0.04s to      5.78s in /fast-tests/csf12/KAS2_original_analyzed.spthy
  The steps changed from  246 steps to  254 steps in KAS_key_secrecy
The time changed from         0.04s to     22.74s in /fast-tests/csf12/DH2_original_analyzed.spthy
  The steps changed from  501 steps to  503 steps in KAS_key_secrecy
The time changed from         0.03s to      0.08s in /fast-tests/loops/Minimal_Loop_Example_analyzed.spthy
  The steps changed from   12 steps to   14 steps in Stop_unique
The time changed from         0.04s to      0.22s in /fast-tests/loops/Typing_and_Destructors_analyzed.spthy
  The steps changed from   14 steps to   17 steps in Responder_secrecy
The time changed from         0.05s to     14.51s in /fast-tests/related_work/YubiSecure_KS_STM12/Yubikey_analyzed.spthy
  The steps changed from 1141 steps to 1145 steps in slightly_weaker_invariant
The time changed from         0.03s to      4.68s in /fast-tests/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset_analyzed.spthy
  The steps changed from  119 steps to  132 steps in slightly_weaker_invariant
The time changed from         0.03s to      1.46s in /fast-tests/features/multiset/counter_analyzed.spthy
  The steps changed from   50 steps to   52 steps in counters_linear_order
  The steps changed from   44 steps to   58 steps in counter_increases
  The steps changed from   25 steps to   26 steps in lesser_senc_secret
The time changed from         0.04s to      1.65s in /fast-tests/csf18-xor/KCL07_analyzed.spthy
  The steps changed from  113 steps to  128 steps in recentalive_tag
The time changed from         0.04s to     16.28s in /fast-tests/csf18-xor/LAK06_analyzed.spthy
  The steps changed from 2082 steps to 2148 steps in noninjectiveagreementTAG

--------------------------------------------------------------------------------

The total amount of time  changed from 3s to 718s - this is 22401%
The total amount of steps changed from 18858 steps to 18988 steps - this is 100%

Time elapsed: 0:08:17s
```