### PR TITLE
Sapic fixes diverse

### DIFF
--- a/examples/sapic/export/ExistingSapicModels/AC_counter_with_attack.spthy
+++ b/examples/sapic/export/ExistingSapicModels/AC_counter_with_attack.spthy
@@ -53,8 +53,8 @@ lemma can_run_v: //for sanity
 	"Ex #t h .Voutput(h)@t"
 */
 
+/* attack  expected to be found */
 lemma attested_comput_second_step:
-    exists-trace
-	"not(All #t1 o2 i2 o i.  Voutput(<o2,i2,<o,list(i,'init')>>)@t1 ==> (Ex #t2 . Poutput(<o2,i2,<o,list(i,'init')>>)@t2 & t2<t1))"
+	"All #t1 o2 i2 o i.  Voutput(<o2,i2,<o,list(i,'init')>>)@t1 ==> (Ex #t2 . Poutput(<o2,i2,<o,list(i,'init')>>)@t2 & t2<t1)"
 
 end

--- a/examples/sapic/export/SSH/ssh-with-forwarding-bounded.spthy
+++ b/examples/sapic/export/SSH/ssh-with-forwarding-bounded.spthy
@@ -118,12 +118,12 @@ let remoteP(pkS,~remote:channel) =
 		let <lvl,ms,'sign_req'> = sdec(signreq,kSP) in
                 out(senc(<nest(lvl),ms,'sign_req'>,kSP2));
 		in(signans2);
-		let <sig3,lvl,'sign_ans'> = sdec(signans2,kPS2) in
+		let <sig3,lvlr,'sign_ans'> = sdec(signans2,kPS2) in
                 // let <lvlf3,dump3>= getMess(sig3) in
 //     	        if issign(sig3,pkP)=true then
 //		if isnest(lvl) = true then
 		event Test(sig3);
-		out(senc( <sig3,lvl,'sign_ans'>,kPS))
+		out(senc( <sig3,lvlr,'sign_ans'>,kPS))
 
 		)
 		)

--- a/examples/sapic/export/ex1.spthy
+++ b/examples/sapic/export/ex1.spthy
@@ -20,7 +20,7 @@ equations: bij(unbij(x))=x
 export queries :
  "
  (* This query was added manualy, and the other one automatically from the lemmas. *)
- query x:bitstring; event(Secret(x)) && (attacker(x)).
+ query x:bitstring; event(eSecret(x)) && (attacker(x)).
  "
 
 let P = new a; event Secret(a); out (senc(<a,'test'>,sk))

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -1077,7 +1077,8 @@ loadHeaders tc thy typeEnv = do
       foldl
         ( \y x -> case List.lookup x builtins of
             Nothing -> case x of
-              "multiset"         -> throw UnsupportedBuiltinMS
+              "multiset"         -> -- on the long run, this should throw UnsupportedBuiltinMS, but we currently allow to use multiset in a restricted fashion
+                translationWarning "you are using in the Sapic model the multiset builtin. Unless you are only using it to model natural numbers, this may result in a failure of the translation." y
               "bilinear-pairing" -> throw UnsupportedBuiltinBP
               _                  -> y
             Just t -> y `S.union` t


### PR DESCRIPTION
A few minor fixes for Sapic, including example fix:
 * fix overly strong error reporting when trying to use multiset
 * fix examples with respect to newly raised errors.