### PR TITLE
Display 'None' when there are no injective fact instances

### DIFF
--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -876,7 +876,7 @@ rulesSnippet thy = vcat
                                 else ppWithHeader "Macros" $ 
         (prettyMacros $ theoryMacros thy)
     , ppWithHeader "Fact Symbols with Injective Instances" $
-        fsepList (text . showInjFact) injFacts
+        (if null injFacts then text "None" else fsepList (text . showInjFact) injFacts)
     , ppWithHeader "Multiset Rewriting Rules" $
         (if null(theoryMacros thy) then text empty else text "(Shown with macros application)") <-> (vsep $ map prettyRuleAC msrRules)
     , ppWithHeader "Restrictions of the Set of Traces" $
@@ -942,7 +942,7 @@ rulesDiffSnippetSide s isdiff thy = vcat
                                      else ppWithHeader "Macros" $
         (prettyMacros $ diffTheoryMacros thy)
     ,ppWithHeader "Fact Symbols with Injective Instances" $
-        fsepList (text . showInjFact) injFacts
+        (if null injFacts then text "None" else fsepList (text . showInjFact) injFacts)
     , ppWithHeader "Multiset Rewriting Rules" $
         (if null(diffTheoryMacros thy) then text empty else text "(Shown with macros application)") <-> (vsep $ map prettyRuleAC msrRules)
     , ppWithHeader "Restrictions of the Set of Traces" $


### PR DESCRIPTION
Previously, the section on injective fact instances would simply not be rendered. This should make the GUI more approachable.

Example screenshot with change:

![image](https://github.com/tamarin-prover/tamarin-prover/assets/9728715/e4fa3c39-611b-43f7-852c-21aaedaaee4b)
