### PR TITLE
Update lts

### DIFF
--- a/lib/term/src/Term/LTerm.hs
+++ b/lib/term/src/Term/LTerm.hs
@@ -126,7 +126,6 @@ import qualified Control.Monad.Trans.PreciseFresh as Precise
 
 import           GHC.Generics                     (Generic)
 import           Data.Binary
-import qualified Data.List                        as L
 import qualified Data.DList                       as D
 import           Data.Foldable                    hiding (concatMap, elem, notElem, any)
 import           Data.Data

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
 - lib/sapic/
 - lib/export/
 - lib/accountability/
-resolver: lts-20.12
+resolver: lts-20.26
 ghc-options:
   "$everything": -Wall
 nix:


### PR DESCRIPTION
This PR updates the LTS version to 20.26 (GHC 9.2.8).

The LTS using GHC 9.4.x does not seem to work reliably on Ubuntu/Debian, and 9.6 is not a stable resolver yet.