### PR TITLE
Implement outputting traces in batch mode.

### DIFF
--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -61,7 +61,7 @@ data DotOptions = DotOptions
 
 -- | The default dot options.
 defaultDotOptions :: DotOptions
-defaultDotOptions = DotOptions FullBoringNodes black
+defaultDotOptions = DotOptions CompactBoringNodes black
   where
     black = D.RGB 0 0 0
 

--- a/lib/theory/src/Theory/Constraint/System/Graph/Graph.hs
+++ b/lib/theory/src/Theory/Constraint/System/Graph/Graph.hs
@@ -68,8 +68,9 @@ defaultGraphOptions = GraphOptions
   { _goSimplificationLevel = SL2
   , _goShowAutoSource = False
   , _goClustering = False
-  , _goAbbreviate = False
-  , _goCompress = False }
+  , _goAbbreviate = True
+  , _goCompress = True 
+  }
 
 -- | An abstract graph to derive visualiations of a 'System'.
 data Graph = Graph 

--- a/lib/utils/src/Text/Dot.hs
+++ b/lib/utils/src/Text/Dot.hs
@@ -189,14 +189,21 @@ edgeAttributes attrs = addElements [ GraphNode (NodeId "edge") attrs]
 graphAttributes :: [(String,String)] -> Dot ()
 graphAttributes attrs = addElements [ GraphNode (NodeId "graph") attrs]
 
--- 'showDot' renders a dot graph as a 'String'.
-showDot :: Dot a -> String
-showDot dot = 
-  let initialState = DotGenState { _dgsId = 0, _dgsElements = [] } 
+-- 'showDot' renders a dot graph as a 'String' with the supplied label as the digraph id.
+showDot :: String -> Dot a -> String
+showDot label dot =
+      -- We must escape all double quote characters in the graphviz label by using a backslash. 
+      -- In the comparison we just use '"' because it is a single character.
+      -- Then for the replacement we must use three \, the first two insert a literal backslash into the string, 
+      -- the third one is used to insert a literal double quote into the string. 
+  let escapedLabel = concatMap (\c -> if c == '"' then "\\\"" else [c]) label
+      initialState = DotGenState { _dgsId = 0, _dgsElements = [] } 
       (_, finalState) = runDot initialState dot
       elems = get dgsElements finalState
   in 
-    "digraph G {\n" ++ unlines (map showGraphElement elems) ++ "\n}\n"
+    "digraph " ++ 
+    "\"" ++ escapedLabel ++ "\"" ++
+    " {\n" ++ unlines (map showGraphElement elems) ++ "\n}\n"
 
 -- | Render a record in the Dot monad. It exploits the internal counter in
 -- order to generate unique port-ids. However, they must be combined with the

--- a/manual/src/011_advanced-features.md
+++ b/manual/src/011_advanced-features.md
@@ -872,3 +872,29 @@ For example, the following example program would result in the debug output belo
 
     === TITLE ======================================================================
     functionA: called functionA
+
+Outputting constraint systems when satisfying traces are found.
+-------------------------------------------------------------------
+
+It can be useful for further analysis to output the constraint system of the 
+state of the proof of a lemma when either a satisfying trace is found in an 
+"exists-trace" lemma, or when a counterexample trace is found in an
+"all-traces" lemma.
+For this you can use the command line options `--output-json` (or `--oj`) and
+`--output-dot` (or `--od`) in the non-interactive mode of tamarin. The command
+line options take a required filename and will output all those constraint
+systems into the file in the respective format.
+
+    tamarin-prover --prove --output-json=traces.json --output-dot=traces.dot examples/Tutorial.spthy
+
+For dot, the file is simply the concatenation of all 'digraph' expressions,
+which can then be rendered into individual image files using the `-O` option
+of the dot command line program.
+
+    # will output images to traces.dot.png, traces.dot.2.png, traces.dot.3.png, ...
+    dot -Tpng -O traces.dot
+
+For JSON, the standard schema already defines a single top-level object with a
+"graphs" key that holds a list of the individual graphs, which we use to output
+the constrain systems.
+

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -929,7 +929,7 @@ getTheoryGraphR idx path = withTheory idx ( \ti -> do
           (outputCmd yesod)
           (cacheDir yesod)
           (dotSystemCompact graphOptions dotOptions)
-          (sequentToJSONPretty graphOptions)
+          (\label system -> sequentsToJSONPretty graphOptions [(label, system)])
           (tiTheory ti) path
       case img' of
         Nothing -> notFound

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -1310,7 +1310,7 @@ imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath =
     prefixedShowDot dot = unlines
         [ "// protocol rules: "          ++ ruleList (getProtoRuleEs thy)
         , "// message deduction rules: " ++ ruleList (getIntrVariants thy)
-        , D.showDot dot
+        , D.showDot "G" dot
         ]
       where
         ruleList :: HasRuleName (Rule i) => [Rule i] -> String
@@ -1407,7 +1407,7 @@ imgDiffThyPath imgFormat dotCommand cacheDir_ compact thy path mirror = go path
         , "// message deduction rules: " ++ ruleList (getIntrVariantsDiff LHS thy) -- FIXME RS: the intruder rule names are the same on LHS and RHS; should pass the current Side through to make this clean
 --        , "// message deduction rules: " ++ ruleList ((intruderRules . get (_crcRules . diffThyCacheLeft)) thy) -- FIXME RS: again, we arbitrarily pick the LHS version of the cache, should be the same on both sides
 --intruderRules . L.get (crcRules . diffThyCacheLeft)
-        , D.showDot dot
+        , D.showDot "G" dot
         ]
       where
         ruleList :: HasRuleName (Rule i) => [Rule i] -> String
@@ -1421,14 +1421,14 @@ imgDiffThyPath imgFormat dotCommand cacheDir_ compact thy path mirror = go path
 
     -- Get dot code for proof path in lemma
     proofPathDotCode s lemma proofPath =
-      D.showDot $ fromMaybe (return ()) $ do
+      D.showDot "G" $ fromMaybe (return ()) $ do
         subProof <- resolveProofPathDiff thy s lemma proofPath
         sequent <- psInfo $ root subProof
         return $ compact sequent
 
     -- Get dot code for proof path in lemma
     proofPathDotCodeDiff lemma proofPath mir =
-      D.showDot $ fromMaybe (return ()) $ do
+      D.showDot "G" $ fromMaybe (return ()) $ do
         subProof <- resolveProofPathDiffLemma thy lemma proofPath
         diffSequent <- dpsInfo $ root subProof
         if mir


### PR DESCRIPTION
In batch mode we add two command line options "--output-json" &
"--output-dot" to output any found traces (either for an exists-trace
lemma, or if an attack is found for an all-traces lemma) to a dot/json
file.
All constraint systems are output into the same file. For dot this means
simply concatenating the graphs. Calling the dot command line tool with
the "-O" option will then generate individual pictures for each
contained graph. For JSON the existing schema already allows for
multiple graphs in one file so we use this.

What is missing is controlling the rendering/graph simplifications
options for the constraint systems. At the moment is always uses the
default options. Should this be configurable?

Below is an example of the output that is generated: the generated JSON and two generated image files, one for a counterexample trace and one for a satisfying trace, although they are not marked explicitly.
![multi dot 2](https://github.com/tamarin-prover/tamarin-prover/assets/25843078/6668a926-419c-4212-84e9-366ffecf3da7)
![multi dot](https://github.com/tamarin-prover/tamarin-prover/assets/25843078/ce48ec73-5b4f-465b-9510-7d8fbd85f7b7)
[multi.json](https://github.com/user-attachments/files/15795353/multi.json)

