### PR TITLE
Make Sapic compatible with new nat type

### DIFF
--- a/examples/sapic/export/5G_AKA/5G_AKA.spthy
+++ b/examples/sapic/export/5G_AKA/5G_AKA.spthy
@@ -177,7 +177,7 @@ c01chja@Colossus05 $ time proverif output.pv
 
    Pre-shared
    secrets:	Symmetric subscription key:		(UE, HSS, ~k)
-		Sequence number:			(UE, HSS, ~sqn_root+'one')
+		Sequence number:			(UE, HSS, ~sqn_root+%1)
 
    Protocol:	1. UE   -> SEAF:	suci
 		2. SEAF -> AUSF:	suci, SNID
@@ -203,7 +203,7 @@ c01chja@Colossus05 $ time proverif output.pv
 
 begin
 
-builtins: dest-pairing,	dest-asymmetric-encryption, multiset, xor
+builtins: dest-pairing,	dest-asymmetric-encryption, natural-numbers, xor
 
 functions:
 	// AKA functions (TS 33.102)
@@ -248,8 +248,8 @@ let Ue(~supi,~idHn,~k,~sqn_root,~idHN,pk_HN) =
 
     lock ~supi;
     // Sqn_UE(~supi, ~idHN, SqnUE, ~sqn_root, count),
-    lookup ~supi as count:nat in
-    let SqnUE = <~sqn_root, count> in
+    lookup ~supi as %count:nat in
+    let SqnUE = <~sqn_root, %count> in
     // Input, checks
     // Authentication Request (Auth-Req) and Sync Failure
     // [3G] Clauses C.2.1, C.2.2
@@ -258,15 +258,15 @@ let Ue(~supi,~idHn,~k,~sqn_root,~idHN,pk_HN) =
     //	- or Received Sqn is not bigger.
     // [3G] Clauses 6.3.3, 6.3.5
     // Input, checks
-    in(<RAND,c2:nat,<xored, MAC, 'FiveG', idSN    >>);
-    if (xored  =   f5(~k, RAND) XOR  <~sqn_root,c2>) & MAC  = f1(~k, < <~sqn_root,c2> , RAND>) then
-    if count (<) c2   then
+    in(<RAND,%c2:nat,<xored, MAC, 'FiveG', idSN    >>);
+    if (xored  =   f5(~k, RAND) XOR  <~sqn_root,%c2>) & MAC  = f1(~k, < <~sqn_root,%c2> , RAND>) then
+    if %count << %c2   then
 //    in( < RAND,  <SqnHSSXORAK, MAC>,  <'FiveG', idSN>  > );
     // let	MAC = f1(~k, <SqnHSS, RAND>) in// check on the MAC
     (
-    event CounterGS(~supi,count);
+    event CounterGS(~supi,%count);
     let	AK = f5(~k, RAND) in
-    let SqnHSS = <~sqn_root,c2> in
+    let SqnHSS = <~sqn_root,%c2> in
 
 //    let MAC =  f1(~k, < <~sqn_root,c2> , RAND>) in // useless rebind?
     let	SNID = <'FiveG', idSN>  in
@@ -285,11 +285,11 @@ let Ue(~supi,~idHn,~k,~sqn_root,~idHN,pk_HN) =
 	let K_seaf = KDF(KDF(<CK, IK>, <SNID, SqnHSS XOR AK>), SNID) in
 	let msgOut = RES_star in
 	// Open chains
-	event Sqn_UE_Invariance(~supi, ~idHN, ~sqn_root, c2);
+	event Sqn_UE_Invariance(~supi, ~idHN, ~sqn_root, %c2);
 
 	// Helper lemmas
-	event Sqn_UE_Change(~supi, ~idHN, c2);
-	event Sqn_UE_Use(~supi, ~idHN, c2);
+	event Sqn_UE_Change(~supi, ~idHN, %c2);
+	event Sqn_UE_Use(~supi, ~idHN, %c2);
 	// GSVerif axiom
 	event KSEAF(K_seaf);
 
@@ -311,8 +311,8 @@ let Ue(~supi,~idHn,~k,~sqn_root,~idHN,pk_HN) =
 	event Honest(~supi);
 	event Honest(~idHN);
 	event Honest(idSN);
-	//	 Sqn_UE(~supi, ~idHN, SqnHSS, ~sqn_root, count+dif)
-	insert ~supi, c2;
+	//	 Sqn_UE(~supi, ~idHN, SqnHSS, ~sqn_root, %count+dif)
+	insert ~supi, %c2;
 	unlock ~supi;
 	out(msgOut);
 	// St_2_UE(~tid, ~supi, ~idHN, ~k, ~sqn_root, idSN, K_seaf),
@@ -333,9 +333,9 @@ let Ue(~supi,~idHn,~k,~sqn_root,~idHN,pk_HN) =
 	out(f1(K_seaf, 'UE'))
 
     )
-    else if (xored  =  <~sqn_root,c2> XOR  f5(~k, RAND)) & MAC  = f1(~k, < <~sqn_root,c2> , RAND>) then //    if SqnUE > SqnHSS then
+    else if (xored  =  <~sqn_root,%c2> XOR  f5(~k, RAND)) & MAC  = f1(~k, < <~sqn_root,%c2> , RAND>) then //    if SqnUE > SqnHSS then
     (
-	in(=count);
+	in(=%count:nat);
 	let AKS = f5_star(~k, RAND) in
 	let MACS = f1_star(~k, <SqnUE, RAND>) in
 	let AUTS = <SqnUE XOR AKS, MACS > in
@@ -343,10 +343,10 @@ let Ue(~supi,~idHn,~k,~sqn_root,~idHN,pk_HN) =
 	// Restriction
 //	event Greater_Or_Equal_Than(SqnUE, SqnHSS); // Check freshness (FAIL)
 	// Open chains
-        event Sqn_UE_Invariance(~supi, ~idHN, ~sqn_root, count);
+        event Sqn_UE_Invariance(~supi, ~idHN, ~sqn_root, %count);
 	// Helper lemmas
-	event Sqn_UE_Nochange(~supi, ~idHN, count);
-	insert ~supi, count;
+	event Sqn_UE_Nochange(~supi, ~idHN, %count);
+	insert ~supi, %count;
 	unlock ~supi;
 	out(out_msg)
      )
@@ -465,11 +465,11 @@ let HSS(~idHN, ~sk_HN, ~supi, ~k, ~sqn_root,~secureChan)=
 // !HSS(~idHN, ~sk_HN),
 // !Ltk_Sym(~supi, ~idHN, ~k, ~sqn_root),
    lock ~sqn_root;
-// Sqn_HSS(~supi, ~idHN, SqnHSS, ~sqn_root, count),
-   lookup ~sqn_root as count:nat in
-   in(=count);
-   event CounterGS(~sqn_root,count);
-   let SqnHSS = <~sqn_root, count> in
+// Sqn_HSS(~supi, ~idHN, SqnHSS, ~sqn_root, count3),
+   lookup ~sqn_root as %count3:nat in
+   in(=%count3:nat);
+   event CounterGS(~sqn_root,%count3);
+   let SqnHSS = <~sqn_root, %count3> in
 // RcvS(~cid, idSN, ~idHN, <'air', msgIn>),
    in(idSN);
    in(~secureChan,<~cid, =idSN, =~idHN, <'air',  <  < cyphersupirR, =~idHN> , <'FiveG', =idSN> > >>);
@@ -485,8 +485,8 @@ let HSS(~idHN, ~sk_HN, ~supi, ~k, ~sqn_root,~secureChan)=
 
 //   let (=idSN2) = idSN in // HSS checks that the received SNID matches the authenticated channel with idSN
    let SNID = <'FiveG', idSN> in
-   let cnext:nat = count + 'one' in
-   let SqnNext = <~sqn_root,count + 'one'> in
+   let cnext:nat = %count3 %+ %1 in
+   let SqnNext = <~sqn_root,%count3 %+ %1> in
 
    // 2. Send
    //     a. ARPF part
@@ -521,13 +521,13 @@ let HSS(~idHN, ~sk_HN, ~supi, ~k, ~sqn_root,~secureChan)=
    event Honest(~supi);
    event Honest(~idHN);
    event Honest(idSN);
-   //         Sqn_HSS(~supi, ~idHN, SqnNext, ~sqn_root, count+'one'),
+   //         Sqn_HSS(~supi, ~idHN, SqnNext, ~sqn_root, count3+%1),
    //         SndS(~cid, ~idHN, idSN, <'aia', msgOut>)
    event SrcId(~idHN);
 event Sqn_HSS_Invariance(~idHN, ~supi, ~sqn_root, cnext);
 	  event	Sqn_HSS_Change(~sqn_root, cnext);
    out(~secureChan,<~cid, ~idHN, idSN, <'aia', msgOut>>);
-  insert ~sqn_root, count+'one';
+  insert ~sqn_root, %count3%+%1;
   unlock ~sqn_root;
 
     // St_1_HSS(~tid, ~idHN, ~supi, suci, idSN, SNID, ~k, SqnNext, XRES_star, ~RAND, ~sqn_root, ~sk_HN, ~cid)
@@ -574,17 +574,17 @@ event Sqn_HSS_Invariance(~idHN, ~supi, ~sqn_root, cnext);
      // directly send the new AVs. Need to rerun the protocol.
      // Sqn is only updated if needed. (recal that delta = infinity in this model)
      (
-	// insert ~sqn_root, count+'one';
+	// insert ~sqn_root, count3+%1;
         // unlock ~sqn_root;
 	  lock ~sqn_root;
-	  // Sqn_HSS(~supi, ~idHN, SqnHSS, ~sqn_root, count),
-        lookup ~sqn_root as count2:nat in
-	event CounterGS(~sqn_root,count2);
-        if count2 = count+'one' then
+	  // Sqn_HSS(~supi, ~idHN, SqnHSS, ~sqn_root, count3),
+        lookup ~sqn_root as %count2:nat in
+	event CounterGS(~sqn_root,%count2);
+        if %count2 = %count3%+%1 then
 //        let SqnHSS2 = SqnNext in
-	in(count3:nat);
-	if    count2 (<) count3 then
-	  let SqnUE = <~sqn_root,count3> in
+	in(%countin:nat);
+	if    %count2 << %countin then
+	  let SqnUE = <~sqn_root,%countin> in
 	let  <=~RAND, <sqnuexoredf5, f1s  > >  = msg2 in
 	if sqnuexoredf5 = SqnUE XOR  f5_star(~k, ~RAND) then
 	if f1s = f1_star(~k, <SqnUE, ~RAND>) then
@@ -593,15 +593,15 @@ event Sqn_HSS_Invariance(~idHN, ~supi, ~sqn_root, cnext);
 
 
 
-//	  let <=SqnHSS, =SqnUE,=SqnUE > = <count2 + ~sqn_root, dif + SqnHSS, SqnUE2> in
+//	  let <=SqnHSS, =SqnUE,=SqnUE > = <%count2 + ~sqn_root, dif + SqnHSS, SqnUE2> in
 
 	  // Open chains
-	  event	Sqn_HSS_Invariance(~idHN, ~supi, ~sqn_root, count3);
-	  event	Sqn_HSS_Change(~sqn_root, count3);
+	  event	Sqn_HSS_Invariance(~idHN, ~supi, ~sqn_root, %countin);
+	  event	Sqn_HSS_Change(~sqn_root, %countin);
    	  // Executability
-	  event	HSS_Resync_End(count3);
-	  insert ~sqn_root, count3;
-	  // Sqn_HSS(~supi, ~idHN, SqnUE, ~sqn_root, count+dif)
+	  event	HSS_Resync_End(%countin);
+	  insert ~sqn_root, %countin;
+	  // Sqn_HSS(~supi, ~idHN, SqnUE, ~sqn_root, %count+dif)
 	  unlock ~sqn_root
        )
 
@@ -618,20 +618,20 @@ let addSub(~idHN,~sk_HN,~secureChan) = // HSS(~idHN, ~sk_HN)
   // Helper lemmas
   event Sqn_Create(~supi, ~idHN, ~sqn_root);
   event CreateUser(~supi, ~k, ~idHN);
-  // |	 Sqn_UE(~supi, ~idHN, ~sqn_root+'one', ~sqn_root, 'one'),
+  // |	 Sqn_UE(~supi, ~idHN, ~sqn_root+%1, ~sqn_root, %1),
   // Remark, we use ~supi as an identifier for the state Sqn_UE
 
-  // |	 Sqn_HSS(~supi, ~idHN, ~sqn_root+'one', ~sqn_root, 'one')]
+  // |	 Sqn_HSS(~supi, ~idHN, ~sqn_root+%1, ~sqn_root, %1)]
   // Remark, we use ~sqn_root as an identifier for the state Sqn_HSS
-  insert ~sqn_root, 'one';
-  insert ~supi, 'one';
+  insert ~sqn_root, %1;
+  insert ~supi, %1;
   //!Ltk_Sym(~supi, ~idHN, ~k, ~sqn_root),
   (
   // Compromised subscriptions (symmetric key k)
    (event Rev(~supi, <'k', ~k>); event Rev(~idHN, <'k', ~k>); event RevId(~supi); event RevId(~idHN);
    event Revk(); event Revk();
    out(~k))
-   // Compromised subscriptions ("initial" counter sqn_root)
+   // Compromised subscriptions ("initial" %counter sqn_root)
    || (event Rev(~supi, <'sqn', ~sqn_root>); event Rev(~idHN, <'sqn', ~sqn_root>); event RevId(~supi); event RevId(~idHN);
       event Revsqn(); event Revsqn();
    out(~sqn_root))
@@ -648,20 +648,20 @@ let addSub(~idHN,~sk_HN,~secureChan) = // HSS(~idHN, ~sk_HN)
       // trivially violate injectivity
 	(
 	lock ~supi;
-	lookup ~supi as count:nat in
+	lookup ~supi as %count4:nat in
 
-	event CounterGS(~supi,count);
-//	let Sqn:nat = ~sqn_root + count in
+	event CounterGS(~supi,%count4);
+//	let Sqn:nat = ~sqn_root + %count4 in
 //	in(m:nat); 		// Open chains
-	event	Sqn_UE_Invariance(~supi, ~idHN, ~sqn_root, count+'one');
+	event	Sqn_UE_Invariance(~supi, ~idHN, ~sqn_root, %count4 %+%1);
 		// Helper lemmas
-	event	Sqn_UE_Change(~supi, ~idHN, count+'one');
+	event	Sqn_UE_Change(~supi, ~idHN, %count4 %+%1);
 		// Executability
 	event	Sqn_UE_Desync();
 
-	insert ~supi, count+'one';
+	insert ~supi, %count4%+%1;
 	unlock ~supi
-	//Sqn_UE(~supi, ~idHN, Sqn+m, ~sqn_root, count+m)
+	//Sqn_UE(~supi, ~idHN, Sqn+m, ~sqn_root, %count4+m)
 	)
 
 
@@ -775,19 +775,19 @@ lemma true_sqn_ue_nodecrease [use_induction, reuse, output=[spthy], heuristic=O]
 	" (All supi HN Sqni Sqnj #i #j.
 		(Sqn_UE_Change(supi, HN, Sqnj)@j &
 		 Sqn_UE_Change(supi, HN, Sqni)@i &
-		 i < j)	==> (Ex dif. Sqnj = Sqni + dif)) &
+		 i < j)	==> (Ex dif. Sqnj = Sqni %+ dif)) &
 	  (All supi HN Sqni Sqnj #i #j.
 		(Sqn_UE_Change(supi, HN, Sqnj)@j &
 		 Sqn_UE_Nochange(supi, HN, Sqni)@i &
-		 i < j)	==> (Ex dif. Sqnj = Sqni + dif)) &
+		 i < j)	==> (Ex dif. Sqnj = Sqni %+ dif)) &
 	  (All supi HN Sqni Sqnj #i #j.
 		(Sqn_UE_Nochange(supi, HN, Sqnj)@j &
 		 Sqn_UE_Change(supi, HN, Sqni)@i &
-		 i < j)	==> ((Sqnj = Sqni) | (Ex dif. Sqnj = Sqni + dif))) &
+		 i < j)	==> ((Sqnj = Sqni) | (Ex dif. Sqnj = Sqni %+ dif))) &
 	  (All supi HN Sqni Sqnj #i #j.
 		(Sqn_UE_Nochange(supi, HN, Sqnj)@j &
 		 Sqn_UE_Nochange(supi, HN, Sqni)@i &
-		 i < j)	==> ((Sqnj = Sqni) | (Ex dif. Sqnj = Sqni + dif))) "
+		 i < j)	==> ((Sqnj = Sqni) | (Ex dif. Sqnj = Sqni %+ dif))) "
 
 // // proof (automatic) (~1 sec)
  lemma true_sqn_ue_unique [reuse, hide_lemma=true_sqn_ue_src, hide_lemma=true_sqn_hss_src, output=[spthy], heuristic=O]:
@@ -827,7 +827,7 @@ lemma false_executability_desync[output=[proverif]]:
 //
 lemma false_executability_resync[output=[proverif]]:
 	" All #i2.
-		 HSS_Resync_End('one'+'one'+'one'+'one')@i2
+		 HSS_Resync_End(%1%+%1%+%1%+%1)@i2
 ==>
 Ex X data #r. Rev(X,data)@r
 "
@@ -950,7 +950,7 @@ lemma gsverif_sqn_hss_nodecrease [use_induction, reuse, output=[spthy], heuristi
 	" (All supi  Sqni Sqnj #i #j.
 			 (Sqn_HSS_Change(supi, Sqnj)@j &
 		 Sqn_HSS_Change(supi, Sqni)@i &
-		 i < j)	==> (Ex dif. Sqnj = Sqni + dif)) "
+		 i < j)	==> (Ex dif. Sqnj = Sqni %+ dif)) "
 
 
 lemma gsverif_intermediate [use_induction, reuse,hide_lemma=true_sqn_ue_src, hide_lemma=true_sqn_hss_src, output=[spthy], heuristic=O]:

--- a/examples/sapic/export/States/canauth.spthy
+++ b/examples/sapic/export/States/canauth.spthy
@@ -10,7 +10,7 @@ section{* CANauth protocol *}
    Tamarin: ?
 
 */
-builtins: dest-pairing, multiset
+builtins: dest-pairing, natural-numbers
 
 options: translation-state-optimisation
 
@@ -56,7 +56,7 @@ let ReceiverA =
   lookup cellA as i:nat in
   event Read(cellA,i);
   in(<msg,'SIGN',j:nat,h>);
-  if i (<) j then
+  if i << j then
     if h = hmac(sk,<j,msg>)
     then
       event Received(sk,msg,j);
@@ -70,9 +70,9 @@ let SenderA =
   lookup cellA as i:nat in
   event Read(cellA,i);
   new msg;
-  event Sent(sk,msg,i+'one');
-  out(<msg,'SIGN',i+'one',hmac(sk,<i+'one',msg>)>);
-  insert cellA, i+'one';
+  event Sent(sk,msg,i%+%1);
+  out(<msg,'SIGN',i%+%1,hmac(sk,<i%+%1,msg>)>);
+  insert cellA, i%+%1;
   unlock cellA
 
 let ReceiverB =
@@ -80,7 +80,7 @@ let ReceiverB =
   lookup cellB as i:nat in
   event Read(cellB,i);
   in(<msg,'SIGN',j:nat,h>);
-  if i (<) j then
+  if i << j then
     if h = hmac(sk,<j,msg>)
     then
       event Received(sk,msg,j);
@@ -94,10 +94,10 @@ let SenderB =
   lookup cellB as i:nat in
   event Read(cellB,i);
   new msg;
-  let j:nat = i+'one' in
+  let j:nat = i%+%1 in
   event Sent(sk,msg,j);
-  out(<msg,'SIGN',i+'one',hmac(sk,<i+'one',msg>)>);
-  insert cellB, i+'one';
+  out(<msg,'SIGN',i%+%1,hmac(sk,<i%+%1,msg>)>);
+  insert cellB, i%+%1;
   unlock cellB
 
   /* We generate an unbounded number of sessions, each with two senders and two receivers    */
@@ -110,8 +110,8 @@ let SenderB =
   /* unbounded number of cells.                                                              */
 process:
 !( new sk;
-   new cellA; insert cellA, 'zero'; event InitC(cellA);
-   new cellB; insert cellB, 'zero'; event InitC(cellB);
+   new cellA; insert cellA, %1; event InitC(cellA);
+   new cellB; insert cellB, %1; event InitC(cellB);
    ! ( ReceiverA || SenderA || ReceiverB || SenderB )
 )
 

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -351,6 +351,7 @@ auxppTerm ppLit t = (ppTerm t, getHdTerm t)
     ppACOp Mult = "*"
     ppACOp NatPlus = "+"
     ppACOp Xor = "⊕"
+    ppACOp u = translationFail $ "Unsupported operator " ++ show u
 
     ppXor [] = text "one"
     ppXor [t1, t2] = text "xor(" <> ppTerm t1 <> text ", " <> ppTerm t2 <> text ")"
@@ -394,6 +395,10 @@ auxppSapicTerm tc mVars isPattern = auxppTerm ppLit
         | S.member lvar mVars ->
           translationWarning ("Pattern matching on fresh variable "++n++" makes Tamarin and Proverif behaviours diverge.") $
           text "=" <> ppLVar lvar
+      Var (SapicLVar lvar@(LVar n LSortNat _) _)
+        | S.member lvar mVars ->
+          translationWarning ("Pattern matching on natural variable "++n++" makes Tamarin and Proverif behaviours diverge.") $
+          text "=" <> ppLVar lvar          
       Var (SapicLVar lvar _)
         | S.member lvar mVars -> text "=" <> ppLVar lvar
       l | isPattern -> ppTypeLit tc l
@@ -1079,9 +1084,8 @@ loadHeaders tc thy typeEnv = do
       foldl
         ( \y x -> case List.lookup x builtins of
             Nothing -> case x of
-              "multiset"         -> -- on the long run, this should throw UnsupportedBuiltinMS, but we currently allow to use multiset in a restricted fashion
-                translationWarning "you are using in the Sapic model the multiset builtin. Unless you are only using it to model natural numbers, this may result in a failure of the translation." y
-              "bilinear-pairing" -> throw UnsupportedBuiltinBP
+              "multiset"         -> translationFail "Multiset is not supported in ProVerif. If you want to model natural numbers, you can use the dedicated Tamarin builtin."
+              "bilinear-pairing" -> translationFail "Bilinear pairings are not supported in ProVerif."
               _                  -> y
             Just t -> y `S.union` t
         )

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -339,6 +339,7 @@ auxppTerm ppLit t = (ppTerm t, getHdTerm t)
       Lit v -> ppLit v
       FApp (AC Xor) ts -> ppXor ts
       FApp (AC o) ts -> ppTerms (ppACOp o) 1 "(" ")" ts
+      FApp (NoEq s) [] | s == natOneSym -> text "1"      
       FApp (NoEq s) [t1, t2] | s == expSym -> text "exp(" <> ppTerm t1 <> text ", " <> ppTerm t2 <> text ")"
       FApp (NoEq s) [t1, t2] | s == diffSym -> text "choice" <> text "[" <> ppTerm t1 <> text ", " <> ppTerm t2 <> text "]"
       FApp (NoEq _) [t1, t2] | isPair tm -> text "(" <> ppTerm t1 <> text ", " <> ppTerm t2 <> text ")"
@@ -348,7 +349,7 @@ auxppTerm ppLit t = (ppTerm t, getHdTerm t)
       FApp List ts -> ppFun (BC.pack "LIST") ts
 
     ppACOp Mult = "*"
-    ppACOp Union = "+"
+    ppACOp NatPlus = "+"
     ppACOp Xor = "⊕"
 
     ppXor [] = text "one"
@@ -880,6 +881,7 @@ ppProtoAtom _ True _ ppT (EqE l r) =
   (sep [ppT l <-> text "<>", ppT r], M.empty)
 -- sep [ppNTerm l <-> text "≈", ppNTerm r]
 ppProtoAtom _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
+ppProtoAtom _ _ _ ppT (Subterm u v) = (ppT u <-> opLess <-> ppT v, M.empty)
 ppProtoAtom _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
 
 ppAtom :: TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -407,9 +407,30 @@ typep = ( try (symbol defaultSapicTypeS) *> return Nothing)
 --   are all valid, but
 --   x: pub: foo
 --   is not
+-- We first redefine lvars but forbidding the suffix
+
+sortedLVarNoSuffix :: [LSort] -> Parser LVar
+sortedLVarNoSuffix ss =
+    asum $ map mkPrefixParser ss
+  where
+    mkPrefixParser s = do
+        case s of
+          LSortMsg       -> pure ()
+          LSortPub       -> void $ char '$'
+          LSortFresh     -> void $ char '~'
+          LSortNode      -> void $ char '#'
+          LSortNat       -> void $ char '%'
+        (n, i) <- indexedIdentifier
+        return (LVar n s i)
+
+-- | An arbitrary logical variable.
+lvarNoSuffix :: Parser LVar
+lvarNoSuffix = sortedLVarNoSuffix [minBound..]
+
+
 sapicvar :: Parser SapicLVar
 sapicvar = do
-        v <- lvar
+        v <- lvarNoSuffix
         t <- option Nothing $ colon *> typep
         return (SapicLVar v t)
 


### PR DESCRIPTION
Cf #582,
```
theory Test

begin

builtins: natural-numbers

process:

let ctr0:nat = %1 in
let ctr1:nat = ctr0 %+ %1 in
out(ctr1)

end
```
Now behaves as expected