### PR TITLE
Archive case studies of CI run as artifact

### DIFF
--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -75,11 +75,13 @@ jobs:
       - name: Regression tests
         run: |
           tamarin-prover test
-          python3 regressionTests.py -noi
+          python3 regressionTests.py -v 6 -noi
 
       - name: Archive case studies as artifact
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: case-studies
-          path: case-studies
+          name: case-studies-with-regression
+          path: |
+            case-studies
+            case-studies-regression

--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -81,7 +81,5 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: case-studies-with-regression
-          path: |
-            case-studies
-            case-studies-regression
+          name: case-studies
+          path: case-studies

--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -76,3 +76,9 @@ jobs:
         run: |
           tamarin-prover test
           python3 regressionTests.py -noi
+
+      - name: Archive case studies as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: case-studies
+          path: case-studies

--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -77,7 +77,7 @@ jobs:
           tamarin-prover test
           python3 regressionTests.py -v 6 -noi
 
-      - name: Archive case studies as artifact
+      - name: Store case studies as artifact
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -78,6 +78,7 @@ jobs:
           python3 regressionTests.py -noi
 
       - name: Archive case studies as artifact
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: case-studies


### PR DESCRIPTION
The case studies of the regression tests are now uploaded as an artifact.
This makes it easier to debug failures of the runs.
Moreover, it allows updating the regression tests in case of changes with the ones produced by the CI.