### PR TITLE
Allow arbitrary public, fresh, and nat names

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -381,17 +381,22 @@ nodevar = asum
   , (\(n, i) -> LVar n LSortNode i) <$> indexedIdentifier ]
   <?> "timepoint variable"
 
+-- | Parse a non-empty single-quoted string
+-- | that does not contain a single-quote or newline.
+singleQuotedString :: Parser String
+singleQuotedString = singleQuoted $ many1 (noneOf "'\n")
+
 -- | Parse a literal fresh name, e.g., @~'n'@.
 freshName :: Parser String
-freshName = try (symbol "~" *> singleQuoted identifier)
+freshName = try (symbol "~" *> singleQuotedString)
 
 -- | Parse a literal public name, e.g., @'n'@.
 pubName :: Parser String
-pubName = singleQuoted identifier
+pubName = singleQuotedString
 
 -- | Parse a literal nat name, e.g. @%'n'@.
 natName :: Parser String
-natName = try (symbol "%" *> singleQuoted identifier)
+natName = try (symbol "%" *> singleQuotedString)
 
 -- | Parse a Sapic Type
 typep :: Parser SapicType


### PR DESCRIPTION
Previous to this change, public, fresh, and nat names were parsed as identifiers which artificially limited the set of expressible names in a theory.

Now arbitrary strings without single quotes and newlines are allowed. This allows including protocol constants verbatim, which could not be parsed as identifiers.