### PR TITLE
Output module fix

### DIFF
--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -66,8 +66,6 @@ import           Paths_tamarin_prover (version)
 
 import           Language.Haskell.TH
 import           Development.GitRev
-import           Theory.Module
-import           Data.List
 
 ------------------------------------------------------------------------------
 -- Static constants for the tamarin-prover
@@ -78,9 +76,9 @@ gitVersion :: String
 gitVersion = concat
   [ "Git revision: "
     , $(gitHash)
-    , case $(gitDirty) of
-          True  -> " (with uncommited changes)"
-          False -> ""
+    , if $(gitDirty) then
+          " (with uncommited changes)"
+      else ""
     , ", branch: "
     , $(gitBranch)
   ]

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -317,13 +317,15 @@ loadTheory thyOpts input inFile = do
 
     parse p = parseString (toParserFlags thyOpts) inFile p input
 
-    translate | isParseOnlyMode = return
+    translate | isParseOnlyMode && not (isMSRModule) = return
               | otherwise       = Sapic.typeTheory
                               >=> Sapic.translate
                               >=> Acc.translate
 
     isDiffMode      = L.get oDiffMode thyOpts
     isParseOnlyMode = L.get oParseOnlyMode thyOpts
+    isMSRModule  = L.get oOutputModule thyOpts == Just ModuleMsr
+
 
     unwrapError (Left (Left e)) = Left e
     unwrapError (Left (Right v)) = Right $ Left v


### PR DESCRIPTION
option -m=msr set parseonlyflags to true, which disabled the sapic translation, and thus produced an empty output.

A fix proposal, but not nice clean up of the global CLI thingy, which is probably what would be needed.
@rkunnema 