### PR TITLE
Remove warnings and some linting in SAPIC.

### DIFF
--- a/lib/sapic/src/Sapic/Annotation.hs
+++ b/lib/sapic/src/Sapic/Annotation.hs
@@ -85,15 +85,17 @@ mayMerge Nothing Nothing = Nothing
 
 instance Monoid (ProcessAnnotation v) where
     mempty = ProcessAnnotation mempty mempty mempty mempty Nothing True False mempty Nothing
-    mappend p1 p2 = ProcessAnnotation
-        (parsingAnn p1 `mappend` parsingAnn p2)
-        (lock p1 `mappend` lock p2)
-        (unlock p1 `mappend` unlock p2)
-        (secretChannel p1 `mappend` secretChannel p2)
+
+instance Semigroup (ProcessAnnotation v) where
+  (<>)  p1 p2 = ProcessAnnotation
+        (parsingAnn p1 <> parsingAnn p2)
+        (lock p1 <> lock p2)
+        (unlock p1 <> unlock p2)
+        (secretChannel p1 <> secretChannel p2)
         (mayMerge (destructorEquation p1) (destructorEquation p2))
         (elseBranch p2)
         (pureState p1 || pureState p2)
-        (stateChannel p1 `mappend` stateChannel p2)
+        (stateChannel p1 <> stateChannel p2)
         (mayMerge (isStateChannel p1) (isStateChannel p2))
 
 getProcessNames :: GoodAnnotation ann => ann -> [String]
@@ -102,17 +104,13 @@ getProcessNames = processnames . getProcessParsedAnnotation
 setProcessNames :: GoodAnnotation a => [String] -> a -> a
 setProcessNames pn = mappendProcessParsedAnnotation (mempty {processnames = pn})
 
-
-instance Semigroup (ProcessAnnotation v) where
-    (<>) =  mappend
-
 instance (Apply s SapicTerm) => (Apply s (ProcessAnnotation v)) where
     apply = applyAnn
 
 newtype AnnotatedProcess = LProcess (ProcessAnnotation LVar)
     deriving (Typeable, Monoid,Semigroup,Show)
 
-data AnProcess ann = AnProcess (LProcess ann)
+newtype AnProcess ann = AnProcess (LProcess ann)
     deriving (Typeable, Show)
 
 -- This instance is useful for modifying annotations, but not for much more.
@@ -153,4 +151,4 @@ toAnProcess = unAnProcess . fmap f . AnProcess
 toProcess :: GoodAnnotation an => LProcess an -> PlainProcess
 toProcess = unAnProcess . fmap f . AnProcess
     where
-        f l = getProcessParsedAnnotation l
+        f = getProcessParsedAnnotation

--- a/lib/sapic/src/Sapic/Locks.hs
+++ b/lib/sapic/src/Sapic/Locks.hs
@@ -38,11 +38,11 @@ annotateEachClosestUnlock t v (ProcessAction (Unlock t') a' p) =
                 return $ ProcessAction (Unlock t') (a' <> annUnlock v) p
             else do
                 p' <- annotateEachClosestUnlock t v p
-                return $ProcessAction (Unlock t') a' p'
+                return $ ProcessAction (Unlock t') a' p'
 annotateEachClosestUnlock t v (ProcessAction (Insert t1 t2) a' p) | t1==t =
                do
                 p' <- annotateEachClosestUnlock t v p
-                return $ProcessAction (Insert t1 t2)  (a' <> annUnlock v) p'
+                return $ ProcessAction (Insert t1 t2)  (a' <> annUnlock v) p'
 annotateEachClosestUnlock _ _ (ProcessAction Rep _ _) = throwM $ LocalException WFRep
 annotateEachClosestUnlock _ _ (ProcessComb Parallel _ _ _) = throwM $ LocalException WFPar
 annotateEachClosestUnlock t v (ProcessAction ac a' p) = do p' <- annotateEachClosestUnlock t v p

--- a/lib/theory/src/Theory/Constraint/Solver/Sources.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Sources.hs
@@ -35,7 +35,6 @@ module Theory.Constraint.Solver.Sources (
 import           Prelude                                 hiding (id, (.))
 import           Safe
 
-import           Data.Foldable                           (asum)
 import qualified Data.Map                                as M
 import qualified Data.Set                                as S
 

--- a/lib/theory/src/Theory/Constraint/System/Guarded.hs
+++ b/lib/theory/src/Theory/Constraint/System/Guarded.hs
@@ -107,8 +107,6 @@ import           Text.PrettyPrint.Highlight
 
 import           Theory.Model
 
-import           Data.Functor.Identity
-
 -- Control.Monad.Fail import will become redundant in GHC 8.8+
 -- import qualified Control.Monad.Fail as Fail
 

--- a/lib/theory/src/Theory/Text/Parser.hs
+++ b/lib/theory/src/Theory/Text/Parser.hs
@@ -28,7 +28,6 @@ module Theory.Text.Parser (
   ) where
 
 import           Prelude                    hiding (id, (.))
-import           Data.Foldable              (asum)
 import           Data.Label
 import           Data.Maybe
 -- import           Data.Monoid                hiding (Last)

--- a/lib/theory/src/Theory/Text/Parser/Formula.hs
+++ b/lib/theory/src/Theory/Text/Parser/Formula.hs
@@ -15,7 +15,6 @@ module Theory.Text.Parser.Formula
   )
 where
 import           Prelude                    hiding (id, (.))
-import           Data.Foldable              (asum)
 -- import           Data.Monoid                hiding (Last)
 import           Control.Applicative        hiding (empty, many, optional)
 import           Control.Category

--- a/lib/theory/src/Theory/Text/Parser/Lemma.hs
+++ b/lib/theory/src/Theory/Text/Parser/Lemma.hs
@@ -17,8 +17,6 @@ module Theory.Text.Parser.Lemma(
 where
 
 import           Prelude                    hiding (id, (.))
-import           Data.Foldable              (asum)
--- import           Data.Monoid                hiding (Last)
 import           Control.Applicative        hiding (empty, many, optional)
 import           Text.Parsec                hiding ((<|>))
 import           Theory

--- a/lib/theory/src/Theory/Text/Parser/Proof.hs
+++ b/lib/theory/src/Theory/Text/Parser/Proof.hs
@@ -15,7 +15,6 @@ module Theory.Text.Parser.Proof (
 where
 
 import           Prelude                    hiding (id, (.))
-import           Data.Foldable              (asum)
 import qualified Data.Map                   as M
 -- import           Data.Monoid                hiding (Last)
 import           Control.Applicative        hiding (empty, many, optional)

--- a/lib/theory/src/Theory/Text/Parser/Rule.hs
+++ b/lib/theory/src/Theory/Text/Parser/Rule.hs
@@ -21,7 +21,6 @@ where
 import           Prelude                    hiding (id, (.))
 import qualified Data.ByteString            as B
 import qualified Data.ByteString.Char8      as BC
-import           Data.Foldable              (asum)
 import           Data.Label
 import           Data.Either
 import           Data.Maybe

--- a/lib/theory/src/Theory/Text/Parser/Signature.hs
+++ b/lib/theory/src/Theory/Text/Parser/Signature.hs
@@ -25,7 +25,6 @@ where
 
 import           Prelude                    hiding (id)
 import qualified Data.ByteString.Char8      as BC
-import           Data.Foldable              (asum)
 import           Data.Either
 -- import           Data.Monoid                hiding (Last)
 import qualified Data.Set                   as S

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -117,7 +117,6 @@ module Theory.Text.Parser.Token (
 
 import           Prelude             hiding (id, (.))
 
-import           Data.Foldable       (asum)
 -- import           Data.Label
 -- import           Data.Binary
 import           Data.List (foldl')

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,8 +7,10 @@ packages:
 - lib/sapic/
 - lib/export/
 - lib/accountability/
-resolver: lts-19.32
+resolver: lts-20.12
 ghc-options:
   "$everything": -Wall
 nix:
   packages: [ zlib ]
+
+


### PR DESCRIPTION
This PR removes many compile-time warnings throughout and does some code cleanup following hlint's suggestions in the SAPIC packages.

1. https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid Semigroup is now a superclass of monoid, so some instance definitions needed to be reformulated to define Semigroup's `<>` instead of Monoid `mappend`.
2. Many redundant imports resulting from the Parser refactoring a while ago.
3. Some incomplete pattern matches.

There are still too many warnings left, but those in SAPIC have been removed except for one.