### PR TITLE
Add back asum import to fix compilation

### DIFF
--- a/lib/utils/src/Extension/Prelude.hs
+++ b/lib/utils/src/Extension/Prelude.hs
@@ -15,6 +15,7 @@ import qualified Data.Set as S
 import qualified Data.Map as M
 import Data.Ord (comparing)
 import Data.Function (on)
+import Data.Foldable (asum)
 
 import Control.Basics
 


### PR DESCRIPTION
Fixes the following build failure on Arch:

```
 [16 of 24] Compiling Extension.Prelude ( src/Extension/Prelude.hs, dist/build/Extension/Prelude.dyn_o )

 src/Extension/Prelude.hs:231:13: error:
     • Variable not in scope: asum :: [f0 a] -> f a
     • Perhaps you meant one of these:
         ‘sum’ (imported from Prelude),
         ‘msum’ (imported from Control.Basics)
     |
 231 | oneOfList = asum . map pure
     |             ^^^^
```

The import was removed in #572 but probably still needed for older GHC versions like 9.0.2 that Arch still uses.