### PR TITLE
Make proof tree more readable when going wide

### DIFF
--- a/data/css/tamarin-prover-ui.css
+++ b/data/css/tamarin-prover-ui.css
@@ -501,6 +501,7 @@ h4 {
     right: 0em;
     padding: 0em;
     overflow: auto;
+    white-space: nowrap;
 }
 
 #ui-main-display, #ui-debug-display, #proof {


### PR DESCRIPTION
Small css change to keep me sane.

With change:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/9728715/227979839-5fd3bfd6-93a5-4853-a99a-7a1fea283eaa.png">

Without change:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/9728715/227980081-12da8f73-6fdb-4eb4-b175-d84755f2c5a1.png">
