### PR TITLE
gitignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ stack.yaml.lock
 
 *.iml
 .idea/
+.vscode/
 out/
 
 *.pv


### PR DESCRIPTION
Visual Studio Code is a very common IDE and I suggest ignoring its config folder. The gitignore already lists `.idea/` which similarly is an IDE settings folder (JetBrains).