### PR TITLE
Mention that one must run make before running regression tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ Regression testing for pull requests
 Before submitting a pull request, please double check that your changes do not break any of the existing proofs by running the regression test suite. To do this run the following commands in your clone of tamarin-prover:
 
 ```
+make
 rm -rf case-studies
 python3 regressionTests.py
 ```

--- a/doc/READMEregressionTests.md
+++ b/doc/READMEregressionTests.md
@@ -18,6 +18,7 @@ and type:
 $ python3 regressionTests.py
 ```
 
+Note that one must run `make` before running regression tests.
 
 
 ## What does the script do?


### PR DESCRIPTION
As a consequence of #640. I find a bit surprising that one must do this because there is a line mentioning that the regression test should run `stack install`, which should put the right Tamarin version in `~/.local/bin`, but this is only a minor conflict.

https://github.com/tamarin-prover/tamarin-prover/blob/07e312662c82688fa717a10b04833aad1243038e/doc/READMEregressionTests.md?plain=1#L25