### PR TITLE
Copyright simplification

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,11 @@
 Authors:
   Benedikt Schmidt <beschmi@gmail.com>
-  Simon Meier      <iridcode@gmail.com>
-
-Obervational Equivalence authors:
+  Simon Meier <iridcode@gmail.com>
+  Cas Cremers <cremers@cispa.de>
   Jannik Dreier <research@jannikdreier.net>
-  Ralf Sasse    <ralf.sasse@gmail.com>
+  Ralf Sasse <ralf.sasse@gmail.com>
 
 Contributors:
-  protocol models, GUI:   Cas Cremers <cremers@cispa.de>
   original web interface: Cedric Staub <cs@cssx.ch>
   YubiKey models, SAPIC:  Robert Kuennemann <robert.kuennemann@cispa.de>
   and many others

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -5,8 +5,8 @@ version:            1.9.0
 license:            GPL
 license-file:       LICENSE
 category:           Theorem Provers
-author:             Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
-                    Simon Meier <simon.meier@inf.ethz.ch>,
+author:             Benedikt Schmidt,
+                    Simon Meier,
                     Cas Cremers <cremers@cispa.de>,
                     Jannik Dreier <research@jannikdreier.net>,
                     Ralf Sasse <ralf.sasse@gmail.com>

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -7,6 +7,7 @@ license-file:       LICENSE
 category:           Theorem Provers
 author:             Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
                     Simon Meier <simon.meier@inf.ethz.ch>,
+                    Cas Cremers <cremers@cispa.de>,
                     Jannik Dreier <research@jannikdreier.net>,
                     Ralf Sasse <ralf.sasse@gmail.com>
 maintainer:         Cas Cremers <cremers@cispa.de>,


### PR DESCRIPTION
We have not consistently added copyright lines to each individual file, and most of these individual file lines are now outdated; a similar thing can be said for the maintainer lines. In general, the authors of a file can be reconstructed from the changelog, which is more indicative. 

However, we should at least try to keep the top-level main files somewhat sane. This is another pass to make the main files more up-to-date. This will probably need more work in the near future.