### PR TITLE
Small fixes

### DIFF
--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -541,12 +541,11 @@ transitiveReduction sys totalRed=
     where
         oldLessesWithR = S.toList $ get sLessAtoms sys
         oldLesses = rawLessRel sys
-        newLesses =
-            case totalRed of
-                True ->[(x,y,z)| (x,y,z)<- oldLessesWithR,
+        newLesses = if totalRed
+            then [(x,y,z)| (x,y,z)<- oldLessesWithR,
                             (x,y) `elem` (D.transRed oldLesses) ]
-                False ->[(x,y,z)| (x,y,z)<- oldLessesWithR,
-                            (x,y) `elem` (D.transRed oldLesses) || z == Formula]
+            else [(x,y,z)| (x,y,z)<- oldLessesWithR,
+                            (x,y) `elem` (D.transRed oldLesses) || z == Formula || z == Adversary ]
 
 
 -- | @hideTransferNode v se@ hides node @v@ in sequent @se@ if it is a

--- a/lib/utils/src/Extension/Prelude.hs
+++ b/lib/utils/src/Extension/Prelude.hs
@@ -15,6 +15,7 @@ import qualified Data.Set as S
 import qualified Data.Map as M
 import Data.Ord (comparing)
 import Data.Function (on)
+import Data.Foldable (asum)
 
 import Control.Basics
 

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -1606,9 +1606,9 @@ nextThyPath :: ClosedTheory -> TheoryPath -> TheoryPath
 nextThyPath thy = go
   where
     go TheoryHelp                       = TheoryMessage
-    go TheoryMessage                    = TheoryTactic
-    go TheoryTactic                     = TheoryRules
-    go TheoryRules                      = TheorySource RawSource 0 0
+    go TheoryMessage                    = TheoryRules
+    go TheoryRules                      = TheoryTactic
+    go TheoryTactic                     = TheorySource RawSource 0 0
     go (TheorySource RawSource _ _)     = TheorySource RefinedSource 0 0
     go (TheorySource RefinedSource _ _) = fromMaybe TheoryHelp firstLemma
     go (TheoryLemma lemma)              = TheoryProof lemma []
@@ -1699,9 +1699,9 @@ prevThyPath thy = go
   where
     go TheoryHelp                        = TheoryHelp
     go TheoryMessage                     = TheoryHelp
-    go TheoryTactic                      = TheoryMessage
-    go TheoryRules                       = TheoryTactic
-    go (TheorySource RawSource _ _)      = TheoryRules
+    go TheoryRules                       = TheoryMessage
+    go TheoryTactic                      = TheoryRules
+    go (TheorySource RawSource _ _)      = TheoryTactic
     go (TheorySource RefinedSource _ _)  = TheorySource RawSource 0 0
     go (TheoryLemma l)
       | Just prevLemma <- getPrevLemma l = TheoryProof prevLemma (lastPath prevLemma)
@@ -1814,9 +1814,9 @@ nextSmartThyPath :: ClosedTheory -> TheoryPath -> TheoryPath
 nextSmartThyPath thy = go
   where
     go TheoryHelp                         = TheoryMessage
-    go TheoryMessage                      = TheoryTactic
-    go TheoryTactic                       = TheoryRules
-    go TheoryRules                        = TheorySource RawSource 0 0
+    go TheoryMessage                      = TheoryRules
+    go TheoryRules                        = TheoryTactic
+    go TheoryTactic                       = TheorySource RawSource 0 0
     go (TheorySource RawSource _ _)       = TheorySource RefinedSource 0 0
     go (TheorySource RefinedSource   _ _) = fromMaybe TheoryHelp firstLemma
     go (TheoryLemma lemma)                = TheoryProof lemma []
@@ -1913,9 +1913,9 @@ prevSmartThyPath thy = go
   where
     go TheoryHelp                          = TheoryHelp
     go TheoryMessage                       = TheoryHelp
-    go TheoryTactic                        = TheoryMessage
-    go TheoryRules                         = TheoryTactic
-    go (TheorySource RawSource _ _)        = TheoryRules
+    go TheoryRules                         = TheoryMessage
+    go TheoryTactic                        = TheoryRules
+    go (TheorySource RawSource _ _)        = TheoryTactic
     go (TheorySource RefinedSource   _ _)  = TheorySource RawSource 0 0
     go (TheoryLemma l)
       | Just prevLemma <- getPrevLemma l   = TheoryProof prevLemma (lastPath prevLemma)


### PR DESCRIPTION
This PR fixes 3 smaller issues:
- The bound for the bounded autoprover was not parsed correctly: https://github.com/tamarin-prover/tamarin-prover/issues/600 (but this PR supersedes https://github.com/tamarin-prover/tamarin-prover/pull/601 by adding some refactoring)
- With the addition of tactics, the keyboard shortcuts jumped through the different pages in wrong order
- The transitive reduction sometimes eliminated Adversary deduction edges, for example it was possible to have a decryption node without an incoming edge for the key that was used (if that key was already used previously). Now by default all Adversary deduction edges are kept.