### PR TITLE
Quick fix to preserve options in a proof.

### DIFF
--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -74,7 +74,40 @@ var server = {
         if(data.redirect) {
             // Server wants redirect
             loadingScreen.show(data.redirect);
-            window.location.href = data.redirect;
+            // Add the image query parameters so that the server response directly contains an image url with the correct parameters.
+            // Get image settings from cookie
+            var params = []
+            // If level == 0, do not compact and compress
+            if (parseInt($.cookie("simplification")) == 0) {
+                params = params.concat(
+                    { name: "uncompact", value: "" }
+                );
+                params = params.concat(
+                    { name: "uncompress", value: "" }
+                );
+            }
+            if ($.cookie("abbreviate") == null) {
+                params = params.concat(
+                    { name: "unabbreviate", value: "" }
+                );
+            }
+            params = params.concat(
+                { name: "simplification", value: $.cookie("simplification") }
+            );
+
+            if($.cookie("auto-sources")== null){
+                params = params.concat(
+                  { name: "no-auto-sources", value: ""}  
+                );
+            }
+
+            var redirectUrl = data.redirect;
+            // Rewrite image paths (if necessary)
+            if(params.length > 0) {
+                var query_string = $.param(params);
+                redirectUrl = redirectUrl + "?" + query_string;
+            }
+            window.location.href = redirectUrl;
         } else if(data.alert) {
             // Server requested alert box
             ui.showDialog(data.alert);
@@ -151,7 +184,7 @@ var ui = {
             $.cookie("not-init",null,{path: "/"});
         }
 
-        $.cookie("simplification", 2, { path: '/' });
+        // $.cookie("simplification", 2, { path: '/' });
         // Navigation drop-down menus
         $("ul#navigation").superfish();
 

--- a/src/Web/Hamlet.hs
+++ b/src/Web/Hamlet.hs
@@ -286,12 +286,13 @@ proofStateDiffTpl renderUrl ti = do
 
 -- | Framing/UI-layout template (based on JavaScript/JQuery)
 overviewTpl :: RenderUrl
+            -> RenderUrl -- ^ URL renderer that includes GET parameters for the image.
             -> TheoryInfo -- ^ Theory information
             -> TheoryPath -- ^ Theory path to load into main
             -> IO Widget
-overviewTpl renderUrl info path = do
+overviewTpl renderUrl renderImgUrl info path = do
   proofState <- proofStateTpl renderUrl info
-  mainView <- pathTpl renderUrl info path
+  mainView <- pathTpl renderUrl renderImgUrl info path
   return [whamlet|
     $newline never
     <div .ui-layout-north>
@@ -343,13 +344,14 @@ overviewDiffTpl renderUrl info path = do
   
 -- | Theory path, displayed when loading main screen for first time.
 pathTpl :: RenderUrl
-        -> TheoryInfo   -- ^ The theory
-        -> TheoryPath   -- ^ Path to display on load
+        -> RenderUrl      -- ^ URL renderer that includes GET parameters for the image.
+        -> TheoryInfo     -- ^ The theory
+        -> TheoryPath     -- ^ Path to display on load
         -> IO Widget
-pathTpl renderUrl info path =
+pathTpl renderUrl renderImgUrl info path =
     return $ [whamlet|
                 $newline never
-                #{htmlThyPath renderUrl info path} |]
+                #{htmlThyPath renderUrl renderImgUrl info path} |]
 
 -- | Theory path, displayed when loading main screen for first time.
 pathDiffTpl :: RenderUrl

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -528,8 +528,11 @@ postRootR = do
 getOverviewR :: TheoryIdx -> TheoryPath -> Handler Html
 getOverviewR idx path = withTheory idx ( \ti -> do
   renderF <- getUrlRender
+  renderParamsF <- getUrlRenderParams
   defaultLayout $ do
-    overview <- liftIO $ overviewTpl renderF ti path
+    getParams <- reqGetParams <$> getRequest
+    let renderParamsF' route = renderParamsF route getParams
+    overview <- liftIO $ overviewTpl renderF renderParamsF' ti path
     setTitle (toHtml $ "Theory: " ++ get thyName (tiTheory ti))
     overview )
 
@@ -615,7 +618,7 @@ getTheoryPathMR idx path = do
     --
     go renderUrl _ ti = do
       let title = T.pack $ titleThyPath (tiTheory ti) path
-      let html = htmlThyPath renderUrl ti path
+      let html = htmlThyPath renderUrl renderUrl ti path
       return $ responseToJson (JsonHtml title $ toContent html)
 
 -- | Show a given path within a diff theory (main view).

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -506,6 +506,7 @@ sequentSnippet se path = refDotPath path $-$ preformatted Nothing (prettySystem 
 -- open-goals, and the new cases.
 subProofSnippet :: HtmlDocument d
                 => RenderUrl
+                -> RenderUrl                 -- ^ URL renderer that includes GET parameters for the image.
                 -> TheoryIdx                 -- ^ The theory index.
                 -> TheoryInfo                -- ^ The theory info of this index.
                 -> String                    -- ^ The lemma.
@@ -513,7 +514,7 @@ subProofSnippet :: HtmlDocument d
                 -> ProofContext              -- ^ The proof context.
                 -> IncrementalProof          -- ^ The sub-proof.
                 -> d
-subProofSnippet renderUrl tidx ti lemma proofPath ctxt prf =
+subProofSnippet renderUrl renderImgUrl tidx ti lemma proofPath ctxt prf =
     case psInfo $ root prf of
       Nothing -> text $ "no annotated constraint system / " ++ nCases ++ " sub-case(s)"
       Just se -> vcat $
@@ -522,7 +523,7 @@ subProofSnippet renderUrl tidx ti lemma proofPath ctxt prf =
         [ text ""
         , withTag "h3" [] (text "Constraint system")
         ] ++
-        [ refDotPath renderUrl tidx (TheoryProof lemma proofPath)
+        [ refDotPath renderImgUrl tidx (TheoryProof lemma proofPath)
         | nonEmptyGraph se ]
         ++
         [ preformatted (Just "sequent") (prettyNonGraphSystem se)
@@ -979,11 +980,12 @@ messageDiffSnippet s isdiff thy = vcat
         (vcat (intersperse (text "") $ t))
 
 -- | Render the item in the given theory given by the supplied path.
-htmlThyPath :: RenderUrl    -- ^ The function for rendering Urls.
-            -> TheoryInfo   -- ^ The info of the theory to render
-            -> TheoryPath   -- ^ Path to render
-            ->  Html
-htmlThyPath renderUrl info path =
+htmlThyPath :: RenderUrl      -- ^ The function for rendering Urls.
+            -> RenderUrl      -- ^ URL renderer that includes GET parameters for the image.
+            -> TheoryInfo     -- ^ The info of the theory to render
+            -> TheoryPath     -- ^ Path to render
+            -> Html
+htmlThyPath renderUrl renderImgUrl info path =
   go path
   where
     thy  = tiTheory info
@@ -1005,7 +1007,7 @@ htmlThyPath renderUrl info path =
     go (TheoryProof l p)       = pp $
         fromMaybe (text "No such lemma or proof path.") $ do
            lemma <- lookupLemma l thy
-           subProofSnippet renderUrl tidx info l p (getProofContext lemma thy)
+           subProofSnippet renderUrl renderImgUrl tidx info l p (getProofContext lemma thy)
              <$> resolveProofPath thy l p
 
     go (TheoryLemma _)         = pp $ text "Implement lemma pretty printing!"


### PR DESCRIPTION
This pull request addresses some UI behavior that we talked about previously. This was the easiest solution that still has a good latency even though it is a bit hacky to include the GET parameters in a request so that the server generates HTML including these parameters which will then be used in a second http request.
Not sure if this is actually needed or the original behavior is desired but I used it locally when testing out the abbreviation option.

**Commit message:**
The previous behavior was that if you change any options away from the default (e.g. turning off abbreviations or setting a simplification level other than 2) the UI would send a request to the server to render the current constraint graph under the new settings and update the current page.
However, when doing a proof step (e.g. solve X) the server sends a complete new HTML page describing the updated proof state, which then triggers a new request to render the constraint graph but using the default settings, even though the settings are still changed in the UI.

In this commit we add a quick hack to pass the image options via GET parameters when triggering the full page reload. The server will then generate an HTML page that includes an image URL with these parameters, so that the new image is generated correctly.
It would also possible to do everything client-side, i.e. when receiving the HTML page we rewrite the image URL locally. But this results in a higher latency, as the browser first has to execute JS code before requesting the image.