### PR TITLE
Never redefine in the proverif export the nat type

### DIFF
--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -204,6 +204,7 @@ filterHeaders = S.filter (not . isForbidden)
     isForbidden (Fun "fun" "true" _ _ _) = True
     isForbidden (Type "bitstring") = True
     isForbidden (Type "channel") = True
+    isForbidden (Type "nat") = True    
     isForbidden _ = False
 
 -- We cannot define a constant and a function with the same name in proverif


### PR DESCRIPTION
In some cases, the sapic typing and priority of parsing makes it so that the export redefines the nat type of Proverif, which leads to failure. We simply never redefine the nat type to avoid any possible clashes.