### PR TITLE
Allow Maude 3.3 and 3.3.1

### DIFF
--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -169,7 +169,7 @@ ensureMaude as = do
 
 --  Maude versions prior to 2.7.1 are no longer supported,
 --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2"]
+    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
This PR supersedes https://github.com/tamarin-prover/tamarin-prover/pull/544 which now has a conflict.

I tested both versions of Maude locally without issues.