### PR TITLE
Run wellformedness checks in parse-only mode and on export

### DIFF
--- a/case-studies-regression/fast-tests/ccs15/DDH_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/ccs15/DDH_analyzed-diff.spthy
@@ -17,8 +17,6 @@ rule (modulo E) DDH:
   -->
    [ Out( <g^~x, g^~y, diff(g^~z, g^~x^~y)> ) ]
 
-/* All wellformedness checks were successful. */
-
 diffLemma Observational_equivalence:
 rule-equivalence
   case Rule_DDH
@@ -7557,19 +7555,18 @@ next
   qed
 qed
 
+/* All wellformedness checks were successful. */
+
 /*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -7577,7 +7574,7 @@ summary of summaries:
 analyzed: examples/ccs15/DDH.spthy
 
   output:          examples/ccs15/DDH.spthy.tmp
-  processing time: 4.08s
+  processing time: 6.43s
   
   DiffLemma:  Observational_equivalence : verified (2522 steps)
 

--- a/case-studies-regression/fast-tests/ccs15/probEnc_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/ccs15/probEnc_analyzed-diff.spthy
@@ -22,8 +22,6 @@ rule (modulo E) enc:
   -->
    [ Out( diff(~r1, penc(x, pk(k), ~r2)) ) ]
 
-/* All wellformedness checks were successful. */
-
 diffLemma Observational_equivalence:
 rule-equivalence
   case Rule_Destrd_0_fst
@@ -221,19 +219,18 @@ next
   qed
 qed
 
+/* All wellformedness checks were successful. */
+
 /*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -241,7 +238,7 @@ summary of summaries:
 analyzed: examples/ccs15/probEnc.spthy
 
   output:          examples/ccs15/probEnc.spthy.tmp
-  processing time: 0.16s
+  processing time: 0.32s
   
   DiffLemma:  Observational_equivalence : verified (75 steps)
 

--- a/case-studies-regression/fast-tests/csf18-xor/diff-models/CH07-UK3_analyzed-diff-obseqonly.spthy
+++ b/case-studies-regression/fast-tests/csf18-xor/diff-models/CH07-UK3_analyzed-diff-obseqonly.spthy
@@ -191,23 +191,6 @@ guarded formula characterizing all satisfying traces:
 */
 by sorry
 
-/*
-WARNING: the following wellformedness checks failed!
-
-Check presence of the --prove/--lemma arguments in theory
-=========================================================
-
-  --> 'Observational_equivalence' from arguments do(es) not correspond to a specified lemma in the theory 
-
-Message Derivation Checks
-=========================
-
-  The variables of the follwing rule(s) are not derivable from their premises, you may be performing unintended pattern matching.
-
-Rule reader2: 
-Failed to derive Variable(s): hash
-*/
-
 diffLemma Observational_equivalence:
 rule-equivalence
   case Rule_Equality
@@ -273,18 +256,32 @@ rule-equivalence
 qed
 
 /*
+WARNING: the following wellformedness checks failed!
+
+Check presence of the --prove/--lemma arguments in theory
+=========================================================
+
+  --> 'Observational_equivalence' from arguments do(es) not correspond to a specified lemma in the theory 
+
+Message Derivation Checks
+=========================
+
+  The variables of the follwing rule(s) are not derivable from their premises, you may be performing unintended pattern matching.
+
+Rule reader2: 
+Failed to derive Variable(s): hash
+*/
+
+/*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -292,7 +289,7 @@ summary of summaries:
 analyzed: examples/csf18-xor/diff-models/CH07-UK3.spthy
 
   output:          examples/csf18-xor/diff-models/CH07-UK3.spthy.tmp
-  processing time: 118.44s
+  processing time: 248.08s
   
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!

--- a/case-studies-regression/fast-tests/features/equivalence/MacroDiffprobEnc_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/features/equivalence/MacroDiffprobEnc_analyzed-diff.spthy
@@ -37,8 +37,6 @@ rule (modulo E) gen:
   rule (modulo E) gen:
      [ Fr( ~k ) ] --> [ !Key( ~k ), Out( pk(~k) ) ]
 
-/* All wellformedness checks were successful. */
-
 diffLemma Observational_equivalence:
 rule-equivalence
   case Rule_Destrd_0_fst
@@ -236,19 +234,18 @@ next
   qed
 qed
 
+/* All wellformedness checks were successful. */
+
 /*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -256,7 +253,7 @@ summary of summaries:
 analyzed: examples/features/equivalence/MacroDiffprobEnc.spthy
 
   output:          examples/features/equivalence/MacroDiffprobEnc.spthy.tmp
-  processing time: 0.15s
+  processing time: 0.23s
   
   DiffLemma:  Observational_equivalence : verified (75 steps)
 

--- a/case-studies-regression/fast-tests/features/equivalence/N5N6DiffTest_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/features/equivalence/N5N6DiffTest_analyzed-diff.spthy
@@ -14,8 +14,6 @@ equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
 rule (modulo E) Test:
    [ Fr( ~f ) ] --> [ Out( diff(h($A), ~f) ) ]
 
-/* All wellformedness checks were successful. */
-
 diffLemma Observational_equivalence:
 rule-equivalence
   case Rule_Equality
@@ -38,19 +36,18 @@ rule-equivalence
   qed
 qed
 
+/* All wellformedness checks were successful. */
+
 /*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -58,7 +55,7 @@ summary of summaries:
 analyzed: examples/features/equivalence/N5N6DiffTest.spthy
 
   output:          examples/features/equivalence/N5N6DiffTest.spthy.tmp
-  processing time: 0.08s
+  processing time: 0.11s
   
   DiffLemma:  Observational_equivalence : falsified - found trace (8 steps)
 

--- a/case-studies-regression/fast-tests/regression/diff/issue223_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/regression/diff/issue223_analyzed-diff.spthy
@@ -25,8 +25,6 @@ rule (modulo E) Attack3:
    Out( fake(~ni1, ~rnd1, ~ltkV1, ~ni1) ), Out( ~ltkV1 )
    ]
 
-/* All wellformedness checks were successful. */
-
 diffLemma Observational_equivalence:
 rule-equivalence
   case Rule_Attack3
@@ -3237,19 +3235,18 @@ next
   qed
 qed
 
+/* All wellformedness checks were successful. */
+
 /*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -3257,7 +3254,7 @@ summary of summaries:
 analyzed: examples/regression/diff/issue223.spthy
 
   output:          examples/regression/diff/issue223.spthy.tmp
-  processing time: 2.39s
+  processing time: 4.42s
   
   DiffLemma:  Observational_equivalence : verified (1082 steps)
 

--- a/case-studies-regression/fast-tests/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset_analyzed.spthy
+++ b/case-studies-regression/fast-tests/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset_analyzed.spthy
@@ -1252,28 +1252,24 @@ Facts occur in the left-hand-side but not in any right-hand-side
   
   3. in rule "YSM_AES_ESC_BLOCK_ENCRYPT":  factName `YSM_AES_ESC_BLOCK_ENCRYPT' arity: 1 multiplicity: Persistent
 
-Message Derivation Checks
-=========================
+Derivation Checks
+=================
 
-  The variables of the follwing rule(s) are not derivable from their premises, you may be performing unintended pattern matching.
-
-Rule YSM_AEAD_YUBIKEY_OTP_DECODE: 
-Failed to derive Variable(s): N
+  Derivation checks timed out.
+  Use --derivcheck-timeout=INT to configure timeout.
+  Set to 0 to deactivate for no timeout.
 */
 
 /*
 Generated from:
-Tamarin version 1.8.0
-Maude version 3.2.1
-Git revision: 93c7165df1b26f607b8475e26d3a7e0d54f295cb, branch: master
-Compiled at: 2023-08-29 12:56:59.317473841 UTC
+Tamarin version 1.9.0
+Maude version 3.2.2
+Git revision: 0194f3b61d6d8b8c1d70bbad8fe0a7143cac0fb3, branch: feature/export-wellformedness
+Compiled at: 2023-10-25 08:40:09.47146758 UTC
 */
 
 end
 /* Output
-maude tool: 'maude'
- checking version: 3.2.1. OK.
- checking installation: OK.
 
 ==============================================================================
 summary of summaries:
@@ -1281,7 +1277,7 @@ summary of summaries:
 analyzed: examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
 
   output:          examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy.tmp
-  processing time: 4.55s
+  processing time: 11.61s
   
   WARNING: 2 wellformedness check failed!
            The analysis results might be wrong!

--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -117,6 +117,7 @@ module Theory (
   , theoryRules
   , theoryLemmas
   , theoryCaseTests
+  , theoryFormalComments
   , theoryRestrictions
   , theoryProcesses
   , theoryProcessDefs
@@ -128,6 +129,7 @@ module Theory (
   , theoryAccLemmas
   , diffTheoryRestrictions
   , diffTheorySideRestrictions
+  , diffTheoryFormalComments
   , addTactic
   , addRestriction
   , addLemma

--- a/lib/theory/src/TheoryObject.hs
+++ b/lib/theory/src/TheoryObject.hs
@@ -54,12 +54,14 @@ module TheoryObject (
   , theoryProcessDefs
   , theoryPredicates
   , theoryMacros
+  , theoryFormalComments
   , diffTheoryRestrictions
   , diffTheorySideRestrictions
   , diffTheoryLemmas
   , diffTheorySideLemmas
   , diffTheoryDiffLemmas
   , diffTheoryMacros
+  , diffTheoryFormalComments
   , expandFormula
   , expandRestriction
   , expandLemma
@@ -305,6 +307,11 @@ theoryMacros :: Theory sig c r p s -> [Macro]
 theoryMacros =
     foldTheoryItem (const []) (const []) (const []) (const []) (const []) (\m -> m) (const []) <=< L.get thyItems
 
+-- | All formal comments of a theory.
+theoryFormalComments :: Theory sig c r p s -> [FormalComment]
+theoryFormalComments =
+    foldTheoryItem (const []) (const []) (const []) return (const []) (const []) (const []) <=< L.get thyItems
+
 -- | All restrictions of a theory.
 theoryRestrictions :: Theory sig c r p s -> [Restriction]
 theoryRestrictions =
@@ -367,6 +374,11 @@ diffTheoryRestrictions =
 diffTheoryMacros :: DiffTheory sig c r r2 p p2 -> [Macro]
 diffTheoryMacros =
     foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (\m -> m) (const []) <=< L.get diffThyItems
+
+-- | All formal comments of a diff theory.
+diffTheoryFormalComments :: DiffTheory sig c r r2 p p2 -> [FormalComment]
+diffTheoryFormalComments =
+    foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) return <=< L.get diffThyItems
 
 -- | All restrictions of one side of a theory.
 diffTheorySideRestrictions :: Side -> DiffTheory sig c r r2 p p2 -> [Restriction]

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -29,6 +29,8 @@ module Main.TheoryLoader (
 
   , TheoryLoadError(..)
   , loadTheory
+  , translateAndCheckTheory
+  , prettyOpenTheoryByModule
   , closeTheory
 
   -- ** Constructing automatic prover
@@ -72,11 +74,12 @@ import           Theory.Tools.IntruderRules          (specialIntruderRules, subt
                                                      , multisetIntruderRules, xorIntruderRules)
 import           Theory.Tools.Wellformedness
 import           Theory.Tools.MessageDerivationChecks
-import           Theory.Module (ModuleType (ModuleSpthy, ModuleMsr))
+import           Theory.Module
 
 import           TheoryObject                        (diffThyOptions)
 
 import qualified Sapic
+import qualified Export
 import           Main.Console
 
 import           Text.Read (readEither, readMaybe)
@@ -180,7 +183,7 @@ data TheoryLoadOptions = TheoryLoadOptions {
   , _oQuitOnWarning     :: Bool
   , _oAutoSources       :: Bool
   , _oVerboseMode       :: Bool
-  , _oOutputModule      :: Maybe ModuleType -- Note: This flag is only used for batch mode.
+  , _oOutputModule      :: ModuleType -- Note: This flag is only used for batch mode.
   , _oMaudePath         :: FilePath -- FIXME: Other functions defined in Environment.hs
   , _oParseOnlyMode     :: Bool
   , _oOpenChain         :: Integer
@@ -202,7 +205,7 @@ defaultTheoryLoadOptions = TheoryLoadOptions {
   , _oQuitOnWarning     = False
   , _oAutoSources       = False
   , _oVerboseMode       = False
-  , _oOutputModule      = Nothing
+  , _oOutputModule      = ModuleMsr
   , _oMaudePath         = "maude"
   , _oParseOnlyMode     = False
   , _oOpenChain         = 10
@@ -274,16 +277,13 @@ mkTheoryLoadOptions as = TheoryLoadOptions
     quitOnWarning = return $ argExists "quit-on-warning" as
     autoSources   = return $ argExists "auto-sources" as
 
-    outputModule
-    -- MSR is default module, i.e., we translate by default ... otherwise we get warnings for actions used in lemmas that appear only in processes.
-     | Nothing  <- findArg "outModule" as = return $ Just ModuleMsr
-     -- Otherwise, find output module  that matches string argument
-     | Just str <- findArg "outModule" as
-     , Just modCon <- find (\x -> show x  == str) (enumFrom minBound) = return $ Just modCon
-     | otherwise   = throwError $ ArgumentError "output mode not supported."
+    outputModule = case findArg "outModule" as of
+      Just str -> case find ((str ==) . show) [minBound..] of
+        Just m -> return m
+        _       -> throwError $ ArgumentError "output mode not supported."
+      Nothing   -> return $ L.get oOutputModule defaultTheoryLoadOptions
 
-    -- NOTE: Output mode implicitly activates parse-only mode
-    parseOnlyMode = return $ argExists "parseOnly" as || argExists "outModule" as
+    parseOnlyMode = return $ argExists "parseOnly" as
 
     chain = findArg "OpenChainsLimit" as
     chainDefault = L.get oOpenChain defaultTheoryLoadOptions
@@ -309,9 +309,7 @@ mkTheoryLoadOptions as = TheoryLoadOptions
 lemmaSelectorByModule :: HasLemmaAttributes l => TheoryLoadOptions -> l -> Bool
 lemmaSelectorByModule thyOpt lem = case lemmaModules of
     [] -> True -- default to true if no modules (or only empty ones) are set
-    _  -> case L.get oOutputModule thyOpt of
-      Just outMod -> outMod `elem` lemmaModules
-      Nothing     -> ModuleSpthy `elem` lemmaModules
+    _  -> (L.get oOutputModule thyOpt) `elem` lemmaModules
     where
         lemmaModules = concat [ m | LemmaModule m <- getField @"lAttributes" lem]
 
@@ -344,91 +342,83 @@ instance Show TheoryLoadError
     show (ParserError e) = show e
     show (WarningError e) = Pretty.render (prettyWfErrorReport e)
 
--- FIXME: How can we avoid the MonadCatch here?
-loadTheory :: MonadCatch m => TheoryLoadOptions -> String -> FilePath -> ExceptT TheoryLoadError m (Either OpenTheory OpenDiffTheory)
+-- | Load an open theory from a string with the given options.
+loadTheory :: Monad m => TheoryLoadOptions -> String -> FilePath -> ExceptT TheoryLoadError m (Either OpenTheory OpenDiffTheory)
 loadTheory thyOpts input inFile = do
     thy <- withExceptT ParserError $ liftEither $ unwrapError $ bimap parse parse thyParser
-    let thy' = addParamsOptions thyOpts thy
-    withTheory translate thy'
+    traceM ("[Theory " ++ theoryName thy ++ "] Theory loaded")
+    return $ addParamsOptions thyOpts thy
   where
     thyParser | isDiffMode = Right $ diffTheory $ Just inFile
               | otherwise  = Left  $ theory     $ Just inFile
 
     parse p = parseString (toParserFlags thyOpts) inFile p input
 
-    translate | isMSRModule = Sapic.typeTheory
-                          >=> Sapic.translate
-                          >=> Acc.translate
-              | otherwise   = return
-
     isDiffMode   = L.get oDiffMode thyOpts
-    isMSRModule  = L.get oOutputModule thyOpts == Just ModuleMsr
 
     unwrapError (Left (Left e)) = Left e
     unwrapError (Left (Right v)) = Right $ Left v
     unwrapError (Right (Left e)) = Left e
     unwrapError (Right (Right v)) = Right $ Right v
 
+    theoryName = either (L.get thyName) (L.get diffThyName)
+
+-- | Process an open theory based on the specified output module.
+processOpenTheory :: MonadCatch m => TheoryLoadOptions -> OpenTheory -> m OpenTheory
+processOpenTheory thyOpts = case modType of
+  ModuleSpthy               -> return
+  ModuleSpthyTyped          -> Sapic.typeTheory
+  ModuleMsr                 -> Sapic.typeTheory >=> Sapic.translate >=> Acc.translate >=> (return . filterLemma lemmas)
+  ModuleProVerifEquivalence -> Sapic.typeTheory -- Type theory here to catch errors.
+  ModuleProVerif            -> Sapic.typeTheory -- Type theory here to catch errors.
+  ModuleDeepSec             -> Sapic.typeTheory
+  where
+    modType = L.get oOutputModule thyOpts
+    lemmas = lemmaSelector thyOpts
+
+
+-- | Translate an open theory.
+translateTheory :: MonadCatch m => MonadError TheoryLoadError m => TheoryLoadOptions -> Either OpenTheory OpenDiffTheory -> m (WfErrorReport, Either OpenTheory OpenDiffTheory)
+translateTheory thyOpts thy = do
+    traceM ("[Theory " ++ theoryName thy ++ "] Theory translated")
+    let report = either (\t -> Sapic.checkWellformedness t ++ Acc.checkWellformedness t) (const []) thy
+    transThy <- withTheory (processOpenTheory thyOpts) thy
+    return (report, transThy)
+  where
     withTheory f = bitraverse f return
+    theoryName = either (L.get thyName) (L.get diffThyName)
 
-closeTheory :: MonadIO m => MonadError TheoryLoadError m => String -> TheoryLoadOptions -> SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> m ((WfErrorReport, Either ClosedTheory ClosedDiffTheory))
-closeTheory version thyOpts sign srcThy = do
-  let name = either (L.get thyName) (L.get diffThyName) srcThy
-
-  traceM ("[Theory " ++ show name ++ "] Loading Theory")
-
-  let preReport = either (\t -> Sapic.checkWellformedness t ++ Acc.checkWellformedness t)
-                         (const []) srcThy
-
-  transThy   <- withTheory (return . removeTranslationItems) srcThy
-
+-- | Perform wellformedness and deducability checks on a theory.
+checkTranslatedTheory :: MonadIO m => MonadError TheoryLoadError m => TheoryLoadOptions -> SignatureWithMaude -> Either OpenTranslatedTheory OpenDiffTheory -> m ((WfErrorReport, Either OpenTranslatedTheory OpenDiffTheory))
+checkTranslatedTheory thyOpts sign thy = do
   let transReport = either (`checkWellformedness` sign)
-                           (`checkWellformednessDiff` sign) transThy
+                           (`checkWellformednessDiff` sign) thy
 
-  let wellformednessReport = preReport ++ transReport
+  deducThy <- bitraverse (return . addMessageDeductionRuleVariants)
+                         (return . addMessageDeductionRuleVariantsDiff) thy
 
-  when (quitOnWarning && not (null wellformednessReport)) (throwError $ WarningError wellformednessReport)
-
-  deducThy   <- bitraverse (return . addMessageDeductionRuleVariants)
-                           (return . addMessageDeductionRuleVariantsDiff) transThy
 
   variableReport <- case compare derivChecks 0 of
     EQ -> pure $ Just []
     _ -> do
-      traceM ("[Theory " ++ show name ++ "] Derivation Checks Begin")
-      derivCheckSignature <- Control.Monad.Except.liftIO $ toSignatureWithMaude (get oMaudePath thyOpts) $ maudePublicSig (toSignaturePure sign)
-      rep <- Control.Monad.Except.liftIO $ timeout (1000000 * derivChecks) $ evaluate . force $ either (\t -> checkVariableDeducability  t derivCheckSignature autoSources defaultProver)
-        (\t-> diffCheckVariableDeducability t derivCheckSignature autoSources defaultProver defaultDiffProver) deducThy
-      traceM ("[Theory " ++ show name ++ "] Derivation Checks End")
+      traceM ("[Theory " ++ theoryName thy ++ "] Derivation checks started")
+      derivCheckSignature <- liftIO $ toSignatureWithMaude (get oMaudePath thyOpts) $ maudePublicSig (toSignaturePure sign)
+      rep <- liftIO $ timeout (1000000 * derivChecks) $ evaluate . force $ either (\t -> checkVariableDeducability t derivCheckSignature autoSources defaultProver)
+             (\t-> diffCheckVariableDeducability t derivCheckSignature autoSources defaultProver defaultDiffProver) deducThy
+      traceM ("[Theory " ++ theoryName thy ++ "] Derivation checks ended")
       return rep
 
+  let report = transReport ++ fromMaybe derivTimeoutMsg  variableReport
 
-  let report = wellformednessReport  ++ fromMaybe [(underlineTopic "Derivation Checks", Pretty.text "Derivation checks timed out. Use --derivcheck-timeout=INT to configure timeout, 0 to deactivate.")] variableReport
-
-  checkedThy <- bitraverse (return . addComment     (reportToDoc report))
-                           (return . addDiffComment (reportToDoc report)) deducThy
-
-  when (quitOnWarning && not (null report)) (throwError $ WarningError report)
-
-  diffLemThy <- withDiffTheory (return . addDefaultDiffLemma) checkedThy
-  closedThy  <- bitraverse (\t -> return $ closeTheoryWithMaude     sign t autoSources True)
-                           (\t -> return $ closeDiffTheoryWithMaude sign t autoSources) diffLemThy
-  partialThy <- bitraverse (return . maybe id (`applyPartialEvaluation` autoSources) partialStyle)
-                           (return . maybe id (`applyPartialEvaluationDiff` autoSources) partialStyle) closedThy
-  provedThy  <- bitraverse (return . proveTheory     (lemmaSelectorByModule thyOpts &&& lemmaSelector thyOpts) prover)
-                           (return . proveDiffTheory (lemmaSelectorByModule thyOpts &&& lemmaSelector thyOpts) prover diffProver) partialThy
-  provedThyWithVersion <- bitraverse (return . addComment (Pretty.text version))
-                           (return . addDiffComment (Pretty.text version) )  provedThy
-
-  traceM ("[Theory " ++ show name ++ "] Theory Loaded")
-
-  return (report, provedThyWithVersion)
-
+  return (report, deducThy)
   where
     autoSources = L.get oAutoSources thyOpts
     derivChecks = L.get oDerivationChecks thyOpts
-    partialStyle = L.get oPartialEvaluation thyOpts
-    quitOnWarning = L.get oQuitOnWarning thyOpts
+    derivTimeoutMsg = [(underlineTopic "Derivation Checks"
+                      , Pretty.vcat [
+                          Pretty.text "Derivation checks timed out."
+                        , Pretty.text "Use --derivcheck-timeout=INT to configure timeout."
+                        , Pretty.text "Set to 0 to deactivate for no timeout." ])]
 
     defaultProver = replaceSorryProver $ runAutoProver $ constructAutoProver defaultTheoryLoadOptions
     defaultDiffProver = replaceDiffSorryProver $ runAutoDiffProver $ constructAutoProver defaultTheoryLoadOptions
@@ -444,20 +434,95 @@ closeTheory version thyOpts sign srcThy = do
       x -> x
       )
 
+    theoryName = either (L.get thyName) (L.get diffThyName)
+
+-- | Add report and version information to a theory.
+withVersionAndReport :: MonadError TheoryLoadError m => String -> TheoryLoadOptions -> WfErrorReport -> Either (Theory sig1 c1 r1 p1 s) (DiffTheory sig2 c2 r2 r3 p2 p3) -> m (Either (Theory sig1 c1 r1 p1 s) (DiffTheory sig2 c2 r2 r3 p2 p3))
+withVersionAndReport version thyOpts report thy = do
+    reportThy <- bitraverse (return . addComment     (reportToDoc report))
+                            (return . addDiffComment (reportToDoc report)) thy
+
+    versionThy <- bitraverse (return . addComment (Pretty.text version))
+                             (return . addDiffComment (Pretty.text version) ) reportThy
+
+    when (quitOnWarning && not (null report)) (throwError $ WarningError report)
+
+    return versionThy
+  where
+    quitOnWarning = L.get oQuitOnWarning thyOpts
+
+    reportToDoc rep
+      | null rep = Pretty.text "All wellformedness checks were successful."
+      | otherwise   = Pretty.vsep
+                        [ Pretty.text "WARNING: the following wellformedness checks failed!"
+                        , prettyWfErrorReport rep ]
+
+-- | Close a translated theory.
+closeTranslatedTheory :: MonadError TheoryLoadError m => TheoryLoadOptions -> SignatureWithMaude -> Either OpenTranslatedTheory OpenDiffTheory -> m (Either ClosedTheory ClosedDiffTheory)
+closeTranslatedTheory thyOpts sign srcThy = do
+  diffLemThy <- withDiffTheory (return . addDefaultDiffLemma) srcThy
+  closedThy  <- bitraverse (\t -> return $ closeTheoryWithMaude     sign t autoSources True)
+                           (\t -> return $ closeDiffTheoryWithMaude sign t autoSources) diffLemThy
+  partialThy <- bitraverse (return . maybe id (`applyPartialEvaluation` autoSources) partialStyle)
+                           (return . maybe id (`applyPartialEvaluationDiff` autoSources) partialStyle) closedThy
+  provedThy  <- bitraverse (return . proveTheory     (lemmaSelectorByModule thyOpts &&& lemmaSelector thyOpts) prover)
+                           (return . proveDiffTheory (lemmaSelectorByModule thyOpts &&& lemmaSelector thyOpts) prover diffProver) partialThy
+
+  traceM ("[Theory " ++ theoryName srcThy ++ "] Theory closed")
+
+  return provedThy
+  where
+    autoSources = L.get oAutoSources thyOpts
+    partialStyle = L.get oPartialEvaluation thyOpts
+
     prover | L.get oProveMode thyOpts = replaceSorryProver $ runAutoProver $ constructAutoProver thyOpts
            | otherwise                = mempty
 
     diffProver | L.get oProveMode thyOpts = replaceDiffSorryProver $ runAutoDiffProver $ constructAutoProver thyOpts
                | otherwise                = mempty
 
-    reportToDoc report
-      | null report = Pretty.text "All wellformedness checks were successful."
-      | otherwise   = Pretty.vsep
-                        [ Pretty.text "WARNING: the following wellformedness checks failed!"
-                        , prettyWfErrorReport report ]
-
-    withTheory f = bitraverse f return
     withDiffTheory = bitraverse return
+
+    theoryName = either (L.get thyName) (L.get diffThyName)
+
+-- | Translate an open theory, perform checks on the translated theory and finally close it.
+closeTheory :: MonadCatch m => MonadIO m => MonadError TheoryLoadError m => String -> TheoryLoadOptions -> SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> m ((WfErrorReport, Either ClosedTheory ClosedDiffTheory))
+closeTheory version thyOpts sign srcThy = do
+  (preReport, transThy)    <- translateTheory thyOpts srcThy
+  removedThy               <- withTheory (return . removeTranslationItems) transThy
+  (postReport, checkedThy) <- checkTranslatedTheory thyOpts sign removedThy
+  closedThy                <- closeTranslatedTheory thyOpts sign checkedThy
+  finalThy                 <- withVersionAndReport version thyOpts (preReport ++ postReport) closedThy
+
+  return (preReport ++ postReport, finalThy)
+  where
+    withTheory f = bitraverse f return
+
+-- | Translate an open theory and perform checks on the translated theory.
+translateAndCheckTheory :: MonadCatch m => MonadIO m => MonadError TheoryLoadError m => String -> TheoryLoadOptions -> SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> m ((WfErrorReport, Either OpenTheory OpenDiffTheory))
+translateAndCheckTheory version thyOpts sign srcThy = do
+  (preReport, transThy) <- translateTheory thyOpts srcThy
+  removedThy            <- withTheory (return . removeTranslationItems) transThy
+  (postReport, _)       <- checkTranslatedTheory thyOpts sign removedThy
+  finalThy              <- withVersionAndReport version thyOpts (preReport ++ postReport) transThy
+
+  return (preReport ++ postReport, finalThy)
+  where
+    withTheory f = bitraverse f return
+
+-- | Pretty print an open theory based on the specified output module.
+prettyOpenTheoryByModule :: TheoryLoadOptions -> OpenTheory -> IO Pretty.Doc
+prettyOpenTheoryByModule thyOpts = case modType of
+  ModuleSpthy               -> return . prettyOpenTheory
+  ModuleSpthyTyped          -> return . prettyOpenTheory
+  ModuleMsr                 -> return . prettyOpenTranslatedTheory . removeTranslationItems
+  ModuleProVerifEquivalence -> Export.prettyProVerifEquivTheory   <=< Sapic.typeTheoryEnv
+  ModuleProVerif            -> Export.prettyProVerifTheory lemmas <=< Sapic.typeTheoryEnv
+  ModuleDeepSec             -> Export.prettyDeepSecTheory
+  where
+    modType = L.get oOutputModule thyOpts
+    lemmas = lemmaSelector thyOpts
+
 
 (&&&) :: (t -> Bool) -> (t -> Bool) -> t -> Bool
 (&&&) f g x = f x && g x


### PR DESCRIPTION
Wellformedness checks are now also executed in parse-only mode and when exporting to other formats. Warnings and the version string are included as comments in tho output.