### PR TITLE
Introduce abstract graph to generate dot/JSON from & implement abbreviations.

### DIFF
--- a/lib/term/src/Term/Term/Raw.hs
+++ b/lib/term/src/Term/Term/Raw.hs
@@ -238,15 +238,16 @@ instance Sized a => Sized (Term a) where
 -- Subterm Handling
 ----------------------------------------------------------------------
 
+-- | Check if a term is a subterm of another.
 isSubterm :: Eq a => Term a -> Term a -> Bool
-isSubterm x y = (x == y) || go x y
-  where
-    go t (FAPP _ ts) = any (isSubterm t) ts
-    go _ _ = False
+isSubterm t1 t2 = (t1 == t2) || isProperSubterm t1 t2
 
+-- | Check if a term is a proper subterm (i.e. subterm but not equal) of another.
 isProperSubterm :: Eq a => Term a -> Term a -> Bool
-isProperSubterm x y = (x /= y) && isSubterm x y
+isProperSubterm t (viewTerm -> FApp _ ts) = any (isSubterm t) ts
+isProperSubterm _ _ = False
 
+-- | Replace all subterms of a term top-down according to the supplied replacement function.
 replaceSubterm :: (Term a -> Term a) -> Term a -> Term a
 replaceSubterm f originalTerm =
   let newTerm = f originalTerm  in
@@ -254,6 +255,7 @@ replaceSubterm f originalTerm =
     (Lit _) -> newTerm
     FApp s ts -> termViewToTerm (FApp s (map (replaceSubterm f) ts))
 
+-- | Replace all proper subterms of a term top-down according to the supplied replacement function.
 replaceProperSubterm :: (Term a -> Term a) -> Term a -> Term a
 replaceProperSubterm f (viewTerm -> FApp s ts) = termViewToTerm (FApp s (map (replaceSubterm f) ts))
 replaceProperSubterm _ t = t

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -244,6 +244,9 @@ module Theory.Constraint.System (
   , prettyNonGraphSystemDiff
   , prettySource
 
+  , nonEmptyGraph
+  , nonEmptyGraphDiff
+
   ) where
 
 -- import           Debug.Trace
@@ -1912,3 +1915,20 @@ compareSystemsUpToNewVars
             compareNodes = compareNodesUpToNewVars a1 a2
 -- in case of diff systems, we remain prudent
 compareSystemsUpToNewVars s1 s2 = compare s1 s2
+
+
+-- | 'True' iff the dotted system will be a non-empty graph.
+nonEmptyGraph :: System -> Bool
+nonEmptyGraph sys = not $
+    M.null (L.get sNodes sys) && null (unsolvedActionAtoms sys) &&
+    null (unsolvedChains sys) &&
+    S.null (L.get sEdges sys) && S.null (L.get sLessAtoms sys)
+
+-- | 'True' iff the dotted system will be a non-empty graph.
+nonEmptyGraphDiff :: DiffSystem -> Bool
+nonEmptyGraphDiff diffSys = not $
+     case (L.get dsSystem diffSys) of
+          Nothing    -> True
+          (Just sys) -> M.null (L.get sNodes sys) && null (unsolvedActionAtoms sys) &&
+                        null (unsolvedChains sys) &&
+                        S.null (L.get sEdges sys) && S.null (L.get sLessAtoms sys)

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- |
 -- Copyright   : (c) 2010, 2011 Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -8,242 +10,85 @@
 --
 -- Conversion of the graph part of a sequent to a Graphviz Dot file.
 module Theory.Constraint.System.Dot (
-    dotSystemLoose
-  , dotSystemCompact
-  , compressSystem
-  , simplifySystem
+    dotSystemCompact
   , BoringNodeStyle(..)
+  , DotOptions
+  , doNodeStyle
+  , defaultDotOptions
   ) where
 
+import           Data.Ord
 import           Data.Char                (isSpace)
 import           Data.Color
-import qualified Data.DAG.Simple          as D
-import qualified Data.Foldable            as F
-import           Data.List                (find,foldl',intersect,isPrefixOf, intercalate,sort)
+import           Data.List                (find, isPrefixOf, intercalate, sortBy, intersperse)
 import qualified Data.Map                 as M
 import           Data.Maybe
-import           Data.Monoid              (Any(..))
 import qualified Data.Set                 as S
 import           Data.Ratio
-import           Safe
-
+import qualified Data.Text.Lazy           as T
 import           Extension.Data.Label
 import           Extension.Prelude
 
 import           Control.Basics
+import qualified Control.Category         as L
 import           Control.Monad.Reader
 import           Control.Monad.State      (StateT, evalStateT)
 
 import qualified Text.Dot                 as D
 import           Text.PrettyPrint.Class
 
-import           Theory.Constraint.System
+import           Theory.Constraint.System hiding (Edge, resolveNodeConcFact, resolveNodePremFact)
+import qualified Theory as Sys
+import           Theory.Constraint.System.Graph.Graph
 import           Theory.Model
 import           Theory.Text.Pretty       (opAction)
 
 import           Utils.Misc
+import qualified Data.Graph               as G
+import           Data.GraphViz.Attributes.HTML
+import qualified Data.GraphViz.Attributes.Colors as GColor
+import           Data.GraphViz.Printing   (renderDot, unqtDot)
 
 type NodeColorMap = M.Map (RuleInfo ProtoRuleACInstInfo IntrRuleACInfo) (RGB Rational)
-type SeDot = ReaderT (System, NodeColorMap) (StateT DotState D.Dot)
+type SeDot = ReaderT (Graph, NodeColorMap) (StateT DotState D.Dot)
 
--- | State to avoid multiple drawing of the same entity.
+-- | State to track the dot NodeId (different from a System NodeId) of created dot components.
 data DotState = DotState {
     _dsNodes   :: M.Map NodeId   D.NodeId
   , _dsPrems   :: M.Map NodePrem D.NodeId
   , _dsConcs   :: M.Map NodeConc D.NodeId
+  -- a.d. TODO this is unused. Check if I droppped it somewhere, else delete.
   , _dsSingles :: M.Map (NodeConc, NodePrem) D.NodeId
   }
 
 $(mkLabels [''DotState])
 
+-- | Wrap a computation that generates dot components (SeDot) in order cache that component in the DotState and be able to retrieve its NodeId.
+cacheState :: Ord k
+           => (DotState :-> M.Map k D.NodeId) -- ^ Accessor to map storing this type of actions.
+           -> k                               -- ^ Action index.
+           -> SeDot D.NodeId
+           -> SeDot ()
+cacheState stateAccessor k dot = do
+    i <- dot
+    modM stateAccessor (M.insert k i)
+
+-- | Retrieve a NodeId from a cached dot component.
+getState :: Ord k
+         => (DotState :-> M.Map k D.NodeId)
+         -> k 
+         -> String
+         -> SeDot D.NodeId
+getState stateAccessor k msg = do
+    stateMap <- getM stateAccessor
+    let mi = stateMap M.!? k
+    case mi of
+      Nothing -> error msg
+      Just i -> return i
+
 -- | Lift a 'D.Dot' action.
 liftDot :: D.Dot a -> SeDot a
 liftDot = lift . lift
-
--- | All edges in a bipartite graph that have neither start point nor endpoint
--- in common with any other edge.
-singleEdges :: (Ord a, Ord b) => [(a,b)] -> [(a,b)]
-singleEdges es =
-    singles fst es `intersect` singles snd es
-  where
-    singles proj = concatMap single . groupOn proj . sortOn proj
-    single []  = error "impossible"
-    single [x] = return x
-    single _   = mzero
-
--- | Ensure that a 'SeDot' action is only executed once by querying and
--- updating the 'DotState' accordingly.
-dotOnce :: Ord k
-        => (DotState :-> M.Map k D.NodeId) -- ^ Accessor to map storing this type of actions.
-        -> k                               -- ^ Action index.
-        -> SeDot D.NodeId                  -- ^ Action to execute only once.
-        -> SeDot D.NodeId
-dotOnce mapL k dot = do
-    i <- join $ (maybe dot return . M.lookup k) `liftM` getM mapL
-    modM mapL (M.insert k i)
-    return i
-
-dotNode :: NodeId -> SeDot D.NodeId
-dotNode v = dotOnce dsNodes v $ do
-    (se, colorMap) <- ask
-    let nodes = get sNodes se
-        dot info moreStyle facts = do
-            vId <- liftDot $ D.node $ [("label", show v ++ info),("shape","ellipse")]
-                                      ++ moreStyle
-            _ <- facts vId
-            return vId
-
-    case M.lookup v nodes of
-      Nothing -> do
-          dot "" [] (const $ return ()) -- \vId -> do
-              {-
-              premIds <- mapM dotPrem
-                           [ NodePremFact v fa
-                           | SeRequires v' fa <- S.toList $ get sRequires se
-                           , v == v' ]
-              sequence_ [ dotIntraRuleEdge premId vId | premId <- premIds ]
-              -}
-      Just ru -> do
-          let
-              color     = M.lookup (get rInfo ru) colorMap
-              nodeColor = maybe "white" rgbToHex color
-          dot (label ru) [("fillcolor", nodeColor),("style","filled")] $ \vId -> do
-              premIds <- mapM dotPrem
-                           [ (v,i) | (i,_) <- enumPrems ru ]
-              concIds <- mapM dotConc
-                           [ (v,i) | (i,_) <- enumConcs ru ]
-              sequence_ [ dotIntraRuleEdge premId vId | premId <- premIds ]
-              sequence_ [ dotIntraRuleEdge vId concId | concId <- concIds ]
-  where
-    label ru = " : " ++ render nameAndActs
-      where
-        nameAndActs =
-            ruleInfo (prettyProtoRuleName . get praciName) prettyIntrRuleACInfo (get rInfo ru) <->
-            brackets (vcat $ punctuate comma $ map prettyLNFact $ filter isNotDiffAnnotation $ get rActs ru)
-        isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
-
--- | An edge from a rule node to its premises or conclusions.
-dotIntraRuleEdge :: D.NodeId -> D.NodeId -> SeDot ()
-dotIntraRuleEdge from to = liftDot $ D.edge from to [("color","gray")]
-
-{-
--- | An edge from a rule node to some of its premises or conclusions.
-dotNonFixedIntraRuleEdge :: D.NodeId -> D.NodeId -> SeDot ()
-dotNonFixedIntraRuleEdge from to =
-    liftDot $ D.edge from to [("color","steelblue")]
--}
-
--- | The style of a node displaying a fact.
-factNodeStyle :: LNFact -> [(String,String)]
-factNodeStyle fa
-  | isJust (kFactView fa) = []
-  | otherwise             = [("fillcolor","gray85"),("style","filled")]
-
--- | An edge that shares no endpoints with another edge and is therefore
--- contracted.
---
--- FIXME: There may be too many edges being contracted.
-dotSingleEdge :: (NodeConc, NodePrem) -> SeDot D.NodeId
-dotSingleEdge edge@(_, to) = dotOnce dsSingles edge $ do
-    se <- asks fst
-    let fa    = nodePremFact to se
-        label = render $ prettyLNFact fa
-    liftDot $ D.node $ [("label", label),("shape", "hexagon")]
-                       ++ factNodeStyle fa
-
--- | A compressed edge.
-dotTrySingleEdge :: Eq c
-                 => ((NodeConc, NodePrem) -> c) -> c
-                 -> SeDot D.NodeId -> SeDot D.NodeId
-dotTrySingleEdge sel x dot = do
-    singles <- getM dsSingles
-    maybe dot (return . snd) $ find ((x ==) . sel . fst) $ M.toList singles
-
--- | Premises.
-dotPrem :: NodePrem -> SeDot D.NodeId
-dotPrem prem@(v, i) =
-    dotOnce dsPrems prem $ dotTrySingleEdge snd prem $ do
-        nodes <- asks (get sNodes . fst)
-        let ppPrem = show prem -- FIXME: Use better pretty printing here
-            (label, moreStyle) = fromMaybe (ppPrem, []) $ do
-                ru <- M.lookup v nodes
-                fa <- lookupPrem i ru
-                return ( render $ prettyLNFact fa
-                       , factNodeStyle fa
-                       )
-        liftDot $ D.node $ [("label", label),("shape",shape)]
-                           ++ moreStyle
-  where
-    shape = "invtrapezium"
-
--- | Conclusions.
-dotConc :: NodeConc -> SeDot D.NodeId
-dotConc =
-    dotNodeWithIndex dsConcs fst rConcs (id *** getConcIdx) "trapezium"
-  where
-    dotNodeWithIndex stateSel edgeSel ruleSel unwrap shape x0 =
-        dotOnce stateSel x0 $ dotTrySingleEdge edgeSel x0 $ do
-            let x = unwrap x0
-            nodes <- asks (get sNodes . fst)
-            let (label, moreStyle) = fromMaybe (show x, []) $ do
-                    ru <- M.lookup (fst x) nodes
-                    fa <- (`atMay` snd x) $ get ruleSel ru
-                    return ( render $ prettyLNFact fa
-                           , factNodeStyle fa
-                           )
-            liftDot $ D.node $ [("label", label),("shape",shape)]
-                               ++ moreStyle
-
-
-
--- | Convert the sequent to a 'D.Dot' action representing this sequent as a
--- graph in the GraphViz format. The style is loose in the sense that each
--- premise and conclusion gets its own node.
-dotSystemLoose :: System -> D.Dot ()
-dotSystemLoose se =
-    (`evalStateT` DotState M.empty M.empty M.empty M.empty) $
-    (`runReaderT` (se, nodeColorMap (M.elems $ get sNodes se))) $ do
-        liftDot $ setDefaultAttributes
-        -- draw single edges with matching facts.
-        mapM_ dotSingleEdge $ singleEdges $ do
-            Edge from to <- S.toList $ get sEdges se
-            -- FIXME: ensure that conclusion and premise are equal
-            guard (nodeConcFact from se == nodePremFact to se)
-            return (from, to)
-        sequence_ $ do
-            (v, ru) <- M.toList $ get sNodes se
-            (i, _)  <- enumConcs ru
-            return (dotConc (v, i))
-        sequence_ $ do
-            (v, ru) <- M.toList $ get sNodes se
-            (i, _)  <- enumPrems ru
-            return (dotPrem (v,i))
-        -- FIXME: Also dot unsolved actions.
-        mapM_ dotNode     $ M.keys   $ get sNodes     se
-        mapM_ dotEdge     $ S.toList $ get sEdges     se
-        mapM_ dotChain    $            unsolvedChains se
-        mapM_ dotLess     $ S.toList (reasonToColor  $ get sLessAtoms    se)
-  where
-    dotEdge  (Edge src tgt)  = do
-        mayNid <- M.lookup (src,tgt) `liftM` getM dsSingles
-        maybe (dotGenEdge [] src tgt) (const $ return ()) mayNid
-
-    dotChain (src, tgt) =
-        dotGenEdge [("style","dotted"),("color","green")] src tgt
-
-    dotLess (src, tgt, color) = do
-        srcId <- dotNode src
-        tgtId <- dotNode tgt
-        liftDot $ D.edge srcId tgtId
-                [("color",color),("style","dashed")]
-             -- FIXME: Reactivate,("constraint","false")]
-            -- setting constraint to false ignores less-edges when ranking nodes.
-
-    dotGenEdge style src tgt = do
-        srcId <- dotConc src
-        tgtId <- dotPrem tgt
-        liftDot $ D.edge srcId tgtId style
-
 
 -- | Set default attributes for nodes and edges.
 setDefaultAttributes :: D.Dot ()
@@ -299,33 +144,60 @@ nodeColorMap rules =
 data BoringNodeStyle = FullBoringNodes | CompactBoringNodes
     deriving( Eq, Ord, Show )
 
+data DotOptions = DotOptions 
+  { _doNodeStyle :: BoringNodeStyle }
+    deriving ( Eq, Ord, Show )
+
+defaultDotOptions = DotOptions FullBoringNodes
+
+$(mkLabels [''DotOptions])
+
+-- | Render an LNFact using the abbreviations given by the graph.
+renderLNFact :: Document d => LNFact -> SeDot d
+renderLNFact fact = do
+  (graph, _) <- ask
+  let abbreviate = get ((L..) goAbbreviate gOptions) graph
+      abbrevs = get gAbbreviations graph
+      replacedFact = applyAbbreviationsFact abbrevs fact
+  if abbreviate 
+    then return $ prettyLNFact replacedFact
+    else return $ prettyLNFact fact
 
 -- | Dot a node in record based (compact) format.
-dotNodeCompact :: BoringNodeStyle ->Bool -> NodeId -> SeDot D.NodeId
-dotNodeCompact boringStyle showAutosource v = dotOnce dsNodes v $ do
-    (se, colorMap) <- ask
-    let hasOutgoingEdge =
-            or [ v == v' | Edge (v', _) _ <- S.toList $ get sEdges se ]
-    case M.lookup v $ get sNodes se of
-      Nothing -> case filter ((v ==) . fst) (unsolvedActionAtoms se) of
-        [] -> mkSimpleNode (show v) []
-        as -> let lbl = (fsep $ punctuate comma $ map (prettyLNFact . snd) as)
-                        <-> opAction <-> text (show v)
-                  attrs | any (isKUFact . snd) as = [("color","gray")]
-                        | otherwise               = [("color","darkblue")]
-              in mkSimpleNode (render lbl) attrs
-      Just ru -> do
-          let color     = M.lookup (get rInfo ru) colorMap
-              nodeColor = maybe "white" rgbToHex color
-              attrs     = [("fillcolor", nodeColor),("style","filled")
-                            , ("fontcolor", if colorUsesWhiteFont color then "white" else "black")]
-          ids <- mkNode ru attrs hasOutgoingEdge showAutosource
-          let prems = [ ((v, i), nid) | (Just (Left i),  nid) <- ids ]
-              concs = [ ((v, i), nid) | (Just (Right i), nid) <- ids ]
-          modM dsPrems $ M.union $ M.fromList prems
-          modM dsConcs $ M.union $ M.fromList concs
-          return $ fromJust $ lookup Nothing ids
+dotNodeCompact :: DotOptions -> Node -> SeDot ()
+dotNodeCompact dotOptions node = do
+  let v = get nNodeId node
+  (graph, colorMap) <- ask
+  case get nNodeType node of
+    SystemNode ru -> cacheState dsNodes v $ do
+      let outgoingEdge = hasOutgoingEdge graph v
+      let color     = M.lookup (get rInfo ru) colorMap
+          nodeColor = maybe "white" rgbToHex color
+          attrs     = [("fillcolor", nodeColor),("style","filled")
+                        , ("fontcolor", if colorUsesWhiteFont color then "white" else "black")]
+      ids <- mkNode v ru attrs outgoingEdge
+      let prems = [ ((v, i), nid) | (Just (Left i),  nid) <- ids ]
+          concs = [ ((v, i), nid) | (Just (Right i), nid) <- ids ]
+      modM dsPrems $ M.union $ M.fromList prems
+      modM dsConcs $ M.union $ M.fromList concs
+      return $ fromJust $ lookup Nothing ids    
+    UnsolvedActionNode facts -> cacheState dsNodes v $ do
+      lblPre <- (fsep <$> punctuate comma <$> mapM renderLNFact facts)
+      let lbl = lblPre <-> opAction <-> text (show v)
+      let attrs | any isKUFact facts = [("color","gray")]
+                | otherwise          = [("color","darkblue")]
+      mkSimpleNode (render lbl) attrs
+    LastActionAtom -> cacheState dsNodes v $ mkSimpleNode (show v) []
+    MissingNode (Left conc) -> cacheState dsConcs (v, conc) $ dotConcC (v, conc)
+    MissingNode (Right prem) -> cacheState dsPrems (v, prem) $ dotPremC (v, prem)
   where
+    hasOutgoingEdge graph v =
+      let (_, _, edges) = get gRepr graph
+      in or [ v == v' | SystemEdge ((v', _), _) <- edges ]
+    missingNode shape label = liftDot $ D.node $ [("label", render label),("shape",shape)]
+    dotPremC prem = missingNode "invtrapezium" $ prettyNodePrem prem
+    dotConcC conc = missingNode "trapezium" $ prettyNodeConc conc
+
     --True if there's a colour, and it's 'darker' than 0.5 in apparent luminosity
     --This assumes a linear colourspace, which is what graphviz seems to use
     colorUsesWhiteFont (Just (RGB r g b)) = (0.2126*r + 0.7152*g + 0.0722*b) < 0.5
@@ -334,35 +206,56 @@ dotNodeCompact boringStyle showAutosource v = dotOnce dsNodes v $ do
     mkSimpleNode lbl attrs =
         liftDot $ D.node $ [("label", lbl),("shape","ellipse")] ++ attrs
 
-    mkNode  :: RuleACInst -> [(String, String)] -> Bool -> Bool
-      -> ReaderT (System, NodeColorMap) (StateT DotState D.Dot)
+    mkNode  :: NodeId -> RuleACInst -> [(String, String)] -> Bool
+      -> ReaderT (Graph, NodeColorMap) (StateT DotState D.Dot)
        [(Maybe (Either PremIdx ConcIdx), D.NodeId)]
-    mkNode ru attrs hasOutgoingEdge showAutoLabel
+    mkNode v ru attrs outgoingEdge
       -- single node, share node-id for all premises and conclusions
-      | boringStyle == CompactBoringNodes &&
+      | get doNodeStyle dotOptions == CompactBoringNodes &&
         (isIntruderRule ru || isFreshRule ru) = do
-            let lbl | hasOutgoingEdge = show v ++ " : " ++ showRuleCaseName ru
+            ps <- psM
+            as <- asM
+            cs <- csM
+            let lbl | outgoingEdge = show v ++ " : " ++ showRuleCaseName ru
                     | otherwise       = concatMap snd as
             nid <- mkSimpleNode lbl []
             return [ (key, nid) | (key, _) <- ps ++ as ++ cs ]
       -- full record syntax
-      | otherwise =
+      | otherwise = do
+            ps <- psM
+            as <- asM
+            cs <- csM
             fmap snd $ liftDot $ (`D.record` attrs) $
-            D.vcat $ map D.hcat $ map (map (uncurry D.portField)) $
-            filter (not . null) [ps, as, cs]
+              D.vcat $ map D.hcat $ map (map (uncurry D.portField)) $
+              filter (not . null) [ps, as, cs]
       where
-        ps = renderRow [ (Just (Left i),  prettyLNFact p) | (i, p) <- enumPrems ru ]
-        as = renderRow [ (Nothing,        ruleLabel ) ]
-        cs = renderRow [ (Just (Right i), prettyLNFact c) | (i, c) <- enumConcs ru ]
+        psM = do
+          row <- mapM (\(i, p) -> do 
+            lbl <- renderLNFact p
+            return (Just (Left i), lbl)
+            ) $ enumPrems ru
+          return $ renderRow row
+        asM = do
+          ruleLabel <- ruleLabelM
+          return $ renderRow [ (Nothing, ruleLabel ) ]
+        csM = do
+          row <- mapM (\(i, c) -> do
+            lbl <- renderLNFact c
+            return (Just (Right i), lbl)
+            ) $ enumConcs ru
+          return $ renderRow row
+        
+        ruleLabelM = do
+          showAutoSource <- asks (get ((L..) goShowAutoSource gOptions) . fst)
+          case showAutoSource of
+            True -> do
+              lbl <- mapM renderLNFact $ filter isAutoSource
+                     $ filter isNotDiffAnnotation $ get rActs ru
+              return $ prettyNodeId v <-> colon <-> text (showRuleCaseName ru) <> (brackets $ vcat $ punctuate comma $ lbl)
+            False -> do 
+              lbl <- mapM renderLNFact $ filter isNotDiffAnnotation $ get rActs ru
+              return $ prettyNodeId v <-> colon <-> text (showRuleCaseName ru) <> (brackets $ vcat $ punctuate comma $ lbl)
 
-        ruleLabel = case showAutoLabel of
-            True -> prettyNodeId v <-> colon <-> text (showRuleCaseName ru) <>
-                    (brackets $ vcat $ punctuate comma $
-                    map prettyLNFact $ filter isAutoSource
-                    $ filter isNotDiffAnnotation $ get rActs ru)
-            False -> prettyNodeId v <-> colon <-> text (showRuleCaseName ru) <>
-                    (brackets $ vcat $ punctuate comma $
-                    map prettyLNFact $ filter isNotDiffAnnotation $ get rActs ru)
 
         isNotDiffAnnotation fa = (fa /= (Fact (ProtoFact Linear ("Diff" ++ getRuleNameDiff ru) 0) S.empty []))
 
@@ -405,212 +298,171 @@ dotNodeCompact boringStyle showAutosource v = dotOnce dsNodes v $ do
                   in  replicate (round n) ' ' ++ rest
 
 
+-- | Dot a normal edge.
+dotEdge :: Edge -> SeDot ()
+dotEdge edge = 
+  case edge of
+    SystemEdge (src, tgt) -> do
+      (graph, _) <- ask 
+      let check p = maybe False p (resolveNodePremFact tgt graph) ||
+                    maybe False p (resolveNodeConcFact src graph) 
+          attrs | check isProtoFact =
+                    [("style","bold"),("weight","10.0")] ++
+                    (guard (check isPersistentFact) >> [("color","gray50")])
+                | check isKFact     = [("color","orangered2")]
+                | otherwise         = [("color","gray30")]
+      dotGenEdge attrs src tgt  
+    UnsolvedChain (src, tgt) -> 
+      dotGenEdge [("style","dotted"),("color","green")] src tgt
+    LessEdge _ -> error "LessEdges are handled by dotLessEdge"
+  where
+    dotGenEdge style src tgt = do
+      srcId <- getState dsConcs src ("Source node of edge not found: " ++ show src)
+      tgtId <- getState dsPrems tgt ("Target node of edge not found: " ++ show tgt)
+      liftDot $ D.edge srcId tgtId style
+
+-- | Dot a less edge, which needs to be transformed first to contain the correct color.
+dotLessEdge :: (NodeId, NodeId, String) -> SeDot ()
+dotLessEdge (src, tgt, color) = do
+  srcId <- getState dsNodes src ("Source node of less edge not found: " ++ show src)
+  tgtId <- getState dsNodes tgt ("Target node of less edge not found: " ++ show src)
+  liftDot $ D.edge srcId tgtId [("color",color),("style","dashed")]
+
+-- | Dot a legend listing all abbreviations by adding a sink node with a suitable HTML table label.
+generateLegend :: SeDot ()
+generateLegend = do
+  (graph, _) <- ask
+  let abbrevs = get gAbbreviations graph
+  -- Akip generating anything if no abbreviations exist.
+  unless (null abbrevs) $ do
+    nLegend <- liftDot $ D.scope (do 
+      D.attribute ("rank", "sink")
+      let sortedAbbrevs = topoSortAbbrevs $ zip [0..] $
+            sortOn (Data.Ord.Down . render . Sys.prettyLNTerm . fst) $ M.elems abbrevs
+          label = "<" ++ (T.unpack $ renderDot $ unqtDot $ htmlLabel sortedAbbrevs) ++ ">" 
+      D.node [("shape", "plain"), ("raw_label", label)])
+    -- We add invisible edges from all sink nodes of the graph to the legend node to place it somewhere in the middle of the bottom row.
+    -- We only add edges from the sink nodes because edges from earlier nodes will be routed avoid later nodes (even if they are invisible) and create constraints that lead to excessive whitespace.
+    let sinks = getGraphSinks graph 
+    dotIds <- getM dsNodes
+    mapM_ (\nsink ->
+      case M.lookup (get nNodeId nsink) dotIds of
+      Nothing -> pure ()
+      Just nid -> liftDot $ D.edge nid nLegend [("style", "invis")]) sinks
+  where
+    -- | Render all abbreviations as a table using graphviz' HTML notation.
+    htmlLabel sortedAbbrevs = 
+      let tableAttributes = [Border 1, CellBorder 0, CellSpacing 3, CellPadding 1] in
+        Table $ HTable Nothing tableAttributes $ map renderLine sortedAbbrevs
+
+    -- | Render an abbreviation to a table row in the legend using graphviz' HTML notation.
+    renderLine :: (AbbreviationTerm, AbbreviationExpansion) -> Row
+    renderLine (abbrevName, recursiveExpansion) = 
+      let red = GColor.RGB 255 0 0 
+          cellAttributes = [Align HLeft, VAlign HTop]
+          font txt = Text [Font [Color red] txt]
+          name = LabelCell cellAttributes (font [Str $ T.pack $ render $ Sys.prettyLNTerm abbrevName])
+          eq = LabelCell cellAttributes (Text [Str $ "="])
+          expansion = render $ Sys.prettyLNTerm recursiveExpansion
+          -- The expansions can get pretty big, i.e. span multiple lines. To handle linebreaks we replace them with HTML <br> tags.
+          expansionBR = LabelCell cellAttributes (Text $ expansion `joinLinesWith` (Newline [Align HLeft])) in
+      Cells [name, eq, expansionBR]
+    
+    -- | Replace newlines in `s` with the given separator.
+    joinLinesWith :: String -> TextItem -> Text
+    joinLinesWith s sep = intersperse sep $ map (Str . T.pack) $ lines s
+
+    -- | Do a topological sort of abbreviations to ensure that we print abbreviations in the order in which they are defined.
+    -- We define a partial order where for two abbreviations A & B, it holds A < B if A appears in the recursive expansion of B.
+    -- To extend the partial order to all abbreviations we do a topological sort on the graph where the nodes are abbreviations and edges are based on the partial order.
+    topoSortAbbrevs :: [(Int, (AbbreviationTerm, AbbreviationExpansion))] -> [(AbbreviationTerm, AbbreviationExpansion)]
+    topoSortAbbrevs keyedElems = 
+      let edgeList = map (\(key1, node) ->
+                            let outlist = findLegendEdges keyedElems node in
+                            (node, key1, outlist)) keyedElems
+          (graph, vf, _) = G.graphFromEdges edgeList
+          vertices = G.topSort graph in
+      map (\v -> fst3 $ vf v) vertices
+    
+    -- | We create an edge A -> B between two abbreviations A & B if A appears in the recursive expansion of B.
+    findLegendEdges :: [(Int, (AbbreviationTerm, AbbreviationExpansion))] -> (AbbreviationTerm, AbbreviationExpansion) -> [Int]
+    findLegendEdges keyedElems (abbrevName1, _) =
+      mapMaybe (\(key2, (_, recursiveExpansion2)) -> 
+                  if isProperSubterm abbrevName1 recursiveExpansion2
+                  then Just key2
+                  else Nothing) keyedElems 
+      
 
 -- | Dot a sequent in compact form (one record per rule), if there is anything
 -- to draw.
-dotSystemCompact :: BoringNodeStyle ->Bool -> System -> D.Dot ()
-dotSystemCompact boringStyle showAutosource se =
+dotSystemCompact :: GraphOptions -> DotOptions -> System -> D.Dot ()
+dotSystemCompact graphOptions dotOptions se = 
+    let graph = systemToGraph se graphOptions
+        -- a.d. TODO make nodeColorMap filter systemnodes from graph instead of accessing System directly.
+        colorMap = nodeColorMap (M.elems $ get sNodes se)
+        dot = dotGraphCompact dotOptions colorMap graph in
+    dot
+
+-- | Dot a graph in compact form (one record per rule).
+dotGraphCompact :: DotOptions -> NodeColorMap -> Graph -> D.Dot ()
+dotGraphCompact dotOptions colorMap graph =
     (`evalStateT` DotState M.empty M.empty M.empty M.empty) $
-    (`runReaderT` (se, nodeColorMap (M.elems $ get sNodes se))) $ do
+    (`runReaderT` (graph, colorMap)) $ do
         liftDot $ setDefaultAttributes
-        mapM_ (dotNodeCompact boringStyle showAutosource) $ M.keys $ get sNodes       se
-        mapM_ (dotNodeCompact boringStyle showAutosource . fst) $ unsolvedActionAtoms se
-        F.mapM_ dotEdge                            $ get sEdges        se
-        F.mapM_ dotChain                           $ unsolvedChains    se
-        F.mapM_ dotLess                          (reasonToColor  $ get sLessAtoms    se)
+        let (clusters, nodes, edges) = get gRepr graph
+            (lessEdges, restEdges) = mergeLessEdges edges
+            abbreviate = get ((L..) goAbbreviate gOptions) graph 
+        mapM_ (dotNodeCompact dotOptions) nodes
+        mapM_ dotEdge restEdges
+        mapM_ dotLessEdge lessEdges
+
+        when abbreviate generateLegend 
+
+-- | Compute proper colors for all less-edges.
+-- Computing the colors requires all less-edges of the graph, so we cannot do it per edge.
+-- This is why we split up the edges here and use two different functions to convert them to a dot.
+mergeLessEdges :: [Edge] -> ([(NodeId, NodeId, String)], [Edge])
+mergeLessEdges edges = (merged, rest)
   where
-    missingNode shape label = liftDot $ D.node $ [("label", render label),("shape",shape)]
-    dotPremC prem = dotOnce dsPrems prem $ missingNode "invtrapezium" $ prettyNodePrem prem
-    dotConcC conc = dotOnce dsConcs conc $ missingNode "trapezium" $ prettyNodeConc conc
-    dotEdge (Edge src tgt)  = do
-        let check p = maybe False p (resolveNodePremFact tgt se) ||
-                      maybe False p (resolveNodeConcFact src se)
-            attrs | check isProtoFact =
-                      [("style","bold"),("weight","10.0")] ++
-                      (guard (check isPersistentFact) >> [("color","gray50")])
-                  | check isKFact     = [("color","orangered2")]
-                  | otherwise         = [("color","gray30")]
-        dotGenEdge attrs src tgt
+    rest = filter (not . isLessEdge) edges
+    merged = 
+      let lessEdges = mapMaybe extractLessEdge edges in
+      map getAllRToC $ eqClasses (\(x,y,_) -> (x,y)) lessEdges
 
-    dotGenEdge style src tgt = do
-        srcId <- dotConcC src
-        tgtId <- dotPremC tgt
-        liftDot $ D.edge srcId tgtId style
+    isLessEdge :: Edge -> Bool
+    isLessEdge (LessEdge _) = True
+    isLessEdge _ = False
 
-    dotChain (src, tgt) =
-        dotGenEdge [("style","dotted"),("color","green")] src tgt
+    extractLessEdge :: Edge -> Maybe Less
+    extractLessEdge (LessEdge e) = Just e
+    extractLessEdge _ = Nothing
 
-    dotLess (src, tgt, color) = do
+    getAllRToC :: [Less]-> (NodeId,NodeId,String)
+    -- SAFETY: Output of eqClasses never contains the empty list.
+    getAllRToC [] = error "empty list"
+    getAllRToC (x:xs) = 
+      (fst3 x, snd3 x,
+        -- Sort order is reversed to put the "most important reason" first.
+        allRtoColors (sortBy (comparing Data.Ord.Down) $ map thd3 (x:xs)))
 
-        srcId <- dotNodeCompact boringStyle showAutosource src
-        tgtId <- dotNodeCompact boringStyle showAutosource tgt
-        liftDot $ D.edge srcId tgtId [("color",color),("style","dashed")]
-            -- FIXME: Reactivate,("constraint","false")]
-            -- setting constraint to false ignores less-edges when ranking nodes.
+    allRtoColors :: [Reason] -> String
+    allRtoColors reasons = 
+      let len = length reasons
+          per = if len >1 then ";" ++ show ((1 :: Double)/fromIntegral len) else ""
+          colors = map toColor reasons
+          scaledColors = map (++per) colors
+      in intercalate ":" scaledColors
 
-
--- | To get the color style for each less 
-reasonToColor :: S.Set (NodeId, NodeId, Reason)
-                -> S.Set (NodeId, NodeId, String)
-reasonToColor l = S.fromList ( map getAllRToC $
-                  groupOn  (\(x,y,_)->(x,y)) $ S.toList l)
-    where
-        toColor :: Reason -> String
-        toColor r = case r of
-             Adversary      -> "red"
-             Formula        -> "black"
-             Fresh          -> "blue3"
-             InjectiveFacts -> "purple"
-             NormalForm     -> "darkorange3"
-        allRtoColors :: [Reason] -> String
-        allRtoColors r = intercalate ":" (map toColor r)++per
-            where
-                len = length r
-                per = if len >1 then ";" ++ show ((1 :: Double)/fromIntegral len) else ""
-        -- to show all the reasons with their colors
-        getAllRToC :: [Less]-> (NodeId,NodeId,String)
-        getAllRToC [] = error "empty list"
-        getAllRToC (x:xs) = (fst3 x, snd3 x,
-                        allRtoColors (reverse (sort $ map thd3 (x:xs))))
-
-        -- |Or else, to show only the most important reason, we can use
-        -- |the function below, at the same time, we need remove function
-        -- |"allRtoColors"
-
-        -- getAllRToC :: [Less]-> (NodeId,NodeId,String)
-        -- getAllRToC (x:xs) = (fst3 x, snd3 x, 
-        --                 toColor $ head (sort $ map thd3 (x:xs)))
-
-
-------------------------------------------------------------------------------
--- Compressed versions of a sequent
-------------------------------------------------------------------------------
-
--- | Drop 'Less' atoms entailed by the edges of the 'System'.
-dropEntailedOrdConstraints :: System -> System
-dropEntailedOrdConstraints se =
-    modify sLessAtoms (S.filter (not . entailed)) se
-  where
-    edges               = rawEdgeRel se
-    entailed (from, to, _) = to `S.member` D.reachableSet [from] edges
-
--- | Unsound compression of the sequent that drops fully connected learns and
--- knows nodes.
-compressSystem :: System -> System
-compressSystem se0 =
-    foldl' (flip tryHideNodeId) se (frees (get sLessAtoms se, get sNodes se))
-  where
-    se = dropEntailedOrdConstraints se0
-
--- | Simplify the system up to the sent level, 
--- | for level 3, we will simplify the lesses of system by transitive reduction
--- | for level 2, we will apply the transitive reduction but keep the 
--- | formula constraint 
--- | for level 1, there's no transitive reduction applied
-simplifySystem :: Int -> System -> System
-simplifySystem i sys
-    | i==2 = transitiveReduction sys False
-    | i==3 = transitiveReduction sys True
-    | otherwise = sys
-
--- | Simplify the system by transitive reduction (constraint of formula won't  
--- | be applied if totalRed is False) but not for a system which has a graph cyclic
-transitiveReduction :: System -> Bool -> System
-transitiveReduction sys totalRed=
-    if D.cyclic oldLesses
-        then sys
-        else   modify sLessAtoms
-            ( S.intersection ( S.fromList newLesses) ) sys
-    where
-        oldLessesWithR = S.toList $ get sLessAtoms sys
-        oldLesses = rawLessRel sys
-        newLesses = if totalRed
-            then [(x,y,z)| (x,y,z)<- oldLessesWithR,
-                            (x,y) `elem` (D.transRed oldLesses) ]
-            else [(x,y,z)| (x,y,z)<- oldLessesWithR,
-                            (x,y) `elem` (D.transRed oldLesses) || z == Formula || z == Adversary ]
-
-
--- | @hideTransferNode v se@ hides node @v@ in sequent @se@ if it is a
--- transfer node; i.e., a node annotated with a rule that is one of the
--- special intruder rules or a rule with with at most one premise and
--- at most one conclusion and both premises and conclusions have incoming
--- respectively outgoing edges.
---
--- The compression is chosen such that unly uninteresting nodes are that have
--- no open goal are suppressed.
-tryHideNodeId :: NodeId -> System -> System
-tryHideNodeId v se = fromMaybe se $ do
-    guard $  (lvarSort v == LSortNode)
-          && notOccursIn unsolvedChains
-          && notOccursIn (get sFormulas)
-    maybe hideAction hideRule (M.lookup v $ get sNodes se)
-  where
-    selectPart :: (System :-> S.Set a) -> (a -> Bool) -> [a]
-    selectPart l p = filter p $ S.toList $ get l se
-
-    notOccursIn :: HasFrees a => (System -> a) -> Bool
-    notOccursIn proj = not $ getAny $ foldFrees (Any . (v ==)) $ proj se
-
-    -- hide KU-actions deducing pairs, inverses, and simple terms
-    hideAction = do
-        guard $  not (null kuActions)
-              && all eligibleTerm kuActions
-              && all (\(i, j, _) -> not (i == j)) lNews
-              && notOccursIn (standardActionAtoms)
-              && notOccursIn (get sLastAtom)
-              && notOccursIn (get sEdges)
-
-        return $ modify sLessAtoms ( (`S.union` S.fromList lNews)
-                                   . (`S.difference` S.fromList lIns)
-                                   . (`S.difference` S.fromList lOuts)
-                                   )
-               $ modify sGoals (\m -> foldl' removeAction m kuActions)
-               $ se
-      where
-        kuActions            = [ x | x@(i,_,_) <- kuActionAtoms se, i == v ]
-        eligibleTerm (_,_,m) =
-            isPair m || isInverse m || sortOfLNTerm m == LSortPub || sortOfLNTerm m == LSortNat
-
-        removeAction m (i, fa, _) = M.delete (ActionG i fa) m
-
-        lIns  = selectPart sLessAtoms ((v ==) . snd3)
-        lOuts = selectPart sLessAtoms ((v ==) . fst3)
-        lNews = [ (i, j, r) | (i, _, _) <- lIns, (_, j, r) <- lOuts ]
-
-    -- hide a rule, if it is not "too complicated"
-    hideRule :: RuleACInst -> Maybe System
-    hideRule ru = do
-        guard $  eligibleRule
-              && ( length eIns  == length (get rPrems ru) )
-              && ( length eOuts == length (get rConcs ru) )
-              && ( all (not . selfEdge) eNews             )
-              && notOccursIn (get sLastAtom)
-              && notOccursIn (get sLessAtoms)
-              && notOccursIn (unsolvedActionAtoms)
-
-        return $ modify sEdges ( (`S.union` S.fromList eNews)
-                               . (`S.difference` S.fromList eIns)
-                               . (`S.difference` S.fromList eOuts)
-                               )
-               $ modify sNodes (M.delete v)
-               $ se
-      where
-        eIns  = selectPart sEdges ((v ==) . nodePremNode . eTgt)
-        eOuts = selectPart sEdges ((v ==) . nodeConcNode . eSrc)
-        eNews = [ Edge cIn pOut | Edge cIn _ <- eIns, Edge _ pOut <- eOuts ]
-
-        selfEdge (Edge cIn pOut) = nodeConcNode cIn == nodePremNode pOut
-
-        eligibleRule =
-             any ($ ru) [isISendRule, isIRecvRule, isCoerceRule, isFreshRule]
-          || ( null (get rActs ru) &&
-               all (\l -> length (get l ru) <= 1) [rPrems, rConcs]
-             )
+    toColor :: Reason -> String
+    toColor r = case r of
+         Adversary      -> "red"
+         Formula        -> "black"
+         Fresh          -> "blue3"
+         InjectiveFacts -> "purple"
+         NormalForm     -> "darkorange3"
 
 {-
 -- | Try to hide a 'NodeId'. This only works if it has only action and either
 -- edge or less constraints associated.
 tryHideNodeId :: NodeId -> System -> System
 -}
-

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -8,9 +8,7 @@
 --
 -- Conversion of the graph part of a sequent to a Graphviz Dot file.
 module Theory.Constraint.System.Dot (
-    nonEmptyGraph
-  , nonEmptyGraphDiff
-  , dotSystemLoose
+    dotSystemLoose
   , dotSystemCompact
   , compressSystem
   , simplifySystem
@@ -44,21 +42,6 @@ import           Theory.Model
 import           Theory.Text.Pretty       (opAction)
 
 import           Utils.Misc
--- | 'True' iff the dotted system will be a non-empty graph.
-nonEmptyGraph :: System -> Bool
-nonEmptyGraph sys = not $
-    M.null (get sNodes sys) && null (unsolvedActionAtoms sys) &&
-    null (unsolvedChains sys) &&
-    S.null (get sEdges sys) && S.null (get sLessAtoms sys)
-
--- | 'True' iff the dotted system will be a non-empty graph.
-nonEmptyGraphDiff :: DiffSystem -> Bool
-nonEmptyGraphDiff diffSys = not $
-     case (get dsSystem diffSys) of
-          Nothing    -> True
-          (Just sys) -> M.null (get sNodes sys) && null (unsolvedActionAtoms sys) &&
-                        null (unsolvedChains sys) &&
-                        S.null (get sEdges sys) && S.null (get sLessAtoms sys)
 
 type NodeColorMap = M.Map (RuleInfo ProtoRuleACInstInfo IntrRuleACInfo) (RGB Rational)
 type SeDot = ReaderT (System, NodeColorMap) (StateT DotState D.Dot)

--- a/lib/theory/src/Theory/Constraint/System/Graph/Abbreviation.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/Abbreviation.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE ViewPatterns #-}
+-- |
+-- Copyright   : (c) 2010, 2011 Simon Meier
+-- License     : GPL v3 (see LICENSE)
+--
+-- Portability : GHC only
+--
+-- s implements generating abbreviations for a given graph representation.
+--  abbreviation are computed from all LNTerm's in the graph and the method is based on cleandot.py 
+-- All terms in the graph are weighted based on their multiplicity and length, highest weighted terms are abbreviated first.
+--  abbreviation itself is based on the string representation of a term. 
+-- E.g. Function(a,b,c) => Fun1
+module Theory.Constraint.System.Graph.Abbreviation (
+    Abbreviations
+  , lookupAbbreviation
+  , computeAbbreviations
+  , AbbreviationOptions(..)
+  , AbbreviationTerm
+  , AbbreviationExpansion
+  , defaultAbbreviationOptions
+  , applyAbbreviationsFact
+  , applyAbbreviationsTerm
+  ) where
+
+import           Data.Char                (isAlphaNum, toUpper, isAlpha)
+import qualified Data.Text                as T
+import qualified Data.Map                 as M
+import           Data.Maybe
+import qualified Data.Ord                 
+import qualified Data.ByteString.Char8 as BC
+import           Data.List                (sort, nub, mapAccumL)
+import           Extension.Data.Label
+import           Extension.Prelude
+import           Text.PrettyPrint.Class
+import           Theory.Constraint.System.Graph.GraphRepr
+import           Term.LTerm
+import           Theory                   (LNFact, rPrems, rConcs, rActs, factTerms)
+
+type AbbreviationTerm = LNTerm
+type AbbreviationExpansion = LNTerm
+-- | Abbreviations are represented as a map from the original LNTerm 
+-- to the abbreviated LNTerm and the original LNTerm where all existing
+-- abbreviations have already been applied.
+-- ==== __Example__:
+--   [ Function1(a,b)              => Fun1, Function1(a,b)
+--   , Function2(Function1(a,b),c) => Fun2, Function2(Fun1,c)
+--   ]
+type Abbreviations = M.Map LNTerm (AbbreviationTerm, AbbreviationExpansion)
+data AbbreviationOptions = AbbreviationOptions 
+  { aoMaxAbbrevs :: Int
+  , aoFirstIndex :: Int
+  }
+  deriving( Eq, Ord )
+
+defaultAbbreviationOptions :: AbbreviationOptions
+defaultAbbreviationOptions = AbbreviationOptions 
+  { aoMaxAbbrevs = 10
+  , aoFirstIndex = 1
+  }
+
+-- | Lookup a single term in an abbreviations map and return the abbreviation name.
+lookupAbbreviation :: LNTerm -> Abbreviations -> Maybe AbbreviationTerm
+lookupAbbreviation t abbrevs = fst <$> M.lookup t abbrevs
+
+-- | Weigh each term based on its size and how often it appears in the graph.
+judgeTerm :: LNTerm -> Int -> Float
+judgeTerm t occs 
+  | termSize < 7 = -1.0
+  | (termSize < 20) && occs == 1 = -1.0
+  | otherwise = (fromIntegral (2 + occs) ^ (2 :: Integer)) * fromIntegral termSize
+  where
+    termSize :: Int
+    termSize = length $ render $ prettyLNTerm t
+
+
+-- | Find a suitable abbreviation prefix for the given term in upper-case.
+-- For a literal we take the first 3 characters and for function symbols we either special-case the name or also take the first 3 characters.
+-- If more fine-grained control is needed we can use viewTerm2 instead of viewTerm.
+getTermPrefix :: LNTerm -> String
+getTermPrefix t = map toUpper $ take 3 $ filter isAlpha go
+  where
+    go = case viewTerm t of
+         Lit l                  -> show l
+         FApp   (NoEq (s,_)) _  -> BC.unpack s
+         -- a.d. TODO what is a good abbreviation for the "emap"?
+         FApp   (C _) _         -> "EMP"
+         FApp   List _          -> "LST"
+         FApp   (AC o) _        -> show o
+
+
+type PrefixMap = M.Map String Int
+
+-- | For a given term `t`, find a suitable abbreviation and update the prefix index map.
+-- The prefixMap maps a prefix to the next possible index candidate.
+abbreviateTerm :: AbbreviationOptions -> [String] -> PrefixMap -> LNTerm -> (PrefixMap, LNTerm)
+abbreviateTerm options allNames prefixMap t = 
+  let pref = getTermPrefix t
+      idxCandidate = getIndexCandidate pref in
+    go pref idxCandidate
+  where
+    -- | Try out successive index candidates to create an abbreviation. 
+    -- For each candidate we create the abbreviation and check if it is contained in the global map.
+    -- If it already exists we try the next index candidate.
+    go :: String -> Maybe Int -> (PrefixMap, LNTerm)
+    go pref idxCandidate = 
+      let nameCandidate = pref ++ maybe "" show idxCandidate 
+          idxCandidateNext = maybe (aoFirstIndex options) (+1) idxCandidate in
+      if nameCandidate `elem` allNames 
+      then go pref (Just idxCandidateNext)
+      else (M.insert pref idxCandidateNext prefixMap, var nameCandidate)
+
+    -- | Check the prefix index map for a suitable index for the given prefix.
+    getIndexCandidate :: String -> Maybe Int
+    getIndexCandidate pref = M.lookup pref prefixMap 
+        
+    -- | Create a variable from some prefix and index. 
+    -- We append the index to the string directly instead of using the variable index since 
+    -- the variable renderer inserts a point between name and index.
+    var :: String -> LNTerm
+    var name = 
+      let  in
+      lit $ Var $ LVar name LSortMsg 0
+    
+
+-- | For a given graph representation, compute possible abbreviations that can be applied.
+-- Abbreviations are always LNTerm variables with a differentiating number suffix.
+computeAbbreviations :: GraphRepr -> AbbreviationOptions -> Abbreviations 
+computeAbbreviations repr options = 
+  let allTermOccs = getAllTermOccs repr
+      allWeightedTerms = M.mapWithKey judgeTerm allTermOccs
+      toAbbreviate = filterWeights $ M.toList allWeightedTerms
+      abbrevs = abbreviateTerms toAbbreviate
+      recursiveAbbrevs = makeRecursive abbrevs
+  in 
+    recursiveAbbrevs
+  where
+    -- | Collect all terms in our graph along with their number of occurrences
+    getAllTermOccs :: GraphRepr -> M.Map LNTerm Int
+    getAllTermOccs (clusters, nodes, _) = 
+      let terms = concatMap getNodeTerms nodes ++ concatMap (\c -> concatMap getNodeTerms $ get cNodes c) clusters in
+      M.fromListWith (+) $ map (\t -> (t,1)) terms
+
+    -- | Collect all terms in a single graph node. 
+    -- At the moment terms only appear in SystemNodes and UnsolvedActionNodes.
+    getNodeTerms :: Node -> [LNTerm]
+    getNodeTerms (Node _ (SystemNode ru)) =
+      concatMap getFactTerms (get rPrems ru)
+      ++ concatMap getFactTerms (get rActs ru)
+      ++ concatMap getFactTerms (get rConcs ru) 
+    getNodeTerms (Node _ (UnsolvedActionNode facts)) = concatMap getFactTerms facts
+    getNodeTerms _ = []
+
+    -- | Collect all terms of a LNFact.
+    -- We filter out pairs so that we do not abbreviate pairs of terms but only the inner terms.
+    getFactTerms :: LNFact -> [LNTerm]
+    getFactTerms fact = filter (not . isPair) $ concatMap getSubTerms $ factTerms fact 
+
+    -- | Subterms are the term itself along with ts of an FApp
+    getSubTerms :: LNTerm -> [LNTerm]
+    getSubTerms t@(viewTerm -> FApp _ ts) = t : ts
+    getSubTerms t = [t]
+
+    -- | Collect all names that appear somewhere in the graph to avoid generating abbreviations with the same name as existing objects.
+    --  quickest way to do this is to render the entire graph as a string and pull out all alphanumeric substrings.
+    --  We convert all names to upper-case to compare in a case-insensitive way.
+    allNames :: [String]
+    allNames = 
+      let rendered = T.pack $ show repr
+          names = filter (not . null) $ map (T.unpack . T.toUpper) $ T.split (not . isAlphaNum) rendered
+      in
+        sort $ nub names
+
+    -- | For a number of weighted terms, take the first aoMaxAbbrevs terms sorted by decreasing weight.
+    filterWeights :: [(LNTerm, Float)] -> [LNTerm]
+    filterWeights weightedTerms = take (aoMaxAbbrevs options) $ mapMaybe removeNegativeWeights $ sortOn (Data.Ord.Down . snd) weightedTerms
+
+    -- | Terms with negative weights should never be abbreviated.
+    removeNegativeWeights (t, w)
+      | w < 0.0 = Nothing
+      | otherwise = Just t
+
+    -- | For a given list of terms, find suitable abbreviations and return a mapping from the original to the abbreviated terms. 
+    -- The prefix index map is initially empty and accumulates the next possible index candidate for each prefix while we create abbreviations.
+    abbreviateTerms :: [LNTerm] -> [(LNTerm, LNTerm)]
+    abbreviateTerms ts =
+      let (_, abbrevNames) = mapAccumL (abbreviateTerm options allNames) M.empty ts in
+      zip ts abbrevNames
+
+    -- | For a given list of (expansion, abbrevName) pairs, compute a recursiveExpansion that is the original expansion term where any subterm which is also an expansion is replaced by the respective abbrevName. 
+    -- Going through all expansions once is enough because abbrevNames do not contain any subterms themselves, so we do not introduce any new possibilities for recursive occurrences. 
+    --
+    -- ==== __Example__:
+    -- [(A(B, C), H1), (B, H2)] => [(A(H2, C), H1), (B, H2)]
+    makeRecursive :: [(LNTerm, LNTerm)] -> Abbreviations
+    makeRecursive abbrevs = 
+      let replacementMap = M.fromList abbrevs 
+          replacement t = fromMaybe t (M.lookup t replacementMap)
+          recursiveExpansions = map (replaceProperSubterm replacement . fst) abbrevs
+          recursiveAbbrevs = zipWith (\(expansion, abbrevName) recursiveExpansion -> 
+                                        (expansion, (abbrevName, recursiveExpansion))) 
+                                      abbrevs recursiveExpansions
+      in
+        M.fromList recursiveAbbrevs
+
+-- | Go through an LNTerm and replace all possible subterms with their abbreviation top-down.
+applyAbbreviationsTerm :: Abbreviations -> LNTerm -> LNTerm
+applyAbbreviationsTerm abbrevs term = 
+  let replaceWithAbbrev t = fromMaybe t $ lookupAbbreviation t abbrevs
+      replacedTerm = replaceSubterm replaceWithAbbrev term
+  in
+    replacedTerm
+
+-- | Go through an LNFact and apply the abbreviations to all contained LNTerm's.
+applyAbbreviationsFact :: Abbreviations -> LNFact -> LNFact
+applyAbbreviationsFact abbrevs fact = 
+  let terms = factTerms fact
+      replacedTerms = map (applyAbbreviationsTerm abbrevs) terms
+  in 
+    fact { factTerms = replacedTerms }

--- a/lib/theory/src/Theory/Constraint/System/Graph/Abbreviation.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/Abbreviation.hs
@@ -6,11 +6,10 @@
 --
 -- Portability : GHC only
 --
--- s implements generating abbreviations for a given graph representation.
--- hlsearch
---  abbreviation are computed from all LNTerm's in the graph and the method is based on cleandot.py 
+-- This implements generating abbreviations for a given graph representation.
+-- The abbreviations are computed from all LNTerm's in the graph and the method is based on cleandot.py 
 -- All terms in the graph are weighted based on their multiplicity and length, highest weighted terms are abbreviated first.
---  abbreviation itself is based on the string representation of a term. 
+-- The abbreviation itself is based on the string representation of a term. 
 -- E.g. Function(a,b,c) => FU1
 module Theory.Constraint.System.Graph.Abbreviation (
     Abbreviations
@@ -134,8 +133,7 @@ abbreviateTerm options allNames prefixMap t =
 -- Abbreviations are always LNTerm variables with a differentiating number suffix.
 computeAbbreviations :: GraphRepr -> AbbreviationOptions -> Abbreviations 
 computeAbbreviations repr options = 
-  let allTermOccs = getAllTermOccs repr
-      allWeightedTerms = M.mapWithKey judgeTerm allTermOccs
+  let allWeightedTerms = M.mapWithKey judgeTerm allTermOccs
       toAbbreviate = filterWeights $ M.toList allWeightedTerms
       abbrevs = abbreviateTerms toAbbreviate
       recursiveAbbrevs = makeRecursive abbrevs
@@ -143,9 +141,9 @@ computeAbbreviations repr options =
     recursiveAbbrevs
   where
     -- | Collect all terms in our graph along with their number of occurrences
-    getAllTermOccs :: GraphRepr -> M.Map LNTerm Int
-    getAllTermOccs (clusters, nodes, _) = 
-      let terms = concatMap getNodeTerms nodes ++ concatMap (\c -> concatMap getNodeTerms $ get cNodes c) clusters in
+    allTermOccs :: M.Map LNTerm Int
+    allTermOccs = 
+      let terms = concatMap getNodeTerms (get grNodes repr) ++ concatMap (\c -> concatMap getNodeTerms $ get cNodes c) (get grClusters repr) in
       M.fromListWith (+) $ map (\t -> (t,1)) terms
 
     -- | Collect all terms in a single graph node. 

--- a/lib/theory/src/Theory/Constraint/System/Graph/Graph.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/Graph.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE ViewPatterns #-}
+-- |
+-- Copyright   : (c) 2010, 2011 Simon Meier
+-- License     : GPL v3 (see LICENSE)
+--
+-- Portability : GHC only
+--
+-- Abstraction over a System to represent certain components as a graph for rendering to a UI.
+module Theory.Constraint.System.Graph.Graph (
+      systemToGraph
+    , SimplificationLevel(..)
+    , levelNum
+    , GraphOptions
+    , goSimplificationLevel
+    , goShowAutoSource
+    , goClustering
+    , goAbbreviate
+    , goCompress
+    , defaultGraphOptions
+    , Graph
+    , gRepr
+    , gOptions
+    , gAbbreviations
+    , getGraphSinks
+    , module Theory.Constraint.System.Graph.GraphRepr
+    , module Theory.Constraint.System.Graph.Abbreviation
+    , resolveNodeConcFact
+    , resolveNodePremFact
+  ) where
+
+import qualified Data.Map                 as M
+import           Data.Maybe
+import qualified Data.Set                 as S
+import           Extension.Data.Label
+import           Extension.Prelude        (collectBy)
+import qualified Theory.Constraint.System as Sys
+import           Theory.Constraint.System.Graph.GraphRepr
+import           Theory.Constraint.System.Graph.Abbreviation
+import qualified Theory                   as Th
+import Theory.Constraint.System.Graph.Simplification (simplifySystem, compressSystem)
+
+data SimplificationLevel = SL0 | SL1 | SL2 | SL3
+    deriving( Eq, Ord, Read, Show )
+
+levelNum :: SimplificationLevel -> Int
+levelNum SL0 = 0
+levelNum SL1 = 1
+levelNum SL2 = 2
+levelNum SL3 = 3
+
+data GraphOptions = GraphOptions 
+  { _goSimplificationLevel :: SimplificationLevel
+  , _goShowAutoSource      :: Bool
+  , _goClustering          :: Bool
+  , _goAbbreviate          :: Bool
+  , _goCompress            :: Bool }
+    deriving( Eq, Ord )
+
+defaultGraphOptions :: GraphOptions
+defaultGraphOptions = GraphOptions 
+  { _goSimplificationLevel = SL0
+  , _goShowAutoSource = False
+  , _goClustering = False
+  , _goAbbreviate = False
+  , _goCompress = False }
+
+data Graph = Graph 
+  { _gSystem        :: Sys.System
+  , _gOptions       :: GraphOptions
+  , _gRepr          :: GraphRepr
+  , _gAbbreviations :: Abbreviations }
+    deriving( Eq, Ord )
+
+$(mkLabels [''Graph, ''GraphOptions])
+
+-- | All facts associated to this node premise.
+resolveNodePremFact :: Sys.NodePrem -> Graph -> Maybe Th.LNFact
+resolveNodePremFact prem graph = 
+  let se = get gSystem graph in
+  Sys.resolveNodePremFact prem se
+
+-- | The fact associated with this node conclusion, if there is one.
+resolveNodeConcFact :: Sys.NodeConc -> Graph -> Maybe Th.LNFact
+resolveNodeConcFact conc graph = 
+  let se = get gSystem graph in
+  Sys.resolveNodeConcFact conc se
+
+systemNodes :: Sys.System -> [Node]
+systemNodes se = map systemNode (M.toList $ get Sys.sNodes se)
+  where
+    systemNode (nid, ru) = Node nid (SystemNode ru)
+
+systemUnsolvedActionNodes :: Sys.System -> [Node]
+systemUnsolvedActionNodes se = map unsolvedActionNode (collectBy $ Sys.unsolvedActionAtoms se)
+  where
+    unsolvedActionNode (nid, facts) = Node nid (UnsolvedActionNode facts)
+
+systemLastActionNode :: Sys.System -> [Node]
+systemLastActionNode se = maybe [] (\nid -> [Node nid LastActionAtom]) (get Sys.sLastAtom se)
+
+-- a.d. This assumes that there is no edge where both the source and target are missing. But that situation should never happen.
+systemMissingNodes :: Sys.System -> [Node]
+systemMissingNodes se = mapMaybe missingNode (S.toList $ get Sys.sEdges se)
+  where
+    missingNode (Sys.Edge (nid, idx) _) | nid `notElem` nodelist = Just $ Node nid (MissingNode (Left idx))
+    missingNode (Sys.Edge _ (nid, idx)) | nid `notElem` nodelist = Just $ Node nid (MissingNode (Right idx))
+    missingNode _ = Nothing
+    nodelist = map fst $ M.toList $ get Sys.sNodes se
+
+systemEdges :: Sys.System -> [Edge]
+systemEdges se = 
+  let edges = S.toList $ get Sys.sEdges se in
+  map (\(Sys.Edge src tgt) -> SystemEdge (src, tgt)) edges
+
+-- | Computes a basic graph representation from a System 
+-- where nodes are 
+-- 1. the System rule instances
+-- 2. unsolved actions by the attacker
+-- 3. a possible last action (for induction) 
+-- 4. and any nodes that are required by edges but don't exist otherwise.
+-- and edges are 
+-- 1. edges between rule instances
+-- 2. edges implied by less-constraints between temporal variables
+-- 3. and any unsolved chains.
+computeBasicGraphRepr :: Sys.System -> GraphRepr
+computeBasicGraphRepr se = 
+  let nodes = systemNodes se
+        ++ systemUnsolvedActionNodes se
+        ++ systemLastActionNode se
+        ++ systemMissingNodes se
+      edges =  systemEdges se 
+        ++ map LessEdge (S.toList $ get Sys.sLessAtoms se)
+        ++ map UnsolvedChain (Sys.unsolvedChains se)
+  in 
+    ([], nodes, edges)
+
+-- | Compute clusters, nodes & edges from a Graph instance according to the Graph's options.
+systemToGraph :: Sys.System -> GraphOptions -> Graph
+systemToGraph se options = 
+  let -- We first do the existing simplification steps on a System that were defined in the Dot module originally.
+      simplfiedSystem = simplifySystem (levelNum $ get goSimplificationLevel options) $
+                          if get goCompress options then compressSystem se else se
+      basicGraphRepr = computeBasicGraphRepr simplfiedSystem
+      -- Iterate on the basicGraphRepr depending on what options are set to get the final repr
+      repr = basicGraphRepr
+      abbrevs = computeAbbreviations repr defaultAbbreviationOptions
+  in
+    Graph se options repr abbrevs
+
+getGraphSinks :: Graph -> [Node]
+getGraphSinks graph = 
+  let repr = get gRepr graph
+      edgeList = toEdgeList repr in
+  map (\(node, _, _) -> node) $ filter (\(_, _, outlist) -> null outlist) edgeList

--- a/lib/theory/src/Theory/Constraint/System/Graph/GraphRepr.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/GraphRepr.hs
@@ -9,7 +9,10 @@
 --
 -- Representation of a graph as a collection of nodes, edges and clusters that can be used for rendering a System.
 module Theory.Constraint.System.Graph.GraphRepr (
-      GraphRepr
+      GraphRepr(..)
+    , grNodes
+    , grClusters
+    , grEdges
     , Node(..)
     , nNodeType
     , nNodeId
@@ -36,40 +39,45 @@ data Node = Node {
   }
   deriving( Eq, Ord, Show )
 
--- | Nodes can be rule instances, unsolved actions, missing (only applicable for sources), or last actions atoms (only applicable for induction).
+-- | Different types of graph nodes.
 data NodeType =
-    SystemNode M.RuleACInst
-  | UnsolvedActionNode [Th.LNFact]
-  | LastActionAtom
-  | MissingNode (Either Th.ConcIdx Th.PremIdx)
+    SystemNode M.RuleACInst                    -- ^ Nodes from rule instances
+  | UnsolvedActionNode [Th.LNFact]             -- ^ Nodes from unsolved adversary actions. 
+  | LastActionAtom                             -- ^ Nodes that are only used for inductin.
+  | MissingNode (Either Th.ConcIdx Th.PremIdx) -- ^ Nodes referenced by edges which don't exist elsewhere.
   deriving( Eq, Ord, Show )
 
 
--- | Edges can either transport facts from premises to conclusions, represent a temporal-before relationship, or be part of an unsolved chain between premises and conclusions.
+-- | Different types of graph edges. 
 data Edge =
-    SystemEdge (Sys.NodeConc, Sys.NodePrem)
-  | LessEdge (M.NodeId, M.NodeId, Sys.Reason)
-  | UnsolvedChain (Sys.NodeConc, Sys.NodePrem)
+    SystemEdge (Sys.NodeConc, Sys.NodePrem)    -- ^ Edges that transport facts from premises to conclusions between rules.
+  | LessEdge (M.NodeId, M.NodeId, Sys.Reason)  -- ^ Edges that represent a temporal-before relationship.
+  | UnsolvedChain (Sys.NodeConc, Sys.NodePrem) -- ^ Edges that are part of an unsolved chain between premises and conclusions.
   deriving( Eq, Ord, Show )
 
 -- | A cluster contains nodes, edges, and a name, which is the common prefix of the contained nodes.
 data Cluster = Cluster {
-    _cName  :: String,
-    _cNodes :: [Node],
-    _cEdges :: [Edge]
+    _cName  :: String
+  , _cNodes :: [Node]
+  , _cEdges :: [Edge]
   }
   deriving( Eq, Ord, Show )
 
-$(mkLabels [''Node, ''Cluster])
-
 -- | A graph consists of nodes, edges and clusters which are only one level deep to represent a collection of derivation rules with the same prefix.
-type GraphRepr = ([Cluster], [Node], [Edge])
+data GraphRepr = GraphRepr {
+    _grClusters :: [Cluster]
+  , _grNodes    :: [Node]
+  , _grEdges    :: [Edge]
+  }
+  deriving ( Eq, Ord, Show )
+
+$(mkLabels [''GraphRepr, ''Node, ''Cluster])
 
 -- | Conversion function to a list of edges as used by Data.Graph.
 toEdgeList :: GraphRepr -> [(Node, M.NodeId, [M.NodeId])]
-toEdgeList (clusters, nodes, edges) = 
-  let allNodes = nodes ++ concatMap (get cNodes) clusters 
-      allEdges = edges ++ concatMap (get cEdges) clusters in
+toEdgeList repr = 
+  let allNodes = get grNodes repr ++ concatMap (get cNodes) (get grClusters repr)
+      allEdges = get grEdges repr ++ concatMap (get cEdges) (get grClusters repr) in
   map (\node -> (node, get nNodeId node, findSinkIndices allEdges node)) allNodes
   where
     -- | For each node, find all connected nodes using allEdges and return their NodeId's.

--- a/lib/theory/src/Theory/Constraint/System/Graph/GraphRepr.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/GraphRepr.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE ViewPatterns #-}
+-- |
+-- Copyright   : (c) 2010, 2011 Simon Meier
+-- License     : GPL v3 (see LICENSE)
+--
+-- Portability : GHC only
+--
+-- Representation of a graph as a collection of nodes, edges and clusters that can be used for rendering a System.
+module Theory.Constraint.System.Graph.GraphRepr (
+      GraphRepr
+    , Node(..)
+    , nNodeType
+    , nNodeId
+    , NodeType(..)
+    , Edge(..)
+    , Cluster(..)
+    , cName
+    , cNodes
+    , cEdges
+    , toEdgeList
+  ) where
+
+import           Extension.Data.Label
+import qualified Theory.Constraint.System as Sys
+import qualified Theory.Model             as M
+import qualified Theory                   as Th
+import Data.Maybe (mapMaybe)
+
+-- | All nodes are identified by their NodeId.
+-- Then we have different types of nodes depending on what data of the System they use.
+data Node = Node {
+    _nNodeId    :: M.NodeId,
+    _nNodeType  :: NodeType
+  }
+  deriving( Eq, Ord, Show )
+
+-- | Nodes can be rule instances, unsolved actions, missing (only applicable for sources), or last actions atoms (only applicable for induction).
+data NodeType =
+    SystemNode M.RuleACInst
+  | UnsolvedActionNode [Th.LNFact]
+  | LastActionAtom
+  | MissingNode (Either Th.ConcIdx Th.PremIdx)
+  deriving( Eq, Ord, Show )
+
+
+-- | Edges can either transport facts from premises to conclusions, represent a temporal-before relationship, or be part of an unsolved chain between premises and conclusions.
+data Edge =
+    SystemEdge (Sys.NodeConc, Sys.NodePrem)
+  | LessEdge (M.NodeId, M.NodeId, Sys.Reason)
+  | UnsolvedChain (Sys.NodeConc, Sys.NodePrem)
+  deriving( Eq, Ord, Show )
+
+-- | A cluster contains nodes, edges, and a name, which is the common prefix of the contained nodes.
+data Cluster = Cluster {
+    _cName  :: String,
+    _cNodes :: [Node],
+    _cEdges :: [Edge]
+  }
+  deriving( Eq, Ord, Show )
+
+$(mkLabels [''Node, ''Cluster])
+
+-- | A graph consists of nodes, edges and clusters which are only one level deep to represent a collection of derivation rules with the same prefix.
+type GraphRepr = ([Cluster], [Node], [Edge])
+
+-- | Conversion function to a list of edges as used by Data.Graph.
+toEdgeList :: GraphRepr -> [(Node, M.NodeId, [M.NodeId])]
+toEdgeList (clusters, nodes, edges) = 
+  let allNodes = nodes ++ concatMap (get cNodes) clusters 
+      allEdges = edges ++ concatMap (get cEdges) clusters in
+  map (\node -> (node, get nNodeId node, findSinkIndices allEdges node)) allNodes
+  where
+    -- | For each node, find all connected nodes using allEdges and return their NodeId's.
+    findSinkIndices :: [Edge] -> Node -> [M.NodeId]
+    findSinkIndices allEdges node = 
+      let srcId = get nNodeId node in
+      mapMaybe (findEdgeTarget srcId) allEdges
+    
+    -- | For a given source node id and an edge, check if the edge belongs to the node and return the target node id.
+    findEdgeTarget :: M.NodeId -> Edge -> Maybe M.NodeId
+    findEdgeTarget srcId (SystemEdge ((srcId', _), (tgtId, _)))    | srcId == srcId' = Just tgtId
+    findEdgeTarget srcId (LessEdge (srcId', tgtId, _))             | srcId == srcId' = Just tgtId
+    findEdgeTarget srcId (UnsolvedChain ((srcId', _), (tgtId, _))) | srcId == srcId' = Just tgtId
+    findEdgeTarget _     _                                                           = Nothing
+      

--- a/lib/theory/src/Theory/Constraint/System/Graph/Simplification.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/Simplification.hs
@@ -1,5 +1,13 @@
 {-# LANGUAGE TypeOperators   #-}
 
+-- |
+-- Copyright   : (c) 2010, 2011 Simon Meier
+-- License     : GPL v3 (see LICENSE)
+--
+-- Portability : GHC only
+--
+-- System simplification functions that were originally contained in the Dot module 
+-- but which we now do on a System when generating an abstract graph.
 module Theory.Constraint.System.Graph.Simplification (
       simplifySystem
     , compressSystem

--- a/lib/theory/src/Theory/Constraint/System/Graph/Simplification.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/Simplification.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE TypeOperators   #-}
+
+module Theory.Constraint.System.Graph.Simplification (
+      simplifySystem
+    , compressSystem
+  )
+  where
+
+import qualified Data.Map                 as M
+import           Data.Maybe
+import qualified Data.Set                 as S
+import           Data.List                (foldl')
+import           Control.Basics
+import           Extension.Data.Label
+-- import           Theory.Constraint.System
+import           Theory                   
+import qualified Data.DAG.Simple          as Dag
+import           Data.Monoid              (Any(..))
+import           Utils.Misc
+
+------------------------------------------------------------------------------
+-- Compressed versions of a sequent (originally from Dot module)
+------------------------------------------------------------------------------
+
+-- | Drop 'Less' atoms entailed by the edges of the 'System'.
+dropEntailedOrdConstraints :: System -> System
+dropEntailedOrdConstraints se =
+    modify sLessAtoms (S.filter (not . entailed)) se
+  where
+    edges               = rawEdgeRel se
+    entailed (from, to, _) = to `S.member` Dag.reachableSet [from] edges
+
+-- | Unsound compression of the sequent that drops fully connected learns and
+-- knows nodes.
+compressSystem :: System -> System
+compressSystem se0 =
+    foldl' (flip tryHideNodeId) se (frees (get sLessAtoms se, get sNodes se))
+  where
+    se = dropEntailedOrdConstraints se0
+
+-- | Simplify the system up to the sent level, 
+-- | for level 3, we will simplify the lesses of system by transitive reduction
+-- | for level 2, we will apply the transitive reduction but keep the 
+-- | formula constraint 
+-- | for level 1, there's no transitive reduction applied
+simplifySystem :: Int -> System -> System
+simplifySystem i sys
+    | i==2 = transitiveReduction sys False
+    | i==3 = transitiveReduction sys True
+    | otherwise = sys
+
+-- | Simplify the system by transitive reduction (constraint of formula won't  
+-- | be applied if totalRed is False) but not for a system which has a graph cyclic
+transitiveReduction :: System -> Bool -> System
+transitiveReduction sys totalRed=
+    if Dag.cyclic oldLesses
+        then sys
+        else   modify sLessAtoms
+            ( S.intersection ( S.fromList newLesses) ) sys
+    where
+        oldLessesWithR = S.toList $ get sLessAtoms sys
+        oldLesses = rawLessRel sys
+        newLesses = if totalRed
+            then [(x,y,z)| (x,y,z)<- oldLessesWithR,
+                            (x,y) `elem` (Dag.transRed oldLesses) ]
+            else [(x,y,z)| (x,y,z)<- oldLessesWithR,
+                            (x,y) `elem` (Dag.transRed oldLesses) || z == Formula || z == Adversary ]
+
+
+-- | @hideTransferNode v se@ hides node @v@ in sequent @se@ if it is a
+-- transfer node; i.e., a node annotated with a rule that is one of the
+-- special intruder rules or a rule with with at most one premise and
+-- at most one conclusion and both premises and conclusions have incoming
+-- respectively outgoing edges.
+--
+-- The compression is chosen such that unly uninteresting nodes are that have
+-- no open goal are suppressed.
+tryHideNodeId :: NodeId -> System -> System
+tryHideNodeId v se = fromMaybe se $ do
+    guard $  (lvarSort v == LSortNode)
+          && notOccursIn unsolvedChains
+          && notOccursIn (get sFormulas)
+    maybe hideAction hideRule (M.lookup v $ get sNodes se)
+  where
+    selectPart :: (System :-> S.Set a) -> (a -> Bool) -> [a]
+    selectPart l p = filter p $ S.toList $ get l se
+
+    notOccursIn :: HasFrees a => (System -> a) -> Bool
+    notOccursIn proj = not $ getAny $ foldFrees (Any . (v ==)) $ proj se
+
+    -- hide KU-actions deducing pairs, inverses, and simple terms
+    hideAction = do
+        guard $  not (null kuActions)
+              && all eligibleTerm kuActions
+              && all (\(i, j, _) -> not (i == j)) lNews
+              && notOccursIn (standardActionAtoms)
+              && notOccursIn (get sLastAtom)
+              && notOccursIn (get sEdges)
+
+        return $ modify sLessAtoms ( (`S.union` S.fromList lNews)
+                                   . (`S.difference` S.fromList lIns)
+                                   . (`S.difference` S.fromList lOuts)
+                                   )
+               $ modify sGoals (\m -> foldl' removeAction m kuActions)
+               $ se
+      where
+        kuActions            = [ x | x@(i,_,_) <- kuActionAtoms se, i == v ]
+        eligibleTerm (_,_,m) =
+            isPair m || isInverse m || sortOfLNTerm m == LSortPub || sortOfLNTerm m == LSortNat
+
+        removeAction m (i, fa, _) = M.delete (ActionG i fa) m
+
+        lIns  = selectPart sLessAtoms ((v ==) . snd3)
+        lOuts = selectPart sLessAtoms ((v ==) . fst3)
+        lNews = [ (i, j, r) | (i, _, _) <- lIns, (_, j, r) <- lOuts ]
+
+    -- hide a rule, if it is not "too complicated"
+    hideRule :: RuleACInst -> Maybe System
+    hideRule ru = do
+        guard $  eligibleRule
+              && ( length eIns  == length (get rPrems ru) )
+              && ( length eOuts == length (get rConcs ru) )
+              && ( all (not . selfEdge) eNews             )
+              && notOccursIn (get sLastAtom)
+              && notOccursIn (get sLessAtoms)
+              && notOccursIn (unsolvedActionAtoms)
+
+        return $ modify sEdges ( (`S.union` S.fromList eNews)
+                               . (`S.difference` S.fromList eIns)
+                               . (`S.difference` S.fromList eOuts)
+                               )
+               $ modify sNodes (M.delete v)
+               $ se
+      where
+        eIns  = selectPart sEdges ((v ==) . nodePremNode . eTgt)
+        eOuts = selectPart sEdges ((v ==) . nodeConcNode . eSrc)
+        eNews = [ Edge cIn pOut | Edge cIn _ <- eIns, Edge _ pOut <- eOuts ]
+
+        selfEdge (Edge cIn pOut) = nodeConcNode cIn == nodePremNode pOut
+
+        eligibleRule =
+             any ($ ru) [isISendRule, isIRecvRule, isCoerceRule, isFreshRule]
+          || ( null (get rActs ru) &&
+               all (\l -> length (get l ru) <= 1) [rPrems, rConcs]
+             )

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -40,11 +40,12 @@ import           Data.Aeson.Encode.Pretty   -- to do pretty printing of JSON
 import           Data.Foldable
 import qualified Data.Map                   as M
 import           Data.Maybe
-import qualified Data.Set                   as S
 import qualified Data.ByteString.Lazy.Char8 as BC (unpack)
-
+import           Control.Monad.Reader
 import           Text.PrettyPrint.Class     -- for Doc and the pretty printing functions 
-import           Theory.Constraint.System   
+import           Theory.Constraint.System hiding (Edge, resolveNodeConcFact, resolveNodePremFact)
+import qualified Theory.Constraint.System.Graph.Graph as G
+import           Theory.Constraint.System.Graph.Graph hiding (defaultOptions)
 import           Theory.Model
 
 -------------------------------------------------------------------------------------------------
@@ -54,73 +55,79 @@ import           Theory.Model
 
 -- | Representation of a term in a JSON graph node.
 data JSONGraphNodeTerm = 
-   Const String
-   | Funct String [JSONGraphNodeTerm] String
-   deriving (Show)
+  Const String
+  | Funct String [JSONGraphNodeTerm] String
+  deriving (Show)
 
 -- | Automatically derived instances have unnecessarily many tag-value pairs. 
 -- Hence, we have our own here.
 instance FromJSON JSONGraphNodeTerm where
-    parseJSON = withObject "JSONGraphNodeTerm" $ \o -> asum [
-      Const <$> o .: "jgnConst",
-      Funct <$> o .: "jgnFunct" <*> o .: "jgnParams" <*> o .: "jgnShow" ]
+  parseJSON = withObject "JSONGraphNodeTerm" $ \o -> asum [
+    Const <$> o .: "jgnConst",
+    Funct <$> o .: "jgnFunct" <*> o .: "jgnParams" <*> o .: "jgnShow" ]
 
 instance ToJSON JSONGraphNodeTerm where
-    toJSON (Const s) = object [ "jgnConst" .= s ]
-    toJSON (Funct f p s) = object 
-      [ "jgnFunct"  .= f
-      , "jgnParams" .= toJSON p
-      , "jgnShow"   .= s
-      ] 
+  toJSON (Const s) = object [ "jgnConst" .= s ]
+  toJSON (Funct f p s) = object 
+    [ "jgnFunct"  .= f
+    , "jgnParams" .= toJSON p
+    , "jgnShow"   .= s
+    ] 
 
 -- | Representation of a fact in a JSON graph node.
 data JSONGraphNodeFact = JSONGraphNodeFact 
-    {
-      jgnFactId    :: String
-    , jgnFactTag   :: String  -- ^ ProtoFact, FreshFact, OutFact, InFact, KUFact, KDFact, DedFact
-    , jgnFactName  :: String  -- ^ Fr, Out, In, !KU, ...
-    , jgnFactMult  :: String  -- ^ "!" = persistent, "" = linear
-    , jgnFactTerms :: [JSONGraphNodeTerm]
-    , jgnFactShow  :: String
-    } deriving (Show)
+  { jgnFactId    :: String
+  , jgnFactTag   :: String  -- ^ ProtoFact, FreshFact, OutFact, InFact, KUFact, KDFact, DedFact
+  , jgnFactName  :: String  -- ^ Fr, Out, In, !KU, ...
+  , jgnFactMult  :: String  -- ^ "!" = persistent, "" = linear
+  , jgnFactTerms :: [JSONGraphNodeTerm]
+  , jgnFactShow  :: String
+  } deriving (Show)
 
 -- | Representation of meta data of a JSON graph node.
 data JSONGraphNodeMetadata = JSONGraphNodeMetadata 
-    {
-      jgnPrems :: [JSONGraphNodeFact]
-    , jgnActs  :: [JSONGraphNodeFact]
-    , jgnConcs :: [JSONGraphNodeFact]
-    } deriving (Show)
+  { jgnPrems :: [JSONGraphNodeFact]
+  , jgnActs  :: [JSONGraphNodeFact]
+  , jgnConcs :: [JSONGraphNodeFact]
+  } deriving (Show)
 
 -- | Representation of a node of a JSON graph.
 data JSONGraphNode = JSONGraphNode 
-    {
-      jgnId :: String
-    , jgnType :: String
-    , jgnLabel :: String
-    , jgnMetadata :: Maybe JSONGraphNodeMetadata
-    } deriving (Show)
+  { jgnId :: String
+  , jgnType :: String
+  , jgnLabel :: String
+  , jgnMetadata :: Maybe JSONGraphNodeMetadata
+  } deriving (Show)
 
 -- | Representation of an edge of a JSON graph.
 data JSONGraphEdge = JSONGraphEdge 
-    {
-      jgeSource :: String
-    , jgeRelation :: String
-    , jgeTarget :: String
---  , jgeDirected :: Maybe Bool
---  , jgeLabel :: Maybe String
-    } deriving (Show)
+  { jgeSource :: String
+  , jgeRelation :: String
+  , jgeTarget :: String
+  } deriving (Show)
+
+data JSONGraphCluster = JSONGraphCluster 
+  { jgcName :: String
+  , jgcNodes :: [JSONGraphNode]
+  , jgcEdges :: [JSONGraphEdge]
+  } deriving (Show)
+
+data JSONGraphAbbrev = JSONGraphAbbrev
+  { jgaTerm :: JSONGraphNodeTerm
+  , jgaAbbrev :: JSONGraphNodeTerm
+  , jgaExpansion :: JSONGraphNodeTerm
+  } deriving (Show)
 
 -- | Representation of a JSON graph.
 data JSONGraph = JSONGraph 
-   {
-      jgDirected :: Bool
-    , jgType :: String
-    , jgLabel :: String
-    , jgNodes :: [JSONGraphNode]
-    , jgEdges :: [JSONGraphEdge]
---  , jgmetadata :: JSONGraphMetadata 
-    } deriving (Show)
+  { jgDirected :: Bool
+  , jgType :: String
+  , jgLabel :: String
+  , jgNodes :: [JSONGraphNode]
+  , jgEdges :: [JSONGraphEdge]
+  , jgClusters :: [JSONGraphCluster]
+  , jgAbbrevs :: [JSONGraphAbbrev]
+  } deriving (Show)
 
 -- | Representation of a collection of JSON graphs.
 data JSONGraphs = JSONGraphs 
@@ -129,23 +136,23 @@ data JSONGraphs = JSONGraphs
     } deriving (Show)
 
 -- | Derive ToJSON and FromJSON. 
-concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphEdge, ''JSONGraph, ''JSONGraphs]
+concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphEdge, ''JSONGraphCluster, ''JSONGraphAbbrev, ''JSONGraph, ''JSONGraphs]
 
 -- | Optional fields are not handled correctly with automatically derived instances
 -- hence, we have our own here.
 instance FromJSON JSONGraphNode where
-    parseJSON = withObject "JSONGraphNode" $ \o -> JSONGraphNode
-        <$> o .: "jgnId"
-        <*> o .: "jgnType"
-        <*> o .: "jgnLabel"
-        <*> o .:? "jgnMetadata"
+  parseJSON = withObject "JSONGraphNode" $ \o -> JSONGraphNode
+      <$> o .: "jgnId"
+      <*> o .: "jgnType"
+      <*> o .: "jgnLabel"
+      <*> o .:? "jgnMetadata"
 
 instance ToJSON JSONGraphNode where
-    toJSON (JSONGraphNode jgnId' jgnType' jgnLabel' jgnMetadata') = object $ catMaybes
-        [ ("jgnId" .=) <$> pure jgnId'
-        , ("jgnType" .=) <$> pure jgnType'
-        , ("jgnLabel" .=) <$> pure jgnLabel'
-        , ("jgnMetadata" .=) <$> jgnMetadata' ]
+  toJSON (JSONGraphNode jgnId' jgnType' jgnLabel' jgnMetadata') = object $ catMaybes
+      [ ("jgnId" .=) <$> pure jgnId'
+      , ("jgnType" .=) <$> pure jgnType'
+      , ("jgnLabel" .=) <$> pure jgnLabel'
+      , ("jgnMetadata" .=) <$> jgnMetadata' ]
 
 -- | Generation of JSON text from JSON graphs.
 
@@ -189,6 +196,21 @@ getRuleType r
     | isCoerceRule r    = "isCoerceRule"
     | isProtocolRule r  = "isProtocolRule"
     | otherwise         = "unknown rule type"
+
+-- | 
+-- Bool: determines whether facts etc are also pretty printed
+-- Graph: Graph to be dumped to JSON
+type RJSON a = Reader (Bool, Graph) a
+
+getPretty :: RJSON Bool
+getPretty = do
+  (pretty, _) <- ask
+  return pretty
+
+getGraph :: RJSON Graph
+getGraph = do
+  (_, graph) <- ask
+  return graph
 
 -- | Generate the JSON data structure from a term.
 -- | "instance Show a" in Raw.hs served as example.
@@ -244,179 +266,196 @@ nodeToJSONGraphNodeMetadata pretty (n, ru) =
                                        $ zip [0..] $ L.get rConcs ru
                           }
 
--- | Generate JSONGraphNode from node of sequent.
-nodeToJSONGraphNode :: Bool -> (NodeId, RuleACInst) -> JSONGraphNode
-nodeToJSONGraphNode pretty (n, ru) = 
-    JSONGraphNode { jgnId = show n
-                  , jgnType = getRuleType ru
-                  , jgnLabel = getRuleName ru
-                  , jgnMetadata = Just (nodeToJSONGraphNodeMetadata pretty (n, ru))
-                  }
+graphNodeToJSONGraphNode :: Node -> RJSON JSONGraphNode
+graphNodeToJSONGraphNode node = do
+  pretty <- getPretty
+  let nid = get nNodeId node
+      nodeType = get nNodeType node
+  case nodeType of
+    SystemNode ru -> 
+      return $ JSONGraphNode 
+                { jgnId = show nid
+                , jgnType = getRuleType ru
+                , jgnLabel = getRuleName ru
+                , jgnMetadata = Just (nodeToJSONGraphNodeMetadata pretty (nid, ru))
+                }
+    UnsolvedActionNode facts -> 
+      return $ JSONGraphNode 
+                { jgnId = show nid
+                , jgnType     = "unsolvedActionAtom"
+                , jgnLabel    = if pretty 
+                                then pps $ fsep $ punctuate comma $ map prettyLNFact facts
+                                else ""
+                , jgnMetadata = 
+                    Just JSONGraphNodeMetadata 
+                      { jgnPrems = []
+                      , jgnActs  = map (itemToJSONGraphNodeFact pretty "action") facts 
+                      , jgnConcs = [] 
+                      }
+               }    
+    LastActionAtom -> 
+      return $ JSONGraphNode 
+                { jgnId = show nid
+                , jgnType = "lastAtom"
+                , jgnLabel = show nid
+                , jgnMetadata = Nothing 
+                }
+    {-|
+      Generate a JSONGraphNode for those nodes in sEdges that are not present in sNodes. 
+      This might occur in the case distinctions shown in the GUI.
+      Since a fact is missing, the id is encoded as jgnFactId, could also be done directly in jgnId.
+    -}
+    MissingNode (Left conc) -> 
+      -- a.d. TODO JSON ignores conc and always sets conclusion id to c0. Is that intended behavior?
+      return $ JSONGraphNode 
+        { jgnId = show nid
+        , jgnType = "missingNodeConc"
+        , jgnLabel = ""
+        , jgnMetadata = 
+            Just JSONGraphNodeMetadata 
+              { jgnPrems = []
+              , jgnActs  = []
+              , jgnConcs = 
+                  [ JSONGraphNodeFact 
+                      { jgnFactId    = show nid ++":c0"
+                      , jgnFactTag   = ""
+                      , jgnFactName  = ""
+                      , jgnFactMult  = ""
+                      , jgnFactTerms = []   
+                      , jgnFactShow  = ""
+                      }
+                  ]
+              }
+        }
+    MissingNode (Right prem) -> 
+      return $ JSONGraphNode 
+        { jgnId = show nid
+        , jgnType = "missingNodePrem"
+        , jgnLabel = ""
+        , jgnMetadata = 
+            Just JSONGraphNodeMetadata 
+              { jgnPrems = 
+                  [ JSONGraphNodeFact 
+                      { jgnFactId    = show nid ++":p0"
+                      , jgnFactTag   = ""
+                      , jgnFactName  = ""
+                      , jgnFactMult  = ""
+                      , jgnFactTerms = []
+                      , jgnFactShow = ""
+                      }
+                  ] 
+              , jgnActs  = []
+              , jgnConcs = []
+              }
+        }
+
 
 -- | Determine the type of an edge.
-getRelationType :: NodeConc -> NodePrem -> System -> String
-getRelationType src tgt se =
-    let check p = maybe False p (resolveNodePremFact tgt se) ||
-                  maybe False p (resolveNodeConcFact src se)
-        relationType | check isKFact          = "KFact"
-                     | check isPersistentFact = "PersistentFact"
-                     | check isProtoFact      = "ProtoFact"
-                     | otherwise              = "default"
-    in
+getRelationType :: NodeConc -> NodePrem -> Graph -> String
+getRelationType src tgt graph =
+  let check p = maybe False p (resolveNodePremFact tgt graph) ||
+                maybe False p (resolveNodeConcFact src graph)
+      relationType | check isKFact          = "KFact"
+                   | check isPersistentFact = "PersistentFact"
+                   | check isProtoFact      = "ProtoFact"
+                   | otherwise              = "default"
+  in
     relationType
 
--- | Generate JSON data structure for lastAtom.
-lastAtomToJSONGraphNode :: Maybe NodeId -> [JSONGraphNode]
-lastAtomToJSONGraphNode n = case n of
-    Nothing -> [] 
-    Just n' -> [JSONGraphNode { jgnId = show n'
-                              , jgnType = "lastAtom"
-                              , jgnLabel = show n'
-                              , jgnMetadata = Nothing 
-                              }] 
 
--- | Generate JSON data structure for unsolvedActionAtom.
-unsolvedActionAtomsToJSONGraphNode :: Bool -> (NodeId, LNFact) -> JSONGraphNode
-unsolvedActionAtomsToJSONGraphNode pretty (n, f) =
-    JSONGraphNode 
-      { jgnId = show n
-      , jgnType     = "unsolvedActionAtom"
-      , jgnLabel    = case pretty of
-                        True  -> pps $ prettyLNFact f
-                        False -> ""
-      , jgnMetadata = 
-          Just JSONGraphNodeMetadata 
-            { jgnPrems = []
-            , jgnActs  = [itemToJSONGraphNodeFact pretty "action" f] 
-            , jgnConcs = [] 
-            }
-     }    
+graphEdgeToJSONGraphEdge :: Edge -> RJSON JSONGraphEdge
+graphEdgeToJSONGraphEdge (SystemEdge (src, tgt)) = do
+  graph <- getGraph
+  return $ JSONGraphEdge { jgeSource = show sid ++ ":c" ++ show concIdx
+                , jgeTarget = show tid ++ ":p" ++ show premIdx
+                , jgeRelation = getRelationType src tgt graph
+                }
+                where 
+                  (sid, ConcIdx concIdx) = src
+                  (tid, PremIdx premIdx) = tgt
+graphEdgeToJSONGraphEdge (LessEdge (src, tgt, reason)) =
+  return $ JSONGraphEdge { jgeSource = show src
+                , jgeRelation = "LessAtoms"
+                , jgeTarget = show tgt
+                }
+graphEdgeToJSONGraphEdge (UnsolvedChain (src, tgt)) = 
+  return $ JSONGraphEdge { jgeSource = show sid ++ ":c" ++ show concIdx
+                , jgeTarget = show tid ++ ":p" ++ show premIdx
+                , jgeRelation = "unsolvedChain"
+                }
+                where 
+                  (sid, ConcIdx concIdx) = src
+                  (tid, PremIdx premIdx) = tgt
 
-{-|
-  Generate a JSONGraphNode for those nodes in sEdges that are not present in sNodes. 
-  This might occur in the case distinctions shown in the GUI.
-  Since a fact is missing, the id is encoded as jgnFactId, could also be done directly in jgnId.
--}
-missingNodesToJSONGraphNodes :: System -> [Edge] -> [JSONGraphNode]
-missingNodesToJSONGraphNodes _ [] = []
-missingNodesToJSONGraphNodes se ((Edge (sid, _) (tid, _)):el) 
-    | notElem sid nodelist = 
-         (JSONGraphNode 
-            { jgnId = show sid
-            , jgnType = "missingNodeConc"
-            , jgnLabel = ""
-            , jgnMetadata = 
-                Just JSONGraphNodeMetadata 
-                  { jgnPrems = []
-                  , jgnActs  = []
-                  , jgnConcs = 
-                      [ JSONGraphNodeFact 
-                          { jgnFactId    = show sid ++":c0"
-                          , jgnFactTag   = ""
-                          , jgnFactName  = ""
-                          , jgnFactMult  = ""
-                          , jgnFactTerms = []   
-                          , jgnFactShow  = ""
-                          }
-                      ]
-                  }
-            }: missingNodesToJSONGraphNodes se el)
-    | notElem tid nodelist = 
-         (JSONGraphNode 
-            { jgnId = show tid
-            , jgnType = "missingNodePrem"
-            , jgnLabel = ""
-            , jgnMetadata = 
-                Just JSONGraphNodeMetadata 
-                  { jgnPrems = 
-                      [ JSONGraphNodeFact 
-                          { jgnFactId    = show tid ++":p0"
-                          , jgnFactTag   = ""
-                          , jgnFactName  = ""
-                          , jgnFactMult  = ""
-                          , jgnFactTerms = []
-                          , jgnFactShow = ""
-                          }
-                      ] 
-                  , jgnActs  = []
-                  , jgnConcs = []
-                  }
-            }: missingNodesToJSONGraphNodes se el)
-    | otherwise = (missingNodesToJSONGraphNodes se el)
-    where 
-      nodelist = map fst $ M.toList $ L.get sNodes se
+graphClusterToJSONGraphCluster :: Cluster -> RJSON JSONGraphCluster 
+graphClusterToJSONGraphCluster cluster = do
+  jnodes <- mapM graphNodeToJSONGraphNode $ get cNodes cluster
+  jedges <- mapM graphEdgeToJSONGraphEdge $ get cEdges cluster
+  return $ JSONGraphCluster 
+    { jgcName = get cName cluster
+    , jgcNodes = jnodes
+    , jgcEdges = jedges
+    }
 
--- | Generate JSON data structure for edges.
-edgeToJSONGraphEdge :: System -> Edge -> JSONGraphEdge
-edgeToJSONGraphEdge se (Edge src tgt)  =
-    JSONGraphEdge { jgeSource = show sid ++ ":c" ++ show concidx
-                  , jgeTarget = show tid ++ ":p" ++ show premidx
-                  , jgeRelation = getRelationType src tgt se
-                  }
-                  where 
-                    (sid, ConcIdx concidx) = src
-                    (tid, PremIdx premidx) = tgt
+graphAbbrevtoJSONGraphAbbrev :: (LNTerm, (LNTerm, LNTerm)) -> RJSON JSONGraphAbbrev
+graphAbbrevtoJSONGraphAbbrev (term, (abbrev, recursiveExpansion)) = do
+  pretty <- getPretty
+  return JSONGraphAbbrev
+    { jgaTerm = lntermToJSONGraphNodeTerm pretty term
+    , jgaAbbrev = lntermToJSONGraphNodeTerm pretty abbrev
+    , jgaExpansion = lntermToJSONGraphNodeTerm pretty recursiveExpansion
+    }
 
--- | Generate JSON data structure for lessAtoms edge.
-lessAtomsToJSONGraphEdge :: (NodeId, NodeId) -> JSONGraphEdge
-lessAtomsToJSONGraphEdge (src, tgt) =
-    JSONGraphEdge { jgeSource = show src
-                  , jgeRelation = "LessAtoms"
-                  , jgeTarget = show tgt
-                  }
-
--- | Generate JSON data structure for unsolvedChain edge.
-unsolvedchainToJSONGraphEdge :: (NodeConc, NodePrem) -> JSONGraphEdge
-unsolvedchainToJSONGraphEdge (src, tgt)  =
-    JSONGraphEdge { jgeSource = show sid ++ ":c" ++ show concidx
-                  , jgeTarget = show tid ++ ":p" ++ show premidx
-                  , jgeRelation = "unsolvedChain"
-                  }
-                  where 
-                    (sid, ConcIdx concidx) = src
-                    (tid, PremIdx premidx) = tgt
 
 -- | Generate JSON graph(s) data structure from sequent.
-sequentToJSONGraphs :: Bool       -- ^ determines whether facts etc are also pretty printed
-                    -> String     -- ^ label of graph
-                    -> System     -- ^ sequent to dump to JSON
-                    -> JSONGraphs
-sequentToJSONGraphs pretty label se = 
-    JSONGraphs 
-      { graphs = 
-          [ JSONGraph 
-              { jgDirected = True
-              , jgType  = "Tamarin prover constraint system"
-              , jgLabel = label
-              , jgNodes = (map (nodeToJSONGraphNode pretty) $ M.toList $ L.get sNodes se)
-                          ++ (lastAtomToJSONGraphNode $ L.get sLastAtom se)
-                          ++ (map (unsolvedActionAtomsToJSONGraphNode pretty) $ unsolvedActionAtoms se)
-                          ++ (missingNodesToJSONGraphNodes se $ S.toList $ L.get sEdges se)
-              , jgEdges = (map (edgeToJSONGraphEdge se) $ S.toList $ L.get sEdges se)
-                          ++ (map lessAtomsToJSONGraphEdge $ S.toList $ getLessAtoms se)
-                          ++ (map unsolvedchainToJSONGraphEdge $ unsolvedChains se)
-              } 
-          ] 
-      }
+sequentToJSONGraphs :: String     -- ^ label of graph
+                    -> RJSON JSONGraphs
+sequentToJSONGraphs label = do
+  graph <- getGraph
+  let (clusters, nodes, edges) = get gRepr graph 
+      abbrevs = get gAbbreviations graph
+  jnodes <- mapM graphNodeToJSONGraphNode nodes
+  jedges <- mapM graphEdgeToJSONGraphEdge edges
+  jclusters <- mapM graphClusterToJSONGraphCluster clusters
+  jabbrevs <- mapM graphAbbrevtoJSONGraphAbbrev $ M.toList abbrevs
+  return $ JSONGraphs 
+    { graphs = 
+        [ JSONGraph 
+            { jgDirected = True
+            , jgType  = "Tamarin prover constraint system"
+            , jgLabel = label
+            , jgNodes = jnodes
+            , jgEdges = jedges
+            , jgClusters = jclusters
+            , jgAbbrevs = jabbrevs
+            } 
+        ] 
+    }
 
 -- | Generate JSON bytestring from sequent.
-sequentToJSON :: String -> System -> String
-sequentToJSON l se =
-    BC.unpack $ encode (sequentToJSONGraphs False l se)
+sequentToJSON :: GraphOptions -> String -> System -> String
+sequentToJSON graphOptions l se =
+  let graph = systemToGraph se graphOptions
+      graphJSON = (`runReader` (False, graph)) $ sequentToJSONGraphs l
+  in
+    BC.unpack $ encode graphJSON
 
 -- | NOTE (dschoop): encodePretty encodes < and > as "\u003c" and "\u003e" respectively.
 -- The encoding is removed with function removePseudoUnicode since Data.Strings.Util is non-standard.
 -- The function encodePretty returns Data.ByteString.Lazy.Internal.ByteString containing
 -- 8-bit bytes. However, eventually some other ByteString or String is expected by writeFile 
 -- in /src/Web/Theory.hs.
-sequentToJSONPretty :: String -> System -> String
-sequentToJSONPretty l se =
-    removePseudoUnicode $ BC.unpack $ encodePretty $ sequentToJSONGraphs True l se
+sequentToJSONPretty :: GraphOptions -> String -> System -> String
+sequentToJSONPretty graphOptions l se =
+  let graph = systemToGraph se graphOptions 
+      graphJSON = (`runReader` (True, graph)) $ sequentToJSONGraphs l
+  in
+    removePseudoUnicode $ BC.unpack $ encodePretty graphJSON
 
-writeSequentAsJSONToFile :: FilePath -> String -> System -> IO ()
-writeSequentAsJSONToFile fp l se =
-    do writeFile fp $ sequentToJSON l se
+writeSequentAsJSONToFile :: FilePath -> GraphOptions -> String -> System -> IO ()
+writeSequentAsJSONToFile fp graphOptions l se =
+  do writeFile fp $ sequentToJSON graphOptions l se
 
-writeSequentAsJSONPrettyToFile :: FilePath -> String -> System -> IO ()
-writeSequentAsJSONPrettyToFile fp l se =
-    do writeFile fp $ sequentToJSONPretty l se
+writeSequentAsJSONPrettyToFile :: FilePath -> GraphOptions -> String -> System -> IO ()
+writeSequentAsJSONPrettyToFile fp graphOptions l se =
+  do writeFile fp $ sequentToJSONPretty graphOptions l se

--- a/lib/theory/tamarin-prover-theory.cabal
+++ b/lib/theory/tamarin-prover-theory.cabal
@@ -67,7 +67,6 @@ library
       , transformers
       , uniplate
       , exceptions
-      , graphviz
 
       , tamarin-prover-utils
       , tamarin-prover-term

--- a/lib/theory/tamarin-prover-theory.cabal
+++ b/lib/theory/tamarin-prover-theory.cabal
@@ -67,6 +67,7 @@ library
       , transformers
       , uniplate
       , exceptions
+      , graphviz
 
       , tamarin-prover-utils
       , tamarin-prover-term
@@ -93,6 +94,10 @@ library
       Theory.Constraint.System.Dot
       Theory.Constraint.System.JSON
       Theory.Constraint.System.Guarded
+      Theory.Constraint.System.Graph.GraphRepr
+      Theory.Constraint.System.Graph.Abbreviation
+      Theory.Constraint.System.Graph.Simplification
+      Theory.Constraint.System.Graph.Graph
 
       Theory.Sapic.Term
       Theory.Sapic.Pattern

--- a/lib/utils/src/Extension/Prelude.hs
+++ b/lib/utils/src/Extension/Prelude.hs
@@ -9,7 +9,7 @@ module Extension.Prelude where
 
 import Data.Maybe
 --import Data.List --hiding (sortOn)
-import Data.List (groupBy,inits,nubBy,sortBy,tails,unfoldr)
+import Data.List (groupBy,inits,nubBy,sortBy,tails,unfoldr,nub)
 import qualified Data.Set as S
 import qualified Data.Map as M
 import Data.Ord (comparing)
@@ -95,6 +95,16 @@ nubOn proj = nubBy ((==) `on` proj)
 -- | //O(n).// Group on a projection of the data to group
 groupOn :: Eq b => (a -> b) -> [a] -> [[a]]
 groupOn proj = groupBy ((==) `on` proj)
+
+-- | For an association list collect all values with the same key in a list.
+collectBy :: (Ord k) => [(k, v)] -> [(k, [v])]
+collectBy lst =
+    let ks = nub $ map fst lst in
+    map findVals ks
+  where
+    findVals k = 
+      let vs = [v | (k', v) <- lst, k == k'] in
+      (k, vs)
 
 -- | sort on a projection of the data to sort
 sortOn :: Ord b => (a -> b) -> [a] -> [a]

--- a/lib/utils/src/Text/Dot.hs
+++ b/lib/utils/src/Text/Dot.hs
@@ -9,6 +9,7 @@
 --
 -- This module provides a simple interface for building .dot graph files, for input into the dot and graphviz tools.
 -- It includes a monadic interface for building graphs.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Text.Dot
         (
@@ -53,6 +54,8 @@ module Text.Dot
 import Data.Char           (isSpace)
 import Data.List           (intersperse)
 import Control.Monad       (liftM, ap)
+import Control.Monad.State (State, evalState, runState)
+import           Extension.Data.Label
 -- import Control.Applicative (Applicative(..))
 
 data NodeId = NodeId String
@@ -68,28 +71,38 @@ data GraphElement = GraphAttribute String String
                   | GraphNode NodeId        [(String,String)]
                   | GraphEdge NodeId NodeId [(String,String)]
                   | Scope           [GraphElement]
-                  | SubGraph NodeId [GraphElement]
+                  | SubGraph (Maybe NodeId) [GraphElement]
+  deriving (Show)
 
-data Dot a = Dot { unDot :: Int -> ([GraphElement],Int,a) }
+data DotGenState = DotGenState {
+  _dgsId :: Int,
+  _dgsElements :: [GraphElement]
+}
 
-instance Functor Dot where
-  fmap f m = Dot $ \ uq -> case unDot m uq of (a,b,x) -> (a,b,f x)
+$(mkLabels [''DotGenState])
 
-instance Applicative Dot where
-  pure  = return
-  (<*>) = ap
+type Dot = State DotGenState
 
-instance Monad Dot where
-  return a = Dot $ \ uq -> ([],uq,a)
-  m >>= k  = Dot $ \ uq -> case unDot m uq of
-                           (g1,uq',r) -> case unDot (k r) uq' of
-                                           (g2,uq2,r2) -> (g1 ++ g2,uq2,r2)
+runDot :: DotGenState -> Dot a -> (a, DotGenState)
+runDot state dot = runState dot state
+
+nextId :: Dot Int
+nextId = do
+  uq <- getM dgsId
+  () <- setM dgsId (succ uq)
+  return uq
+  
+addElements :: [GraphElement] -> Dot ()
+addElements elems = do
+  modM dgsElements (++elems)
 
 -- | 'rawNode' takes a list of attributes, generates a new node, and gives a 'NodeId'.
 rawNode      :: [(String,String)] -> Dot NodeId
-rawNode attrs = Dot $ \ uq ->
+rawNode attrs = do 
+    uq <- nextId
     let nid = NodeId $ "n" ++ show uq
-    in ( [ GraphNode nid attrs ],succ uq,nid)
+    addElements [ GraphNode nid attrs ]
+    return nid
 
 -- | 'node' takes a list of attributes, generates a new node, and gives a
 -- 'NodeId'. Multi-line labels are fixed such that they use non-breaking
@@ -101,30 +114,32 @@ node = rawNode . map fixLabel
     fixLabel attr          = attr
 
 
--- | 'userNodeId' allows a user to use their own (Int-based) node id's, without needing to remap them.
-userNodeId :: Int -> NodeId
-userNodeId i = UserNodeId i
-
 -- | 'userNode' takes a NodeId, and adds some attributes to that node.
 userNode :: NodeId -> [(String,String)] -> Dot ()
-userNode nId attrs = Dot $ \ uq -> ( [GraphNode nId attrs ],uq,())
+userNode nId attrs = addElements [GraphNode nId attrs ]
 
 -- | 'edge' generates an edge between two 'NodeId's, with attributes.
 edge      :: NodeId -> NodeId -> [(String,String)] -> Dot ()
-edge  from to attrs = Dot (\ uq -> ( [ GraphEdge from to attrs ],uq,()))
+edge  from to attrs = addElements [ GraphEdge from to attrs ]
+
 
 -- | 'scope' groups a subgraph together; in dot these are the subgraphs inside "{" and "}".
 scope     :: Dot a -> Dot a
-scope (Dot fn) = Dot (\ uq -> case fn uq of
-                              ( elems,uq',a) -> ([Scope elems],uq',a))
+scope dot = do 
+  uq <- getM dgsId
+  let subState = DotGenState { _dgsId = uq, _dgsElements = [] }
+  let (a, finalState) = runDot subState dot
+  setM dgsId (get dgsId finalState)
+  addElements [SubGraph Nothing (get dgsElements finalState)]
+  return a
 
 -- | 'share' is when a set of nodes share specific attributes. Usually used for layout tweaking.
 share :: [(String,String)] -> [NodeId] -> Dot ()
-share attrs nodeids = Dot $ \ uq ->
-      ( [ Scope ( [ GraphAttribute name val | (name,val) <- attrs]
+share attrs nodeids =
+  let elems = [ Scope ( [ GraphAttribute name val | (name,val) <- attrs]
                ++ [ GraphNode nodeid [] | nodeid <- nodeids ]
-               )
-        ], uq, ())
+               ) ] 
+  in addElements elems
 
 -- | 'same' provides a combinator for a common pattern; a set of 'NodeId's with the same rank.
 same :: [NodeId] -> Dot ()
@@ -133,39 +148,124 @@ same = share [("rank","same")]
 
 -- | 'cluster' builds an explicit, internally named subgraph (called cluster).
 cluster :: Dot a -> Dot (NodeId,a)
-cluster (Dot fn) = Dot (\ uq ->
-                let cid = NodeId $ "cluster_" ++ show uq
-                in case fn (succ uq) of
-                    (elems,uq',a) -> ([SubGraph cid elems],uq',(cid,a)))
+cluster dot = do
+  uq <- getM dgsId  
+  let cid = NodeId $ "cluster_" ++ show uq
+  let clusterState = DotGenState { _dgsId = succ uq, _dgsElements = [] }
+  let (a, finalState) = runDot clusterState dot
+  setM dgsId (get dgsId finalState)
+  addElements [SubGraph (Just cid) (get dgsElements finalState)]
+  return (cid, a)
+
 
 -- | 'attribute' gives a attribute to the current scope.
 attribute :: (String,String) -> Dot ()
-attribute (name,val) = Dot (\ uq -> ( [  GraphAttribute name val ],uq,()))
+attribute (name,val) = addElements [  GraphAttribute name val ]
 
 -- | 'nodeAttributes' sets attributes for all the following nodes in the scope.
 nodeAttributes :: [(String,String)] -> Dot ()
-nodeAttributes attrs = Dot (\uq -> ([ GraphNode (NodeId "node") attrs],uq,()))
+nodeAttributes attrs = addElements [ GraphNode (NodeId "node") attrs]
 
 -- | 'edgeAttributes' sets attributes for all the following edges in the scope.
 edgeAttributes :: [(String,String)] -> Dot ()
-edgeAttributes attrs = Dot (\uq -> ([ GraphNode (NodeId "edge") attrs],uq,()))
+edgeAttributes attrs = addElements [ GraphNode (NodeId "edge") attrs]
 
 -- | 'graphAttributes' sets attributes for current graph.
 graphAttributes :: [(String,String)] -> Dot ()
-graphAttributes attrs = Dot (\uq -> ([ GraphNode (NodeId "graph") attrs],uq,()))
-
+graphAttributes attrs = addElements [ GraphNode (NodeId "graph") attrs]
 
 -- 'showDot' renders a dot graph as a 'String'.
 showDot :: Dot a -> String
-showDot (Dot dm) = case dm 0 of
-                    (elems,_,_) -> "digraph G {\n" ++ unlines (map showGraphElement elems) ++ "\n}\n"
+showDot dot = 
+  let initialState = DotGenState { _dgsId = 0, _dgsElements = [] } 
+      (_, finalState) = runDot initialState dot
+      elems = get dgsElements finalState
+  in 
+    "digraph G {\n" ++ unlines (map showGraphElement elems) ++ "\n}\n"
+
+-- | Render a record in the Dot monad. It exploits the internal counter in
+-- order to generate unique port-ids. However, they must be combined with the
+-- actual node id of the node with the record shape. Thus the returned
+-- association list is parametrized over this missing node id.
+renderRecord :: Record a -> Dot (String, NodeId -> [(a,NodeId)])
+renderRecord = render True
+  where
+  render _ (Field Nothing l) = return (escape l, const [])
+  render _ (Field (Just p) l) = do
+    uq <- nextId
+    let pid = "n" ++ show uq
+    let lbl = "<"++pid++"> "++escape l
+    return (lbl, \nId -> [(p,NodeId (show nId++":"++pid))])
+  render horiz (HCat rs) = do
+    (lbls, ids) <- liftM unzip $ mapM (render True) rs
+    let rawLbl = concat (intersperse "|" lbls)
+        lbl = if horiz then "{{"++rawLbl++"}}" else "{"++rawLbl++"}"
+    return (lbl, \nId -> concatMap (\i -> i nId) ids)
+  render horiz (VCat rs) = do
+    (lbls, ids) <- liftM unzip $ mapM (render False) rs
+    let rawLbl = concat (intersperse "|" lbls)
+        lbl = if horiz then "{"++rawLbl++"}" else "{{"++rawLbl++"}}"
+    return (lbl, \nId -> concatMap (\i -> i nId) ids)
+  -- escape chars used for record label construction
+  escape = concatMap esc
+  esc '|'  = "\\|"
+  esc '{'  = "\\{"
+  esc '}'  = "\\}"
+  esc '<'  = "\\<"
+  esc '>'  = "\\>"
+  esc c    = [c]
+
+
+-- | A generic version of record creation.
+genRecord :: String -> Record a -> [(String,String)] -> Dot (NodeId, [(a,NodeId)])
+genRecord shape rec attrs = do
+  (lbl, ids) <- renderRecord rec
+  i <- rawNode ([("shape",shape),("label",lbl)] ++ attrs)
+  return (i, ids i)
+
+-- | Create a record node with the given attributes. It returns the node-id of
+-- the created node together with an association list mapping the port
+-- idenfiers given in the record to their corresponding node-ids. This list is
+-- ordered according to a left-to-rigth traversal of the record description.
+record :: Record a -> [(String,String)] -> Dot (NodeId, [(a,NodeId)])
+record = genRecord "record"
+
+-- | A variant of "record" ignoring the port identifiers.
+record' :: Record a -> [(String,String)] -> Dot (NodeId, [NodeId])
+record' rec attrs = do (nId, ids) <- record rec attrs
+                       return (nId, map snd ids)
+
+-- | A variant of "record" ignoring the port to node-id association list.
+record_ :: Record a -> [(String,String)] -> Dot NodeId
+record_ rec attrs = liftM fst $ record rec attrs
+
+-- | Like "record", but creates record nodes with rounded corners; i.e. uses
+-- the \"Mrecord\" shape instead of the \"record\" shape.
+mrecord :: Record a -> [(String,String)] -> Dot (NodeId, [(a,NodeId)])
+mrecord = genRecord "Mrecord"
+
+-- | A variant of "mrecord" ignoring the port identifiers.
+mrecord' :: Record a -> [(String,String)] -> Dot (NodeId, [NodeId])
+mrecord' rec attrs = do (nId, ids) <- mrecord rec attrs
+                        return (nId, map snd ids)
+
+-- | A variant of "mrecord" ignoring the port to node-id association list.
+mrecord_ :: Record a -> [(String,String)] -> Dot NodeId
+mrecord_ rec attrs = liftM fst $ mrecord rec attrs
+  
+
+-- | 'userNodeId' allows a user to use their own (Int-based) node id's, without needing to remap them.
+userNodeId :: Int -> NodeId
+userNodeId i = UserNodeId i
+
 
 showGraphElement :: GraphElement -> String
 showGraphElement (GraphAttribute name val) = showAttr (name,val) ++ ";"
 showGraphElement (GraphNode nid attrs)           = show nid ++ showAttrs attrs ++ ";"
 showGraphElement (GraphEdge from to attrs) = show from ++ " -> " ++ show to ++  showAttrs attrs ++ ";"
 showGraphElement (Scope elems) = "{\n" ++ unlines (map showGraphElement elems) ++ "\n}"
-showGraphElement (SubGraph nid elems) = "subgraph " ++ show nid ++ " {\n" ++ unlines (map showGraphElement elems) ++ "\n}"
+showGraphElement (SubGraph Nothing elems) = "{\n" ++ unlines (map showGraphElement elems) ++ "\n}"
+showGraphElement (SubGraph (Just nid) elems) = "subgraph " ++ show nid ++ " {\n" ++ unlines (map showGraphElement elems) ++ "\n}"
 
 showAttrs :: [(String, String)] -> String
 showAttrs [] = ""
@@ -177,8 +277,9 @@ showAttrs xs = "[" ++ showAttrs' xs ++ "]"
         showAttrs' []     = error "showAttrs: the impossible happended"
 
 showAttr :: (String, String) -> String
-showAttr (name, val) =
-      name ++ "=\"" ++ concatMap escape val ++ "\""
+showAttr (name, val) 
+  | name == "raw_label" = "label=" ++ val
+  | otherwise = name ++ "=\"" ++ concatMap escape val ++ "\""
     where
       escape '\n' = "\\l"
       escape '"'  = "\\\""
@@ -238,73 +339,3 @@ vcat = VCat
 -- | Concatenate a list strings interpreted as simple fields vertically.
 vcat' :: [String] -> Record a
 vcat' = vcat . map field
-
--- | Render a record in the Dot monad. It exploits the internal counter in
--- order to generate unique port-ids. However, they must be combined with the
--- actual node id of the node with the record shape. Thus the returned
--- association list is parametrized over this missing node id.
-renderRecord :: Record a -> Dot (String, NodeId -> [(a,NodeId)])
-renderRecord = render True
-  where
-  render _ (Field Nothing l) = return (escape l, const [])
-  render _ (Field (Just p) l) =
-    Dot $ \uq -> let pid = "n" ++ show uq
-                     lbl = "<"++pid++"> "++escape l
-                 in  ([], succ uq, (lbl, \nId -> [(p,NodeId (show nId++":"++pid))]))
-  render horiz (HCat rs) = do
-    (lbls, ids) <- liftM unzip $ mapM (render True) rs
-    let rawLbl = concat (intersperse "|" lbls)
-        lbl = if horiz then "{{"++rawLbl++"}}" else "{"++rawLbl++"}"
-    return (lbl, \nId -> concatMap (\i -> i nId) ids)
-  render horiz (VCat rs) = do
-    (lbls, ids) <- liftM unzip $ mapM (render False) rs
-    let rawLbl = concat (intersperse "|" lbls)
-        lbl = if horiz then "{"++rawLbl++"}" else "{{"++rawLbl++"}}"
-    return (lbl, \nId -> concatMap (\i -> i nId) ids)
-  -- escape chars used for record label construction
-  escape = concatMap esc
-  esc '|'  = "\\|"
-  esc '{'  = "\\{"
-  esc '}'  = "\\}"
-  esc '<'  = "\\<"
-  esc '>'  = "\\>"
-  esc c    = [c]
-
-
--- | A generic version of record creation.
-genRecord :: String -> Record a -> [(String,String)] -> Dot (NodeId, [(a,NodeId)])
-genRecord shape rec attrs = do
-  (lbl, ids) <- renderRecord rec
-  i <- rawNode ([("shape",shape),("label",lbl)] ++ attrs)
-  return (i, ids i)
-
--- | Create a record node with the given attributes. It returns the node-id of
--- the created node together with an association list mapping the port
--- idenfiers given in the record to their corresponding node-ids. This list is
--- ordered according to a left-to-rigth traversal of the record description.
-record :: Record a -> [(String,String)] -> Dot (NodeId, [(a,NodeId)])
-record = genRecord "record"
-
--- | A variant of "record" ignoring the port identifiers.
-record' :: Record a -> [(String,String)] -> Dot (NodeId, [NodeId])
-record' rec attrs = do (nId, ids) <- record rec attrs
-                       return (nId, map snd ids)
-
--- | A variant of "record" ignoring the port to node-id association list.
-record_ :: Record a -> [(String,String)] -> Dot NodeId
-record_ rec attrs = liftM fst $ record rec attrs
-
--- | Like "record", but creates record nodes with rounded corners; i.e. uses
--- the \"Mrecord\" shape instead of the \"record\" shape.
-mrecord :: Record a -> [(String,String)] -> Dot (NodeId, [(a,NodeId)])
-mrecord = genRecord "Mrecord"
-
--- | A variant of "mrecord" ignoring the port identifiers.
-mrecord' :: Record a -> [(String,String)] -> Dot (NodeId, [NodeId])
-mrecord' rec attrs = do (nId, ids) <- mrecord rec attrs
-                        return (nId, map snd ids)
-
--- | A variant of "mrecord" ignoring the port to node-id association list.
-mrecord_ :: Record a -> [(String,String)] -> Dot NodeId
-mrecord_ rec attrs = liftM fst $ mrecord rec attrs
-

--- a/lib/utils/tamarin-prover-utils.cabal
+++ b/lib/utils/tamarin-prover-utils.cabal
@@ -55,6 +55,8 @@ library
       , time
       , transformers
       , exceptions
+      , graphviz
+      , text
 
     hs-source-dirs: src
 

--- a/manual/src/003_example.md
+++ b/manual/src/003_example.md
@@ -475,6 +475,15 @@ Finally, in intermediate proof steps, there can also be dotted green arrows, whi
 
 Note that by default Tamarin does not show all rules and arrows to simplify the graphs, but this can be adjusted using the Options button on the top right of the page.
 
+Another option is whether to render abbreviations in the graph as shown in the picture below.
+When abbreviations are enabled Tamarin will construct abbreviations for terms, list them in a legend at the bottom of the image and replace the original terms in the graph.
+A maximum on 10 abbreviations are generated and terms are prioritized based on their length and how often they appear in the graph.
+Note that abbreviations can appear in other abbreviations, as for example "PK1" appears in the expanded term of "AE1" below.
+The legend is sorted so that it can be read top to bottom.
+
+![FirstExample Lemma 1 Abbreviations](../images/tamarin-tutorial-lemma-1-abbrev.png 
+ "FirstExample Lemma 1 Abbreviations"){width=100%}\
+
 Running Tamarin on the Command Line
 -----------------------------------
 

--- a/src/Main/Environment.hs
+++ b/src/Main/Environment.hs
@@ -19,6 +19,7 @@ import System.IO
 import System.Process
 
 import Main.Console
+import Web.Types (OutputCommand(..), OutputFormat(..))
 
 ------------------------------------------------------------------------------
 -- Retrieving the paths to required tools.
@@ -37,11 +38,11 @@ dotPath :: Arguments -> FilePath
 dotPath = fromMaybe "dot" . findArg "withDot"
 
 -- | Path to dot or json tool
-graphPath :: Arguments -> (String, FilePath)
-graphPath as =
+readOutputCommand :: Arguments -> OutputCommand
+readOutputCommand as =
   if argExists "withJson" as
-     then ("json", (fromMaybe "json" . findArg "withJson") as)
-     else ("dot", (fromMaybe "dot" . findArg "withDot") as)
+     then OutputCommand OutJSON $ (fromMaybe "json" . findArg "withJson") as
+     else OutputCommand OutDot $ (fromMaybe "dot" . findArg "withDot") as
 
 
 ------------------------------------------------------------------------------
@@ -105,7 +106,7 @@ ensureGraphCommand as = do
   hPutStrLn stderr $ "Graph rendering command: " ++ cmd
   testProcess check errMsg "Checking availablity ..." "which" [cmd] "" False False
   where
-    cmd = snd $ graphPath as
+    cmd = ocGraphCommand $ readOutputCommand as
     check _ err
       | err == ""  = Right " OK."
       | otherwise  = Left  errMsg

--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -24,6 +24,7 @@ import Network.Wai.Handler.Warp (defaultSettings, setHost, setPort)
 import Network.Wai.Handler.Warp qualified as Warp
 import Web.Dispatch
 import Web.Settings qualified
+import Web.Types (OutputCommand(..), OutputFormat(..))
 
 import Main.Console
 import Main.Environment
@@ -85,10 +86,9 @@ run thisMode as = case findArg "workDir" as of
       version <- ensureMaudeAndGetVersion as
 
       -- process theories
-      _ <- case fst (graphPath as) of
-          "dot"  -> ensureGraphVizDot as
-          "json" -> ensureGraphCommand as
-          _      -> pure (Just "")
+      _ <- case (ocFormat $ readOutputCommand as) of
+          OutDot  -> ensureGraphVizDot as
+          OutJSON -> ensureGraphCommand as
 
       port <- readPort
       let webUrl = serverUrl port
@@ -110,7 +110,7 @@ run thisMode as = case findArg "workDir" as of
         (loadTheory thyLoadOptions)
         (closeTheory version thyLoadOptions)
 
-        (argExists "debug" as) (graphPath as) readImageFormat
+        (argExists "debug" as) (readOutputCommand as) readImageFormat
         (constructAutoProver thyLoadOptions)
         (runWarp port)
 

--- a/src/Web/Dispatch.hs
+++ b/src/Web/Dispatch.hs
@@ -93,14 +93,14 @@ withWebUI :: String                          -- ^ Message to output once the sev
           -> (SignatureWithMaude -> Either OpenTheory OpenDiffTheory -> ExceptT TheoryLoadError IO (WfErrorReport, Either ClosedTheory ClosedDiffTheory))
           -- ^ Theory closer.
           -> Bool                            -- ^ Show debugging messages?
-          -> (String, FilePath)              -- ^ Path to graph rendering binary (dot or json)
+          -> OutputCommand                   -- ^ Path to graph rendering binary (dot or json)
                                              -- ^ together with indication of choice "dot", "json", ...
           -> ImageFormat                     -- ^ The preferred image format
           -> AutoProver                      -- ^ The default autoprover.
           -> (Application -> IO b)           -- ^ Function to execute
           -> IO b
 withWebUI readyMsg cacheDir_ thDir loadState autosave thOpts thLoad thClose debug'
-          graphCmd' imgFormat' defaultAutoProver' f
+          outputCmd' imgFormat' defaultAutoProver' f
   = do
     thy    <- getTheos
     thrVar <- newMVar M.empty
@@ -121,7 +121,7 @@ withWebUI readyMsg cacheDir_ thDir loadState autosave thOpts thLoad thClose debu
         , theoryVar          = thyVar
         , threadVar          = thrVar
         , autosaveProofstate = autosave
-        , graphCmd           = graphCmd'
+        , outputCmd           = outputCmd'
         , imageFormat        = imgFormat'
         , defaultAutoProver  = defaultAutoProver'
         , debug              = debug'

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -897,6 +897,7 @@ getTheoryPathDR idx path = withTheory idx $ \ti -> ajaxLayout $ do
   -}
 -}
 
+-- | Read the render options from a request to render a sequent.
 getOptions :: Handler (GraphOptions, DotOptions)
 getOptions = do
   compact <- isNothing <$> lookupGetParam "uncompact"

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -76,7 +76,6 @@ import           System.Process
 
 import           Logic.Connectives
 import           Theory
-import           Theory.Constraint.System (nonEmptyGraph,nonEmptyGraphDiff)
 import           Theory.Text.Pretty
 import           TheoryObject
 
@@ -185,9 +184,11 @@ refDotDiffPath renderUrl tidx path mirror = closedTag "img" [("class", "graph"),
           then T.unpack $ renderUrl (TheoryMirrorDiffR tidx path)
           else T.unpack $ renderUrl (TheoryGraphDiffR tidx path)
 
+-- | Generate the dot file path for an intermediate dot output.
 getDotPath :: String -> FilePath
 getDotPath code = imageDir </> addExtension (stringSHA256 code) "dot"
 
+-- | Generate the image file path for the final output.
 getGraphPath :: OutputFormat -> String -> FilePath
 getGraphPath ext code = imageDir </> addExtension (stringSHA256 code) (show ext)
 
@@ -1267,6 +1268,7 @@ htmlThyDbgPath thy path = go path
 -}
 
 -- | Output either JSON or an image corresponding to the given theory path and return the generated file's path.
+-- Returns Nothing if there was an error during the image generation.
 imgThyPath :: ImageFormat                  -- ^ The preferred image output format. 
            -> OutputCommand                -- ^ Choice and command for rendering.
            -> FilePath                     -- ^ Tamarin's cache directory
@@ -1289,6 +1291,7 @@ imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath =
     thyPathSystem (TheoryProof lemma proofPath) = proofPathSystem lemma proofPath
     thyPathSystem _                             = error "Unhandled theory path. This is a bug."
 
+    -- | Get a string serialization for one case.
     casesSystem k i j = do
       let jsonLabel = "Theory: " ++ (get thyName thy) ++ " Case: " ++ show i ++ ":" ++ show j
           cases = map (getDisj . get cdCases) (getSource k thy)
@@ -1380,6 +1383,7 @@ imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath =
 
 
 -- | Render the image corresponding to the given theory path.
+-- Returns Nothing if there was an error during image generation.
 imgDiffThyPath :: ImageFormat
            -> FilePath               -- ^ 'dot' command
            -> FilePath               -- ^ Tamarin's cache directory

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -76,7 +76,7 @@ import           System.Process
 
 import           Logic.Connectives
 import           Theory
-import           Theory.Constraint.System.Dot (nonEmptyGraph,nonEmptyGraphDiff)
+import           Theory.Constraint.System (nonEmptyGraph,nonEmptyGraphDiff)
 import           Theory.Text.Pretty
 import           TheoryObject
 

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -188,8 +188,8 @@ refDotDiffPath renderUrl tidx path mirror = closedTag "img" [("class", "graph"),
 getDotPath :: String -> FilePath
 getDotPath code = imageDir </> addExtension (stringSHA256 code) "dot"
 
-getGraphPath :: String -> String -> FilePath
-getGraphPath ext code = imageDir </> addExtension (stringSHA256 code) ext
+getGraphPath :: OutputFormat -> String -> FilePath
+getGraphPath ext code = imageDir </> addExtension (stringSHA256 code) (show ext)
 
 -- | Create a link to a given theory path.
 linkToPath :: HtmlDocument d
@@ -1266,71 +1266,55 @@ htmlThyDbgPath thy path = go path
     go _ = Nothing
 -}
 
--- | Render the image corresponding to the given theory path.
-imgThyPath :: ImageFormat
-           -> (String, FilePath)     -- ^ choice and command for rendering (dot or json)
-           -> FilePath               -- ^ Tamarin's cache directory
-           -> (System -> D.Dot ())
-           -> (String -> System -> String)
-                                     -- ^ to export contraint system to JSON
-           -> String                 -- ^ Simplification level of graph (string representation of integer >= 0)
-           -> Bool                   -- ^ True iff we want abbreviations
-           -> ClosedTheory
-           -> TheoryPath
-           -> IO FilePath
-imgThyPath imgFormat (graphChoice, graphCommand) cacheDir_ compact showJsonGraphFunct simplificationLevel abbreviate thy path = go path
+-- | Output either JSON or an image corresponding to the given theory path and return the generated file's path.
+imgThyPath :: ImageFormat                  -- ^ The preferred image output format. 
+           -> OutputCommand                -- ^ Choice and command for rendering.
+           -> FilePath                     -- ^ Tamarin's cache directory
+           -> (System -> D.Dot ())         -- ^ Function to render a System to Graphviz dot format.
+           -> (String -> System -> String) -- ^ Function to render a System to JSON.
+           -> ClosedTheory                 -- ^ Theory from which to extract the 'System'.
+           -> TheoryPath                   -- ^ Path of the 'System' in the theory.
+           -> IO (Maybe FilePath)          -- ^ Path to the generated file.
+imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath = 
+    case thyPathSystem thyPath of
+      Nothing -> return Nothing
+      Just (jsonLabel, system) -> do
+        let code = case ocFormat outputCommand of
+                     OutDot -> prefixedShowDot $ toDot system
+                     OutJSON -> toJSON jsonLabel system 
+        renderGraphCode code
   where
-    go (TheorySource k i j)   = case graphChoice of
-                                  "json"  -> renderGraphCode "json" (casesJsonCode k i j)
-                                  _       -> renderGraphCode "dot" (casesDotCode k i j)
-    go (TheoryProof l p)      = case graphChoice of
-                                  "json"  -> renderGraphCode "json" (proofPathJsonCode l p)
-                                  _       -> renderGraphCode "dot" (proofPathDotCode l p)
-    go _                      = error "Unhandled theory path. This is a bug."
+    thyPathSystem :: TheoryPath -> Maybe (String, System)
+    thyPathSystem (TheorySource k i j)          = casesSystem k i j
+    thyPathSystem (TheoryProof lemma proofPath) = proofPathSystem lemma proofPath
+    thyPathSystem _                             = error "Unhandled theory path. This is a bug."
 
-    -- Prefix dot code with comment mentioning all protocol rule names
+    casesSystem k i j = do
+      let jsonLabel = "Theory: " ++ (get thyName thy) ++ " Case: " ++ show i ++ ":" ++ show j
+          cases = map (getDisj . get cdCases) (getSource k thy)
+      return (jsonLabel, snd $ cases !! (i-1) !! (j-1))
+
+    -- | Get string serialization for proof path in lemma.
+    proofPathSystem lemma proofPath = do
+      let jsonLabel = "Theory: " ++ (get thyName thy) ++ " Lemma: " ++ lemma 
+      subProof <- resolveProofPath thy lemma proofPath
+      sequent <- psInfo $ root subProof
+      return (jsonLabel, sequent)
+
+    -- | Prefix dot code with comment mentioning all protocol rule names
     prefixedShowDot dot = unlines
-        [ "// simplification: "          ++ simplificationLevel
-        , "// protocol rules: "          ++ ruleList (getProtoRuleEs thy)
+        [ "// protocol rules: "          ++ ruleList (getProtoRuleEs thy)
         , "// message deduction rules: " ++ ruleList (getIntrVariants thy)
-        , "// abbreviate: "              ++ show abbreviate
         , D.showDot dot
         ]
       where
         ruleList :: HasRuleName (Rule i) => [Rule i] -> String
         ruleList = concat . intersperse ", " . nub . map showRuleCaseName
 
-    -- Get dot code for required cases
-    casesDotCode k i j = prefixedShowDot $
-        compact $ snd $ cases !! (i-1) !! (j-1)
-      where
-        cases = map (getDisj . get cdCases) (getSource k thy)
-
-   -- Get JSON code for required cases
-    casesJsonCode k i j =
-        showJsonGraphFunct ("Theory: " ++ (get thyName thy) ++ " Case: " ++ show i ++ ":" ++ show j)
-        $ snd $ cases !! (i-1) !! (j-1)
-      where
-        cases = map (getDisj . get cdCases) (getSource k thy)
-
-    -- Get dot code for proof path in lemma
-    proofPathDotCode lemma proofPath =
-      prefixedShowDot $ fromMaybe (return ()) $ do
-        subProof <- resolveProofPath thy lemma proofPath
-        sequent <- psInfo $ root subProof
-        return $ compact sequent
-
-   -- Get JSON for proof path in lemma
-    proofPathJsonCode lemma proofPath =
-      fromMaybe ("") $ do
-        subProof <- resolveProofPath thy lemma proofPath
-        sequent <- psInfo $ root subProof
-        return $ showJsonGraphFunct ("Theory: " ++ (get thyName thy) ++ " Lemma: " ++ lemma) sequent
-
     -- Render a piece of dot or JSON code
-    renderGraphCode choice code = do
-      let graphPath = cacheDir_ </> getGraphPath choice code
-          imgPath = addExtension graphPath (show imgFormat)
+    renderGraphCode code = do
+      let graphPath = cacheDir_ </> getGraphPath (ocFormat outputCommand) code
+          imgPath = addExtension graphPath $ show imageFormat
 
           -- A busy wait loop with a maximal number of iterations
           renderedOrRendering :: Int -> IO Bool
@@ -1354,38 +1338,38 @@ imgThyPath imgFormat (graphChoice, graphCommand) cacheDir_ compact showJsonGraph
             -- create dot-file and render to image
           , do writeFile graphPath code
                -- select the correct command to generate img
-               if (choice == "json")
-                   then jsonToImg graphPath imgPath
-                   else dotToImg "dot" graphPath imgPath
+               case ocFormat outputCommand of
+                 OutDot  -> dotToImg "dot" graphPath imgPath
+                 OutJSON -> jsonToImg graphPath imgPath
             -- sometimes 'dot' fails => use 'fdp' as a backup tool
-          , if (choice == "dot")
-                then dotToImg "fdp" graphPath imgPath
-                else return False
+          , case ocFormat outputCommand of
+              OutDot -> dotToImg "fdp" graphPath imgPath
+              _      -> return False
           ]
       if imgGenerated
-        then return imgPath
+        then return $ Just imgPath
         else trace ("WARNING: failed to convert:\n  '" ++ graphPath ++ "'")
-                   (return imgPath)
+                   (return Nothing)
 
     -- render img file from json file
     jsonToImg jsonFile imgFile = do
-      (ecode,_out,err) <- readProcessWithExitCode graphCommand [imgFile, jsonFile] ""
+      (ecode,_out,err) <- readProcessWithExitCode (ocGraphCommand outputCommand) [imgFile, jsonFile] ""
       case ecode of
         ExitSuccess   -> return True
         ExitFailure i -> do
-          putStrLn $ "jsonToImg: "++graphCommand++" failed with code "
+          putStrLn $ "jsonToImg: "++ ocGraphCommand outputCommand ++" failed with code "
                       ++show i++" for file "++jsonFile++":\n"++err
           return False
 
     -- render img file from dot file
     dotToImg dotMode dotFile imgFile = do
-      (ecode,_out,err) <- readProcessWithExitCode graphCommand
-                              [ "-T"++show imgFormat, "-K"++dotMode, "-o",imgFile, dotFile]
+      (ecode,_out,err) <- readProcessWithExitCode (ocGraphCommand outputCommand)
+                              [ "-T"++show imageFormat, "-K"++dotMode, "-o",imgFile, dotFile]
                               ""
       case ecode of
         ExitSuccess   -> return True
         ExitFailure i -> do
-          putStrLn $ "dotToImg: "++graphCommand++" failed with code "
+          putStrLn $ "dotToImg: "++ ocGraphCommand outputCommand ++" failed with code "
                       ++show i++" for file "++dotFile++":\n"++err
           return False
 
@@ -1400,13 +1384,11 @@ imgDiffThyPath :: ImageFormat
            -> FilePath               -- ^ 'dot' command
            -> FilePath               -- ^ Tamarin's cache directory
            -> (System -> D.Dot ())
-           -> String                 -- ^ Simplification level of graph (string representation of integer >= 0)
-           -> Bool                   -- ^ True iff we want abbreviations
            -> ClosedDiffTheory
            -> DiffTheoryPath
            -> Bool
-           -> IO FilePath            -- ^ True if we want the mirror graph
-imgDiffThyPath imgFormat dotCommand cacheDir_ compact simplificationLevel abbreviate thy path mirror = go path
+           -> IO (Maybe FilePath)            -- ^ True if we want the mirror graph
+imgDiffThyPath imgFormat dotCommand cacheDir_ compact thy path mirror = go path
   where
     go (DiffTheorySource s k d i j) = renderDotCode (casesDotCode s k i j d)
     go (DiffTheoryProof s l p)      = renderDotCode (proofPathDotCode s l p)
@@ -1415,12 +1397,10 @@ imgDiffThyPath imgFormat dotCommand cacheDir_ compact simplificationLevel abbrev
 
     -- Prefix dot code with comment mentioning all protocol rule names
     prefixedShowDot dot = unlines
-        [ "// simplification: "          ++ simplificationLevel
-        , "// protocol rules: "          ++ ruleList (getProtoRuleEsDiff LHS thy) -- FIXME RS: the rule names are the same on LHS and RHS, so we just pick LHS; should pass the current Side through to make this clean
+        [ "// protocol rules: "          ++ ruleList (getProtoRuleEsDiff LHS thy) -- FIXME RS: the rule names are the same on LHS and RHS, so we just pick LHS; should pass the current Side through to make this clean
         , "// message deduction rules: " ++ ruleList (getIntrVariantsDiff LHS thy) -- FIXME RS: the intruder rule names are the same on LHS and RHS; should pass the current Side through to make this clean
 --        , "// message deduction rules: " ++ ruleList ((intruderRules . get (_crcRules . diffThyCacheLeft)) thy) -- FIXME RS: again, we arbitrarily pick the LHS version of the cache, should be the same on both sides
 --intruderRules . L.get (crcRules . diffThyCacheLeft)
-        , "// abbreviate: "              ++ show abbreviate
         , D.showDot dot
         ]
       where
@@ -1490,9 +1470,9 @@ imgDiffThyPath imgFormat dotCommand cacheDir_ compact simplificationLevel abbrev
           , dotToImg "fdp" dotPath imgPath
           ]
       if imgGenerated
-        then return imgPath
+        then return $ Just imgPath
         else trace ("WARNING: failed to convert:\n  '" ++ dotPath ++ "'")
-                   (return imgPath)
+                   (return Nothing)
 
     dotToImg dotMode dotFile imgFile = do
       (ecode,_out,err) <- readProcessWithExitCode dotCommand

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -50,6 +50,8 @@ module Web.Types
   -- Image rendering
   , ImageFormat(..)
   , imageFormatMIME
+  , OutputFormat(..)
+  , OutputCommand(..)
   )
 where
 
@@ -104,9 +106,22 @@ type ThreadMap = M.Map T.Text ThreadId
 -- | The image format used for rendering graphs.
 data ImageFormat = PNG | SVG
 
+-- | The output format for serializing a graph.
+data OutputFormat = OutJSON | OutDot 
+
+-- | Describes how a constraint system should be converted to an image. 
+data OutputCommand = OutputCommand 
+  { ocFormat       :: OutputFormat 
+  , ocGraphCommand :: FilePath 
+  }
+
 instance Show ImageFormat where
     show PNG = "png"
     show SVG = "svg"
+
+instance Show OutputFormat where
+    show OutJSON = "json"
+    show OutDot  = "dot"
 
 -- | convert image format to MIME type.
 imageFormatMIME :: ImageFormat -> String
@@ -135,7 +150,7 @@ data WebUI = WebUI
     -- ^ MVar that holds the thread map
   , autosaveProofstate :: Bool
     -- ^ Automatically store theory map
-  , graphCmd           :: (String, FilePath)
+  , outputCmd           :: OutputCommand
     -- ^ The dot or json command with additional flag to indicate choice dot, json, ...
   , imageFormat        :: ImageFormat
     -- ^ The image-format used for rendering graphs


### PR DESCRIPTION
Previously, the serialization of a constraint system to dot and JSON used a `System` object directly, with slightly different definitions about what is included in the graph. We introduce an abstract graph on top of a system which defines the types of nodes and edges that will be serialized.

Graph simplification steps that were previously done separately for dot & JSON are now done on the abstract graph directly. We also implement the generation of abbreviations for term inspired by the cleandot python script. Abbreviations can be toggled via the GUI. 

Clusters like from cleandot.py are not supported yet. I added a section in the manual at the end of the first example about the GUI shortly explaining the abbreviations.