### PR TITLE
Updating development attribution and copyrights.

### DIFF
--- a/lib/term/tamarin-prover-term.cabal
+++ b/lib/term/tamarin-prover-term.cabal
@@ -13,7 +13,7 @@ author:             Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
 maintainer:         Cas Cremers <cremers@cispa.de>,
                     Jannik Dreier <research@jannikdreier.net>,
                     Ralf Sasse <ralf.sasse@gmail.com>
-copyright:          Benedikt Schmidt, Simon Meier, Jannik Dreier, Ralf Sasse, ETH Zurich, 2010-2018
+copyright:          Benedikt Schmidt, Simon Meier, Cas Cremers, Jannik Dreier, Ralf Sasse, 2010-2023
 synopsis:           Term manipulation library for the tamarin prover.
 
 description:        This is an internal library of the Tamarin prover for

--- a/lib/theory/tamarin-prover-theory.cabal
+++ b/lib/theory/tamarin-prover-theory.cabal
@@ -14,7 +14,7 @@ maintainer:         Simon Meier <simon.meier@inf.ethz.ch>,
                     Jannik Dreier <research@jannikdreier.net>,
                     Ralf Sasse <ralf.sasse@gmail.com>
                     Cas Cremers <cremers@cispa.de>
-copyright:          Benedikt Schmidt, Simon Meier, Jannik Dreier, Ralf Sasse, ETH Zurich, 2010-2018
+copyright:          Benedikt Schmidt, Simon Meier, Cas Cremers, Jannik Dreier, Ralf Sasse, 2010-2023
 
 synopsis:           Security protocol types and constraint solver library for the tamarin prover.
 

--- a/lib/utils/tamarin-prover-utils.cabal
+++ b/lib/utils/tamarin-prover-utils.cabal
@@ -13,7 +13,7 @@ author:             Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
 maintainer:         Cas Cremers <cremers@cispa.de>,
                     Jannik Dreier <research@jannikdreier.net>,
                     Ralf Sasse <ralf.sasse@gmail.com>
-copyright:          Benedikt Schmidt, Simon Meier, Jannik Dreier, Ralf Sasse, ETH Zurich, 2010-2018
+copyright:          Benedikt Schmidt, Simon Meier, Cas Cremers, Jannik Dreier, Ralf Sasse, 2010-2023
 
 synopsis:           Utility library for the tamarin prover.
 

--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -222,7 +222,7 @@ versionStr = unlines
     [ programName
     , " "
     , showVersion version
-    , ", (C) David Basin, Cas Cremers, Jannik Dreier, Simon Meier, Ralf Sasse, Benedikt Schmidt, ETH Zurich 2010-2023"
+    , ", (C) David Basin, Cas Cremers, Jannik Dreier, Simon Meier, Ralf Sasse, Benedikt Schmidt, 2010-2023"
     ]
   , ""
   , "This program comes with ABSOLUTELY NO WARRANTY. It is free software, and you"

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -12,7 +12,7 @@ author:             Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
 maintainer:         Cas Cremers <cremers@cispa.de>,
                     Jannik Dreier <research@jannikdreier.net>,
                     Ralf Sasse <ralf.sasse@gmail.com>
-copyright:          Benedikt Schmidt, Simon Meier, Jannik Dreier, Ralf Sasse, ETH Zurich, 2010-2020
+copyright:          Benedikt Schmidt, Simon Meier, Cas Cremers, Jannik Dreier, Ralf Sasse, 2010-2023
 synopsis:           The Tamarin prover for security protocol analysis.
 description:
 


### PR DESCRIPTION
Tamarin was originally developed at ETH Zurich, but over time has seen major developments by other universities and institutions, so attributing it solely to ETH Zurich has become inaccurate. Similarly, authors (beyond commit attribution) evolved historically. This commit corrects and simplifies this situation. In the future we might come up with a more consistent policy for this, but at least now it is less incorrect.