### PR TITLE
Remove duplicates in clashes check

### DIFF
--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -150,7 +150,7 @@ clashesOn :: (Ord b, Ord c)
 clashesOn f g xs = do
     grp <- groupOn f $ sortOn f xs
     guard (length (sortednubOn g grp) >= 2)
-    return grp
+    return $ sortednubOn g grp
 
 -- | Nice quoting.
 quote :: String -> String


### PR DESCRIPTION
This PR removes duplicates when checking for clashes (public names, fact usage, ...).

Prior to this PR, the following theory

```
theory Clashes

begin

rule Init:
  [] --[ Init('c') ]-> [ Init('c') ]

rule Next:
  [ ] --[ Next('C') ]-> [ Next('C') ]

rule End:
  [ Next('C', 'D') ] --> [ ]

end
```

produced the following warnings with duplicates

```
/*
WARNING: the following wellformedness checks failed!

public names with mismatching capitalization:
  1. rule "Init" name 'c', rule "Init" name 'c',
     rule "Next" name 'C', rule "Next" name 'C', rule "End" name 'C'

Fact usage:
  1. Rule `Next', fact "next": ("Next",1,Linear)
       Next( 'C' )
  
  2. Rule `Next', fact "next": ("Next",1,Linear)
       Next( 'C' )
  
  3. Rule `End', fact "next": ("Next",2,Linear)
       Next( 'C', 'D' )
*/
```

With this PR, the duplicates are removed.

```
/*
WARNING: the following wellformedness checks failed!

public names with mismatching capitalization:
  1. rule "Next" name 'C', rule "Init" name 'c'

Fact usage:
  1. Rule `Next', fact "next": ("Next",1,Linear)
       Next( 'C' )
  
  2. Rule `End', fact "next": ("Next",2,Linear)
       Next( 'C', 'D' )
*/
```