### PR TITLE
Add more comfortable debug tracing functions.

### DIFF
--- a/lib/utils/src/Debug/Trace/EnvTracer.hs
+++ b/lib/utils/src/Debug/Trace/EnvTracer.hs
@@ -1,0 +1,65 @@
+-- |
+-- Copyright   : (c) 2024 Adrian Dapprich
+-- License     : GPL v3 (see LICENSE)
+-- 
+--
+-- Module for helper functions to generate debug traces.
+-- Usage: DEBUG_TRACE=foo,bar tamarin-prover interactive <thy>
+-- This will enable all debug traces with keys "foo" or "bar"
+module Debug.Trace.EnvTracer (
+    etraceSectionLn
+  , etraceLn
+  , etraceLnM
+  ) where
+
+import           Data.List.Split (splitOn)
+import           System.IO.Unsafe (unsafePerformIO)
+import           System.Environment (lookupEnv)
+import qualified Debug.Trace as T
+
+-- | Environment variable.
+traceSettings :: String
+traceSettings = "DEBUG_TRACE"
+
+-- | Look up the `traceKey` in the `traceSettings` environment variable to check if a trace should be output.
+shouldTrace :: String -> Bool
+shouldTrace traceKey =
+  -- justification for unsafePerformIO: The normal Debug.trace functions also use this so that they can be used from a pure context.
+  let e = unsafePerformIO (lookupEnv traceSettings) in
+  case e of
+    Nothing -> False
+    Just setting -> traceKey `elem` splitOn "," setting
+
+-- | Output a trace title to separate different traces.
+etraceSectionLn :: String -> -- ^ Key that assigns this trace to a "category" and will be checked against the global trace settings.
+                   String -> -- ^ Title of the trace section.
+                   b -> b    -- ^ Normal arguments to trace.
+etraceSectionLn traceKey title = 
+  let fmt = "=== " ++ title ++ " " ++ replicate (80 - 5 - length title) '=' ++ "\n" in
+  if shouldTrace traceKey
+  then T.trace fmt
+  else id
+
+-- | Do a conditional debug trace.
+etraceLn :: String -> -- ^ Key that assigns this trace to a "category" and will be checked against the global trace settings.
+            String -> -- ^ Label for the trace output.
+            String -> -- ^ The string to be traced.
+            b -> b    -- ^ Normal arguments to trace.
+etraceLn traceKey label s =
+  let fmt = label ++ ": " ++ s ++ "\n" in
+  if shouldTrace traceKey
+  then T.trace fmt
+  else id
+
+-- | Do a conditional debug trace inside an Applicative/Monad f.
+etraceLnM :: Applicative f =>
+             String -> -- ^ Key that assigns this trace to a "category" and will be checked against the global trace settings.
+             String -> -- ^ Label for the trace output.
+             String -> -- ^ The string to be traced.
+             f ()
+etraceLnM traceKey label s = do
+  let fmt = label ++ ": " ++ s ++ "\n"
+  if shouldTrace traceKey
+    then T.traceM fmt
+    else pure ()
+  

--- a/lib/utils/tamarin-prover-utils.cabal
+++ b/lib/utils/tamarin-prover-utils.cabal
@@ -53,6 +53,7 @@ library
       , safe
       , syb
       , time
+      , split
       , transformers
       , exceptions
       , graphviz
@@ -87,6 +88,7 @@ library
         System.Timing
 
         Debug.Trace.Ignore
+        Debug.Trace.EnvTracer
 
         Utils.Misc
 

--- a/manual/src/011_advanced-features.md
+++ b/manual/src/011_advanced-features.md
@@ -833,3 +833,33 @@ With the monotonic term positions, we can additionally reason as follows: if the
   - (3) if `s⊏t`, then `i<j` is deduced
   - (5) if `¬s⊏t` and `¬s=t`, then `j<i` is deduced (as t⊏s must hold because of monotonicity)
 - for decreasing and strictly decreasing, the inverse of the increasing cases holds
+
+Convenience Functions for Print Debugging
+-------------------------------------------------------------------
+
+For debugging Haskell programs it is still convenient to use simple print debugging. 
+The standard library includes the `Debug.trace` family of functions that can even be used from a pure context to print debug output.
+Since adding too many debug prints can lead to a noisy output we implement some convenience functions on top of `Debug.trace`, which can be selectively turned on when debugging a certain section of the code.
+
+The following functions are implemented in the `Debug.Trace.EnvTracer` module.
+Functions usable in an Applicative/Monad have an "M" suffix.
+
+    etraceSectionLn :: String -> String -> b -> b    
+    etraceSectionLnM :: Applicative f => String -> String -> f ()
+    etraceLn :: String -> String -> String -> b -> b    
+    etraceLnM :: Applicative f => String -> String -> String -> f ()
+
+The first argument to all functions is a *trace key* string.
+When running Tamarin you can set the `DEBUG_TRACE` environment variable to a comma-separated list of trace keys, which will then enable the corresponding debug outputs. Any debug trace whose key is not contained in the environment variable will be suppressed.
+
+The `etraceSectionLn*` functions are used to make visual separators for debug outputs.
+The `etraceLn*` functions take a label to give context and an arbitrary string to print. 
+
+For example, the following example program would result in the debug output below if the `DEBUG_TRACE` variable contains "foo".
+
+    etraceSectionLn "foo" "TITLE" $
+    etraceLn "foo" "functionA" "called functionA" $
+    ...
+
+    === TITLE ======================================================================
+    functionA: called functionA


### PR DESCRIPTION
We add the function etraceLn (and etraceLnM) which is like Debug.trace (and traceM) but only outputs the trace if the supplied key is contained in the "DEBUG_TRACE" environment variable. This makes print debugging more comfortable since it's easy to add lots of print statements and selectively enable them.