### PR TITLE
SAPIC: translate processes by default

### DIFF
--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -253,10 +253,8 @@ mkTheoryLoadOptions as = TheoryLoadOptions
     autoSources   = return $ argExists "auto-sources" as
 
     outputModule
-    -- when proving, we act like we chose the Msr Output module.
-     | Nothing  <- findArg "outModule" as , [] /= findArg "prove" as = return $ Just ModuleMsr
-    -- default
-     | Nothing  <- findArg "outModule" as = return $ Just ModuleSpthy
+    -- MSR is default module, i.e., we translate by default ... otherwise we get warnings for actions used in lemmas that appear only in processes.
+     | Nothing  <- findArg "outModule" as = return $ Just ModuleMsr
      -- Otherwise, find output module  that matches string argument
      | Just str <- findArg "outModule" as
      , Just modCon <- find (\x -> show x  == str) (enumFrom minBound) = return $ Just modCon
@@ -336,7 +334,6 @@ loadTheory thyOpts input inFile = do
 
     isDiffMode   = L.get oDiffMode thyOpts
     isMSRModule  = L.get oOutputModule thyOpts == Just ModuleMsr
-
 
     unwrapError (Left (Left e)) = Left e
     unwrapError (Left (Right v)) = Right $ Left v

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,8 +7,10 @@ packages:
 - lib/sapic/
 - lib/export/
 - lib/accountability/
-resolver: lts-19.32
+resolver: lts-20.12
 ghc-options:
   "$everything": -Wall
 nix:
   packages: [ zlib ]
+
+


### PR DESCRIPTION
Calling `tamarin-prover file.spthy` currently pretty-prints the theory, including processes, but may print out warnings when lemmas refer to events that occur in the process, but in no MSR. This PR fixes this by defaulting to translating processes to MSRs, so these warnings are avoided.

(Includes https://github.com/tamarin-prover/tamarin-prover/pull/529 so my local tests correspond to the PR.)