### PR TITLE
Usability improvements for derivability checks

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Rule.hs
+++ b/lib/theory/src/Theory/Text/Parser/Rule.hs
@@ -70,6 +70,7 @@ ruleAttribute = asum
     , symbol "color="  *> (Just . RuleColor <$> parseColor)
     , symbol "process="  *> parseAndIgnore
     , symbol "derivchecks" *> ignore
+    , symbol "no_derivcheck" *> ignore
     ]
   where
     parseColor = do

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -155,7 +155,7 @@ theoryLoadFlags =
   , flagOpt "5" ["saturation","s"] (updateArg "SaturationLimit" ) "PositiveInteger"
       "Limits the number of saturations during precomputations (default 5)"
 
-  , flagOpt "5" ["derivcheck-timeout"] (updateArg "derivcheck-timeout" ) "INT"
+  , flagOpt "5" ["derivcheck-timeout","d"] (updateArg "derivcheck-timeout" ) "INT"
       "Set timeout for message derivation checks in sec (default 5). 0 deactivates check."
 
 


### PR DESCRIPTION
This PR adds a shortcut "-d=" for "--derivcheck-timeout=" and adds rule attribute "no_derivcheck" to ignore derivability checks on a specific rule (rather than the previous "derivchecks", which might suggest the opposite).

Eventually, we might want to remove the "derivchecks" attribute.

A PR for the manual will follow.