### PR TITLE
Refactor Derivation Checks

### DIFF
--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -220,6 +220,8 @@ module Theory (
   , getDiffClassifiedRules
   , getInjectiveFactInsts
   , getDiffInjectiveFactInsts
+  , getLeftProtoRule
+  , getRightProtoRule
 
   , getSource
   , getDiffSource


### PR DESCRIPTION
This PR refactors the derivation checks. It removes all warnings and avoids closing the diff theory just to get the final rules (as for trace theories), which significantly speeds up the process.