### PR TITLE
Simplify the arrows of visualization in interactive mode 

### DIFF
--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -151,7 +151,7 @@ var ui = {
             $.cookie("not-init",null,{path: "/"});
         }
 
-        $.cookie("simplification", 1, { path: '/' });
+        $.cookie("simplification", 2, { path: '/' });
         // Navigation drop-down menus
         $("ul#navigation").superfish();
 
@@ -352,7 +352,7 @@ var ui = {
 
 	/* If no simplification level specified yet, default to 1 */
 	if ($.cookie("simplification") == null) {
-	    $.cookie("simplification", 1, { path: '/' });
+	    $.cookie("simplification", 2, { path: '/' });
 	}
 	/* Add buttons for each of the simplification levels */
 	for (var i=0;i<4;i++) {

--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -146,11 +146,12 @@ var ui = {
         // Load display settings
         this.loadSettings();
 
-        // initialize thz cookie for not-init
+        // initialize the cookie for not-init
         if ($.cookie("not-init")) {
             $.cookie("not-init",null,{path: "/"});
         }
 
+        $.cookie("simplification", 1, { path: '/' });
         // Navigation drop-down menus
         $("ul#navigation").superfish();
 
@@ -351,10 +352,10 @@ var ui = {
 
 	/* If no simplification level specified yet, default to 1 */
 	if ($.cookie("simplification") == null) {
-	    $.cookie("simplification", 10, { path: '/' });
+	    $.cookie("simplification", 1, { path: '/' });
 	}
 	/* Add buttons for each of the simplification levels */
-	for (var i=0;i<10;i++) {
+	for (var i=0;i<4;i++) {
 	    var linkname = "a#lvl"+i+"-toggle";
 	    if (parseInt($.cookie("simplification")) == i) {
                 $(linkname).addClass("active-option");

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -256,7 +256,7 @@ solveAction rules (i, fa@(Fact _ ann _)) = do
     requiresKU t = do
         j <- freshLVar "vk" LSortNode
         let faKU = kuFact t
-        insertLess j i "user-specified"
+        insertLess j i NormalForm
         void (insertAction j faKU)
 
 -- | CR-rules *DG_{2,P}* and *DG_{2,d}*: solve a premise with a direct edge

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -256,7 +256,7 @@ solveAction rules (i, fa@(Fact _ ann _)) = do
     requiresKU t = do
         j <- freshLVar "vk" LSortNode
         let faKU = kuFact t
-        insertLess j i Formula
+        insertLess j i Adversary
         void (insertAction j faKU)
 
 -- | CR-rules *DG_{2,P}* and *DG_{2,d}*: solve a premise with a direct edge

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -256,7 +256,7 @@ solveAction rules (i, fa@(Fact _ ann _)) = do
     requiresKU t = do
         j <- freshLVar "vk" LSortNode
         let faKU = kuFact t
-        insertLess j i
+        insertLess j i "user-specified"
         void (insertAction j faKU)
 
 -- | CR-rules *DG_{2,P}* and *DG_{2,d}*: solve a premise with a direct edge

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -256,7 +256,7 @@ solveAction rules (i, fa@(Fact _ ann _)) = do
     requiresKU t = do
         j <- freshLVar "vk" LSortNode
         let faKU = kuFact t
-        insertLess j i NormalForm
+        insertLess j i Formula
         void (insertAction j faKU)
 
 -- | CR-rules *DG_{2,P}* and *DG_{2,d}*: solve a premise with a direct edge

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -264,7 +264,7 @@ labelNodeId = \i rules parent -> do
           -- corresponding KU-actions before this node.
         _ | isKUFact fa -> do
               j <- freshLVar "vk" LSortNode
-              insertLess j i NormalForm
+              insertLess j i Adversary
               void (insertAction j fa)
 
           -- Store premise goal for later processing using CR-rule *DG2_2*
@@ -386,7 +386,7 @@ insertAction i fa@(Fact _ ann _) = do
     requiresKU t = do
       j <- freshLVar "vk" LSortNode
       let faKU = kuFactAnn ann t
-      insertLess j i NormalForm
+      insertLess j i Adversary
       void (insertAction j faKU)
 
 -- | Insert a 'Less' atom. @insertLess i j@ means that *i < j* is added.

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -264,7 +264,7 @@ labelNodeId = \i rules parent -> do
           -- corresponding KU-actions before this node.
         _ | isKUFact fa -> do
               j <- freshLVar "vk" LSortNode
-              insertLess j i "user-specified"
+              insertLess j i NormalForm
               void (insertAction j fa)
 
           -- Store premise goal for later processing using CR-rule *DG2_2*
@@ -386,7 +386,7 @@ insertAction i fa@(Fact _ ann _) = do
     requiresKU t = do
       j <- freshLVar "vk" LSortNode
       let faKU = kuFactAnn ann t
-      insertLess j i "user-specified"
+      insertLess j i NormalForm
       void (insertAction j faKU)
 
 -- | Insert a 'Less' atom. @insertLess i j@ means that *i < j* is added.
@@ -407,7 +407,7 @@ insertAtom :: LNAtom -> Reduction ChangeIndicator
 insertAtom ato = case ato of
     EqE x y       -> solveTermEqs SplitNow [Equal x y]
     Action i fa   -> insertAction (ltermNodeId' i) fa
-    Less i j      -> do insertLess (ltermNodeId' i) (ltermNodeId' j) "user-specified"
+    Less i j      -> do insertLess (ltermNodeId' i) (ltermNodeId' j) Formula
                         return Unchanged
     Last i        -> insertLast (ltermNodeId' i)
     Syntactic _   -> return Unchanged

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -105,6 +105,7 @@ import           Logic.Connectives
 import           Theory.Constraint.Solver.Contradictions
 import           Theory.Constraint.System
 import           Theory.Model
+import           Utils.Misc
 
 ------------------------------------------------------------------------------
 -- The constraint reduction monad
@@ -263,7 +264,7 @@ labelNodeId = \i rules parent -> do
           -- corresponding KU-actions before this node.
         _ | isKUFact fa -> do
               j <- freshLVar "vk" LSortNode
-              insertLess j i
+              insertLess j i "user-specified"
               void (insertAction j fa)
 
           -- Store premise goal for later processing using CR-rule *DG2_2*
@@ -385,12 +386,12 @@ insertAction i fa@(Fact _ ann _) = do
     requiresKU t = do
       j <- freshLVar "vk" LSortNode
       let faKU = kuFactAnn ann t
-      insertLess j i
+      insertLess j i "user-specified"
       void (insertAction j faKU)
 
 -- | Insert a 'Less' atom. @insertLess i j@ means that *i < j* is added.
-insertLess :: NodeId -> NodeId -> Reduction ()
-insertLess i j = modM sLessAtoms (S.insert (i, j))
+insertLess :: NodeId -> NodeId -> Reason-> Reduction ()
+insertLess i j r = modM sLessAtoms (S.insert (i, j, r))
 
 -- | Insert a 'Last' atom and ensure their uniqueness.
 insertLast :: NodeId -> Reduction ChangeIndicator
@@ -406,7 +407,7 @@ insertAtom :: LNAtom -> Reduction ChangeIndicator
 insertAtom ato = case ato of
     EqE x y       -> solveTermEqs SplitNow [Equal x y]
     Action i fa   -> insertAction (ltermNodeId' i) fa
-    Less i j      -> do insertLess (ltermNodeId' i) (ltermNodeId' j)
+    Less i j      -> do insertLess (ltermNodeId' i) (ltermNodeId' j) "user-specified"
                         return Unchanged
     Last i        -> insertLast (ltermNodeId' i)
     Syntactic _   -> return Unchanged
@@ -648,7 +649,7 @@ conjoinSystem sys = do
     joinSets sLemmas
     joinSets sEdges
     F.mapM_ insertLast                 $ get sLastAtom    sys
-    F.mapM_ (uncurry insertLess)       $ get sLessAtoms   sys
+    F.mapM_  (uncurry3 insertLess)     $ get sLessAtoms   sys
     -- split-goals are not valid anymore
     mapM_   (uncurry insertGoalStatus) $ filter (not . isSplitGoal . fst) $ M.toList $ get sGoals sys
     F.mapM_ insertFormula $ get sFormulas sys

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -74,7 +74,7 @@ simplifySystem = do
         removeSolvedSplitGoals
         -- Add ordering constraint from injective facts
         addNonInjectiveFactInstances
-        -- Apply transitive reduction for lesses
+        -- Apply transitive reduction for the lesses
         transitiveReduction
   where
     go n changes0
@@ -515,26 +515,19 @@ addNonInjectiveFactInstances = do
   let list = nonInjectiveFactInstances ctxt se
   mapM_ (uncurry insertLess) list
 
--- optimal : use topsort in data.graph to make a faster prog
+-- Simplify the lesses by using the algo transitive reduction
 transitiveReduction ::  Reduction ()
 transitiveReduction = do
       sys <- gets id
       oldLessAtoms <- gets (get sLessAtoms)
-    -- get all the lesses of system and apply topological sort
-      let oldLesses = rawLessRel sys -- [vertex]
+      let oldLesses = rawLessRel sys 
       if D.cyclic oldLesses
         then return ()
         else do
             let newLesses = D.transRed oldLesses
                 edges = rawEdgeRel sys
             modM sLessAtoms $ S.intersection ( S.fromList newLesses) 
-            --modifiedLesses <- gets (get sLessAtoms)  
-           -- return $ if oldLessAtoms == modifiedLesses
-             --       then Unchanged
-             --       else Changed
+            
 
 
- --rawLessRel se = S.toList (L.get sLessAtoms se) ++ rawEdgeRel se
-
---getLessAtom :: [(NodeId,NodeId)]->[(NodeId,NodeId)]->[(NodeId,NodeId)]
---getLessAtom edge less = filter (\x-> x `elem` edge) less
+ 

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -74,8 +74,6 @@ simplifySystem = do
         removeSolvedSplitGoals
         -- Add ordering constraint from injective facts
         addNonInjectiveFactInstances
-        -- Apply transitive reduction for the lesses
-        transitiveReduction
   where
     go n changes0
       -- We stop as soon as all simplification steps have been run without
@@ -515,19 +513,6 @@ addNonInjectiveFactInstances = do
   let list = nonInjectiveFactInstances ctxt se
   mapM_ (uncurry insertLess) list
 
--- Simplify the lesses by using the algo transitive reduction
-transitiveReduction ::  Reduction ()
-transitiveReduction = do
-      sys <- gets id
-      oldLessAtoms <- gets (get sLessAtoms)
-      let oldLesses = rawLessRel sys 
-      if D.cyclic oldLesses
-        then return ()
-        else do
-            let newLesses = D.transRed oldLesses
-                edges = rawEdgeRel sys
-            modM sLessAtoms $ S.intersection ( S.fromList newLesses) 
-            
 
 
  

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -164,7 +164,7 @@ exploitUniqueMsgOrder = do
     kdConcs   <- gets (M.fromList . map (\(i, _, m) -> (m, i)) . allKDConcs)
     kuActions <- gets (M.fromList . map (\(i, _, m) -> (m, i)) . allKUActions)
     -- We can add all elements where we have an intersection
-    F.mapM_ (uncurry3 insertLess) (M.map (\(x,y)->(x,y,"user-specified"))  
+    F.mapM_ (uncurry3 insertLess) (M.map (\(x,y)->(x,y, NormalForm))  
               $ M.intersectionWith (,) kdConcs kuActions )
 
 -- | CR-rules *DG4*, *N5_u*, and *N5_d*: enforcing uniqueness of *Fresh* rule
@@ -423,7 +423,7 @@ freshOrdering = do
   reducible <- reducibleFunSyms . mhMaudeSig <$> getMaudeHandle
   let origins = concatMap getFreshFactVars nodes
   let uses = M.fromListWith (++) $ concatMap (getFreshVarsNotBelowReducible reducible) nodes
-  let newLesses = [(i,j,"induced by fresh values") | (fr, i) <- origins, j <- M.findWithDefault [] fr uses]
+  let newLesses = [(i,j,Fresh) | (fr, i) <- origins, j <- M.findWithDefault [] fr uses]
 
   oldLesses <- gets (get sLessAtoms)
   mapM_ (uncurry3 insertLess) newLesses
@@ -513,7 +513,7 @@ addNonInjectiveFactInstances :: Reduction ()
 addNonInjectiveFactInstances = do
   se <- gets id
   ctxt <- ask
-  let list = map (\(x,y)-> (x,y,"user-specified")) $ nonInjectiveFactInstances ctxt se
+  let list = map (\(x,y)-> (x,y,InjectiveFacts)) $ nonInjectiveFactInstances ctxt se
   mapM_ (uncurry3 insertLess) list
 
 

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -269,7 +269,7 @@ import qualified Extension.Data.Label                 as L
 
 import           Logic.Connectives
 import           Theory.Constraint.Solver.AnnotatedGoals
-import           Theory.Constraint.System.Constraints
+import           Theory.Constraint.System.Constraints 
 --import           Theory.Constraint.Solver.Heuristics
 import           Theory.Model
 import           Theory.Text.Pretty

--- a/lib/theory/src/Theory/Constraint/System/Constraints.hs
+++ b/lib/theory/src/Theory/Constraint/System/Constraints.hs
@@ -76,7 +76,7 @@ data Edge = Edge {
   deriving (Show, Ord, Eq, Data, Typeable, Generic, NFData, Binary)
 
 -- | A reason to explain the less, user-specified”, “induced by fresh values
-data Reason = Fresh | Formula | InjectiveFacts | NormalForm
+data Reason = Fresh | Formula | InjectiveFacts | NormalForm | Adversary
       deriving (Ord, Eq, Data, Typeable, Generic, NFData, Binary)
 
 -- | A *⋖* constraint between 'NodeId's.
@@ -89,6 +89,7 @@ instance Show Reason where
     show Formula            = "formula"
     show InjectiveFacts     = "injective facts"
     show NormalForm         = "normal form condition"
+    show Adversary          = "adversary"
 
 instance Apply LNSubst Reason where
     apply = const id
@@ -193,7 +194,7 @@ instance Apply LNSubst Goal where
 ------------------------------------------------------------------------------
 -- | Pretty print a reason
 prettyReason :: HighlightDocument d => Reason -> d
-prettyReason r = text $ "reduced by " ++ show r
+prettyReason r = text $ "induced by " ++ show r
     
 -- | Pretty print a node.
 prettyNode :: HighlightDocument d => (NodeId, RuleACInst) -> d

--- a/lib/theory/src/Theory/Constraint/System/Constraints.hs
+++ b/lib/theory/src/Theory/Constraint/System/Constraints.hs
@@ -21,6 +21,7 @@ module Theory.Constraint.System.Constraints (
   , NodePrem
   , NodeConc
   , Edge(..)
+  , Reason
   , Less
 
   -- * Goal constraints
@@ -73,9 +74,10 @@ data Edge = Edge {
     , eTgt :: NodePrem
     }
   deriving (Show, Ord, Eq, Data, Typeable, Generic, NFData, Binary)
-
+-- | A reason to explain the less, user-specified”, “induced by fresh values
+type Reason = String
 -- | A *⋖* constraint between 'NodeId's.
-type Less = (NodeId, NodeId)
+type Less = (NodeId, NodeId, Reason)
 
 -- Instances
 ------------
@@ -193,7 +195,7 @@ prettyEdge (Edge c p) =
 
 -- | Pretty print a less-atom as @src < tgt@.
 prettyLess :: HighlightDocument d => Less -> d
-prettyLess (i, j) = prettyNAtom $ Less (varTerm i) (varTerm j)
+prettyLess (i, j, r) = (prettyNAtom $ Less (varTerm i) (varTerm j)) <> colon <-> text r
 
 -- | Pretty print a goal.
 prettyGoal :: HighlightDocument d => Goal -> d

--- a/lib/theory/src/Theory/Constraint/System/Constraints.hs
+++ b/lib/theory/src/Theory/Constraint/System/Constraints.hs
@@ -75,8 +75,9 @@ data Edge = Edge {
     }
   deriving (Show, Ord, Eq, Data, Typeable, Generic, NFData, Binary)
 
--- | A reason to explain the less, user-specified”, “induced by fresh values
-data Reason = Fresh | Formula | InjectiveFacts | NormalForm | Adversary
+-- | A reason to explain the less
+-- | Order is from the most important to the least important 
+data Reason = Formula | InjectiveFacts | Fresh | Adversary | NormalForm
       deriving (Ord, Eq, Data, Typeable, Generic, NFData, Binary)
 
 -- | A *⋖* constraint between 'NodeId's.

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -520,8 +520,11 @@ compressSystem se0 =
   where
     se = dropEntailedOrdConstraints se0
 
--- | Simplify the system up to the sent level, for level 1, we will simplify
--- | the lesses of system by transitive reduction
+-- | Simplify the system up to the sent level, 
+-- | for level 3, we will simplify the lesses of system by transitive reduction
+-- | for level 2, we will apply the transitive reduction but keep the 
+-- | formula constraint 
+-- | for level 1, there's no transitive reduction applied
 simplifySystem :: Int -> System -> System
 simplifySystem i sys 
     | i==2 = transitiveReduction sys False
@@ -529,7 +532,7 @@ simplifySystem i sys
     | otherwise = sys
 
 -- | Simplify the system by transitive reduction (constraint of formula won't  
--- | be applied) but not for a system which has a graph cyclic
+-- | be applied if totalRed is False) but not for a system which has a graph cyclic
 transitiveReduction :: System -> Bool -> System
 transitiveReduction sys totalRed= 
     if D.cyclic oldLesses

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -249,11 +249,20 @@ dotSystemLoose se =
     dotChain (src, tgt) =
         dotGenEdge [("style","dashed"),("color","green")] src tgt
 
-    dotLess (src, tgt, _) = do
+    dotLess (src, tgt, reason) = do
         srcId <- dotNode src
         tgtId <- dotNode tgt
-        liftDot $ D.edge srcId tgtId
-            [("color","black"),("style","dotted")] -- FIXME: Reactivate,("constraint","false")]
+        case reason of
+            Adversary -> liftDot $ D.edge srcId tgtId
+                    [("color","red"),("style","dotted")]
+            Formula  -> liftDot $ D.edge srcId tgtId
+                    [("color","black"),("style","dotted")]
+            Fresh -> liftDot $ D.edge srcId tgtId
+                    [("color","darkgrey"),("style","dotted")] 
+            InjectiveFacts ->liftDot $ D.edge srcId tgtId
+                    [("color","purple"),("style","dotted")]
+            NormalForm ->liftDot $ D.edge srcId tgtId
+                    [("color","orange"),("style","dotted")] -- FIXME: Reactivate,("constraint","false")]
             -- setting constraint to false ignores less-edges when ranking nodes.
 
     dotGenEdge style src tgt = do
@@ -455,12 +464,22 @@ dotSystemCompact boringStyle showAutosource se =
     dotChain (src, tgt) =
         dotGenEdge [("style","dashed"),("color","green")] src tgt
 
-    dotLess (src, tgt, _) = do
+    dotLess (src, tgt, reason) = do
         srcId <- dotNodeCompact boringStyle showAutosource src
         tgtId <- dotNodeCompact boringStyle showAutosource tgt
-        liftDot $ D.edge srcId tgtId
-            [("color","black"),("style","dotted")] -- FIXME: reactivate ,("constraint","false")]
+        case reason of
+            Adversary -> liftDot $ D.edge srcId tgtId
+                    [("color","red"),("style","dotted")]
+            Formula  -> liftDot $ D.edge srcId tgtId
+                    [("color","black"),("style","dotted")]
+            Fresh -> liftDot $ D.edge srcId tgtId
+                    [("color","darkgrey"),("style","dotted")] 
+            InjectiveFacts ->liftDot $ D.edge srcId tgtId
+                    [("color","purple"),("style","dotted")]
+            NormalForm ->liftDot $ D.edge srcId tgtId
+                    [("color","orange"),("style","dotted")] -- FIXME: Reactivate,("constraint","false")]
             -- setting constraint to false ignores less-edges when ranking nodes.
+        
 
 
 ------------------------------------------------------------------------------

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -14,6 +14,7 @@ module Theory.Constraint.System.Dot (
   , dotSystemLoose
   , dotSystemCompact
   , compressSystem
+  , simplifySystem
   , BoringNodeStyle(..)
   ) where
 
@@ -462,6 +463,24 @@ compressSystem se0 =
     foldl' (flip tryHideNodeId) se (frees (get sLessAtoms se, get sNodes se))
   where
     se = dropEntailedOrdConstraints se0
+
+--
+simplifySystem :: Int -> System -> System
+simplifySystem i sys 
+    | i==1 = transitiveReduction sys
+    | otherwise = sys
+
+-- |Simplify the system by transitive reduction
+transitiveReduction :: System -> System
+transitiveReduction sys = 
+    if D.cyclic oldLesses
+        then sys
+        else  modify sLessAtoms 
+            ( S.intersection ( S.fromList newLesses) )sys
+    where 
+        oldLesses = rawLessRel sys 
+        newLesses = D.transRed oldLesses
+
 
 -- | @hideTransferNode v se@ hides node @v@ in sequent @se@ if it is a
 -- transfer node; i.e., a node annotated with a rule that is one of the

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -464,13 +464,15 @@ compressSystem se0 =
   where
     se = dropEntailedOrdConstraints se0
 
---
+-- | Simplify the system up to the sent level, for level 1, we will simplify
+-- | the lesses of system by transitive reduction
 simplifySystem :: Int -> System -> System
 simplifySystem i sys 
     | i==1 = transitiveReduction sys
     | otherwise = sys
 
--- |Simplify the system by transitive reduction
+-- | Simplify the system by transitive reduction but not for a system which has
+-- | a graph cyclic
 transitiveReduction :: System -> System
 transitiveReduction sys = 
     if D.cyclic oldLesses
@@ -480,7 +482,6 @@ transitiveReduction sys =
     where 
         oldLesses = rawLessRel sys 
         newLesses = D.transRed oldLesses
-
 
 -- | @hideTransferNode v se@ hides node @v@ in sequent @se@ if it is a
 -- transfer node; i.e., a node annotated with a rule that is one of the

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -40,7 +40,7 @@ import           Control.Monad.State      (StateT, evalStateT)
 import qualified Text.Dot                 as D
 import           Text.PrettyPrint.Class
 
-import           Theory.Constraint.System
+import           Theory.Constraint.System 
 import           Theory.Model
 import           Theory.Text.Pretty       (opAction)
 
@@ -530,7 +530,7 @@ tryHideNodeId v se = fromMaybe se $ do
 
         lIns  = selectPart sLessAtoms ((v ==) . snd3)
         lOuts = selectPart sLessAtoms ((v ==) . fst3)
-        lNews = [ (i, j, r) | (i, _, r) <- lIns, (_, j, r) <- lOuts ]
+        lNews = [ (i, j, NormalForm) | (i, _, _) <- lIns, (_, j, _) <- lOuts ] --Not sure, to check
 
     -- hide a rule, if it is not "too complicated"
     hideRule :: RuleACInst -> Maybe System

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -530,7 +530,7 @@ tryHideNodeId v se = fromMaybe se $ do
 
         lIns  = selectPart sLessAtoms ((v ==) . snd3)
         lOuts = selectPart sLessAtoms ((v ==) . fst3)
-        lNews = [ (i, j, NormalForm) | (i, _, _) <- lIns, (_, j, _) <- lOuts ] --Not sure, to check
+        lNews = [ (i, j, NormalForm) | (i, _, _) <- lIns, (_, j, _) <- lOuts ] 
 
     -- hide a rule, if it is not "too complicated"
     hideRule :: RuleACInst -> Maybe System

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -392,7 +392,7 @@ sequentToJSONGraphs pretty label se =
                           ++ (map (unsolvedActionAtomsToJSONGraphNode pretty) $ unsolvedActionAtoms se)
                           ++ (missingNodesToJSONGraphNodes se $ S.toList $ L.get sEdges se)
               , jgEdges = (map (edgeToJSONGraphEdge se) $ S.toList $ L.get sEdges se)
-                          ++ (map lessAtomsToJSONGraphEdge $ S.toList $ L.get sLessAtoms se)
+                          ++ (map lessAtomsToJSONGraphEdge $ S.toList $ getLessAtoms se)
                           ++ (map unsolvedchainToJSONGraphEdge $ unsolvedChains se)
               } 
           ] 

--- a/lib/utils/src/Data/DAG/Simple.hs
+++ b/lib/utils/src/Data/DAG/Simple.hs
@@ -10,6 +10,7 @@
 module Data.DAG.Simple (
   -- * Computing with binary relations
     Relation
+  , transRed
   , inverse
   , image
   , reachableSet
@@ -30,10 +31,29 @@ import           Control.Monad.RWS
 import           Data.List
 import qualified Data.DList as D
 import qualified Data.Set   as S
+import           Data.Maybe
 
 -- import Test.QuickCheck.Property (label)
 -- import Test.QuickCheck (quickCheck)
 
+
+-- | Transitive reduction for a DAG
+transRed :: Ord a => [(a,a)] -> [(a,a)]
+transRed dag =
+     foldl' visit []( mapMaybe indexToRel indexV)
+    where
+        topoOrdDag = toposort dag
+        i = [1.. (length topoOrdDag -1)]
+        indexV = foldr (\x acc -> zip (reverse [0..x-1]) (repeat x)++ acc) [] i
+        indexToRel ji =
+            let r = (,)  (topoOrdDag !! fst ji ) (topoOrdDag !! snd ji)
+            in (if r `elem` dag then Just r else Nothing)
+        visit newEdges x
+            | snd x `S.member` reachableSet [fst x] newEdges = newEdges
+            | otherwise = x : newEdges
+
+             
+               
 -- | Produce a topological sorting of the given relation. If the relation is
 -- cyclic, then the result is at least some permutation of all elements of
 -- the given relation.

--- a/lib/utils/src/Data/DAG/Simple.hs
+++ b/lib/utils/src/Data/DAG/Simple.hs
@@ -40,7 +40,7 @@ import           Data.Maybe
 -- | Transitive reduction for a DAG
 transRed :: Ord a => [(a,a)] -> [(a,a)]
 transRed dag =
-     foldl' visit []( mapMaybe indexToRel indexV)
+     foldl' visit [] ( mapMaybe indexToRel indexV)
     where
         topoOrdDag = toposort dag
         i = [1.. (length topoOrdDag -1)]

--- a/lib/utils/src/Utils/Misc.hs
+++ b/lib/utils/src/Utils/Misc.hs
@@ -34,6 +34,9 @@ module Utils.Misc (
   , snd3
   , thd3
 
+  -- * uncurry
+  , uncurry3
+
 ) where
 
 import Data.List
@@ -66,6 +69,10 @@ snd3 (_, x, _) = x
 -- | @thd3 (x, y, z)@ returns the third element @z@ of the triple
 thd3 :: (a, b, c) -> c
 thd3 (_, _, x) = x
+
+-- | @uncurry3 f (a,b,c)@ uncurry a function which has three param
+uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
+uncurry3 f (a, b, c) = f a b c
 
 -- | @noDuplicates xs@ returns @True@ if the list @xs@ contains no duplicates
 noDuplicates :: (Ord a) => [a] -> Bool

--- a/src/Web/Hamlet.hs
+++ b/src/Web/Hamlet.hs
@@ -198,11 +198,12 @@ headerTpl info = [whamlet|
         <li><a href="#">Options</a>
           <ul>
             <li><a id=abbrv-toggle href="#">Abbreviate terms</a>
+            <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
             <li><a id=lvl0-toggle href="#">Graph simplification off</a>
             <li><a id=lvl1-toggle href="#">Graph simplification L1</a>
             <li><a id=lvl2-toggle href="#">Graph simplification L2</a>
             <li><a id=lvl3-toggle href="#">Graph simplification L3</a>
-            <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
+            
             
   |]
   where
@@ -242,11 +243,12 @@ headerDiffTpl info = [whamlet|
         <li><a href="#">Options</a>
           <ul>
             <li><a id=abbrv-toggle href="#">Abbreviate terms</a>
+            <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
             <li><a id=lvl0-toggle href="#">Graph simplification off</a>
             <li><a id=lvl1-toggle href="#">Graph simplification L1</a>
             <li><a id=lvl2-toggle href="#">Graph simplification L2</a>
             <li><a id=lvl3-toggle href="#">Graph simplification L3</a>
-            <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
+           
   |]
   where
             -- <li><a id=debug-toggle href="#">Debug pane</a>

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -95,6 +95,7 @@ import qualified Blaze.ByteString.Builder     as B
 import qualified Data.ByteString.Char8        as BS
 import qualified Data.Map                     as M
 import qualified Data.Text                    as T
+import qualified Data.Text.Read               as R
 import qualified Data.Text.Encoding           as T (encodeUtf8, decodeUtf8)
 import qualified Data.Text.Lazy.Encoding      as TLE
 import qualified Data.Traversable             as Tr
@@ -908,18 +909,19 @@ getTheoryGraphR idx path = withTheory idx ( \ti -> do
           (imageFormat yesod)
           (graphCmd yesod)
           (cacheDir yesod)
-          (graphStyle compact compress)
+          (graphStyle compact compress ( read $ T.unpack simplificationLevel))
           (sequentToJSONPretty)
           (show simplificationLevel)
           (abbreviate)
           (tiTheory ti) path
       sendFile (fromString . imageFormatMIME $ imageFormat yesod) img)
   where
-    graphStyle d c = dotStyle d . compression c
+    graphStyle d c s= dotStyle d .simplifySystem s. compression c
     dotStyle True = dotSystemCompact CompactBoringNodes
     dotStyle False = dotSystemCompact FullBoringNodes
     compression True = compressSystem
     compression False = id
+    
 
 -- | Get rendered graph for theory and given path.
 getTheoryGraphDiffR :: TheoryIdx -> DiffTheoryPath -> Handler ()
@@ -938,14 +940,14 @@ getTheoryGraphDiffR' idx path mirror = withDiffTheory idx ( \ti -> do
           (imageFormat yesod)
           (snd $ graphCmd yesod)
           (cacheDir yesod)
-          (graphStyle compact compress)
+          (graphStyle compact compress ( read $ T.unpack simplificationLevel))
           (show simplificationLevel)
           (abbreviate)
           (dtiTheory ti) path
           (mirror)
       sendFile (fromString . imageFormatMIME $ imageFormat yesod) img)
   where
-    graphStyle d c = dotStyle d . compression c
+    graphStyle d c s= dotStyle d .simplifySystem s. compression c
     dotStyle True = dotSystemCompact CompactBoringNodes
     dotStyle False = dotSystemCompact FullBoringNodes
     compression True = compressSystem

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -903,7 +903,7 @@ getTheoryGraphR idx path = withTheory idx ( \ti -> do
       compact <- isNothing <$> lookupGetParam "uncompact"
       compress <- isNothing <$> lookupGetParam "uncompress"
       abbreviate <- isNothing <$> lookupGetParam "unabbreviate"
-      simplificationLevel <- fromMaybe "1" <$> lookupGetParam "simplification"
+      simplificationLevel <- fromMaybe "2" <$> lookupGetParam "simplification"
       showAutosource <- isNothing <$> lookupGetParam "no-auto-sources"
       img <- liftIO $ traceExceptions "getTheoryGraphR" $
         imgThyPath
@@ -934,7 +934,7 @@ getTheoryGraphDiffR' idx path mirror = withDiffTheory idx ( \ti -> do
       compact <- isNothing <$> lookupGetParam "uncompact"
       compress <- isNothing <$> lookupGetParam "uncompress"
       abbreviate <- isNothing <$> lookupGetParam "unabbreviate"
-      simplificationLevel <- fromMaybe "1" <$> lookupGetParam "simplification"
+      simplificationLevel <- fromMaybe "2" <$> lookupGetParam "simplification"
       showAutosource <- isNothing <$> lookupGetParam "auto-sources"
       img <- liftIO $ traceExceptions "getTheoryGraphDiffR" $
         imgDiffThyPath


### PR DESCRIPTION
The object of this PR is to simplify the arrows of visualization in interactive mode, it's for the issues [535](https://github.com/tamarin-prover/tamarin-prover/issues/535). Moreover, the colors of less are modified so that different colors can present different reasons of existence of less. However, it's necessary to decide how to show a less with more than one reason (we show the reason the most important, or we show all the reason by combining all the colors). 
At the same time, I have placed the button of “show annotations of auto-sources” before the option “simplification off”.