### PR TITLE
Allow maude 3.3 and 3.3.1

### DIFF
--- a/src/Main/Environment.hs
+++ b/src/Main/Environment.hs
@@ -218,7 +218,7 @@ ensureMaude as = do
 
 --  Maude versions prior to 2.7.1 are no longer supported,
 --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2"]
+    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
Both versions pass regressionTests.py suite.