### PR TITLE
Updated Stack to LTS 20-12 (GHC 9.2.6).

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,8 +7,10 @@ packages:
 - lib/sapic/
 - lib/export/
 - lib/accountability/
-resolver: lts-19.32
+resolver: lts-20.12
 ghc-options:
   "$everything": -Wall
 nix:
   packages: [ zlib ]
+
+


### PR DESCRIPTION
Hi!

Between these issues
https://gitlab.haskell.org/ghc/ghc/-/issues/20592
https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8437
(and probably others that I do not recall), I had trouble finding a Stack LTS version that works on Mac M1 with the latest OS version and which also has support for haskell-language-server. This one works. If it does not break anyone else's configuration, I propose we update.