### PR TITLE
Interactive prover that stops when oracle returns nothing

### DIFF
--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -194,6 +194,7 @@ var ui = {
             65  : function() { mainDisplay.applyProver('characterization'); },          // A
             98  : function() { mainDisplay.applyProver('bounded-autoprove'); },         // b
             66  : function() { mainDisplay.applyProver('bounded-characterization'); },  // B
+            111 : function() { mainDisplay.applyProver('oracle-autoprove'); },
             115 : function() { mainDisplay.applyProver('autoprove-all'); },             // s
             83  : function() { mainDisplay.applyProver('characterization-all'); },      // S
             74  : function() { proofScript.jump('next/smart', null); },  // j

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -507,9 +507,9 @@ data Tactic a = Tactic{
 -- order of solving in a constraint system.
 data GoalRanking a =
     GoalNrRanking
-  | OracleRanking Oracle
-  | OracleSmartRanking Oracle
-  | InternalTacticRanking (Tactic a)
+  | OracleRanking Bool Oracle
+  | OracleSmartRanking Bool Oracle
+  | InternalTacticRanking Bool (Tactic a)
   | SapicRanking
   | SapicPKCS11Ranking
   | UsefulGoalNrRanking
@@ -558,8 +558,8 @@ maybeSetOracleRelPath :: Maybe FilePath -> Oracle -> Oracle
 maybeSetOracleRelPath p o = o{ oracleRelPath = p }
 
 mapOracleRanking :: (Oracle -> Oracle) -> (GoalRanking ProofContext) -> (GoalRanking ProofContext)
-mapOracleRanking f (OracleRanking o) = OracleRanking (f o)
-mapOracleRanking f (OracleSmartRanking o) = OracleSmartRanking (f o)
+mapOracleRanking f (OracleRanking b o) = OracleRanking b (f o)
+mapOracleRanking f (OracleSmartRanking b o) = OracleSmartRanking b (f o)
 mapOracleRanking _ r = r
 
 oraclePath :: Oracle -> FilePath
@@ -569,7 +569,7 @@ maybeSetInternalTacticName :: Maybe String -> Tactic ProofContext -> Tactic Proo
 maybeSetInternalTacticName s t = maybe t (\x -> t{ _name = x }) s
 
 mapInternalTacticRanking :: (Tactic ProofContext -> Tactic ProofContext) -> GoalRanking ProofContext -> GoalRanking ProofContext
-mapInternalTacticRanking f (InternalTacticRanking t) = InternalTacticRanking (f t)
+mapInternalTacticRanking f (InternalTacticRanking q t) = InternalTacticRanking q (f t)
 mapInternalTacticRanking _ r = r
 
 
@@ -577,15 +577,15 @@ goalRankingIdentifiers :: M.Map String (GoalRanking ProofContext)
 goalRankingIdentifiers = M.fromList
                         [ ("s", SmartRanking False)
                         , ("S", SmartRanking True)
-                        , ("o", OracleRanking defaultOracle)
-                        , ("O", OracleSmartRanking defaultOracle)
+                        , ("o", OracleRanking False defaultOracle)
+                        , ("O", OracleSmartRanking False defaultOracle)
                         , ("p", SapicRanking)
                         , ("P", SapicPKCS11Ranking)
                         , ("c", UsefulGoalNrRanking)
                         , ("C", GoalNrRanking)
                         , ("i", InjRanking False)
                         , ("I", InjRanking True)
-                        , ("{.}", InternalTacticRanking defaultTactic)
+                        , ("{.}", InternalTacticRanking False defaultTactic)
                         ]
 
 goalRankingIdentifiersNoOracle :: M.Map String (GoalRanking ProofContext)
@@ -617,11 +617,11 @@ goalRankingIdentifiersDiff :: M.Map String (GoalRanking ProofContext)
 goalRankingIdentifiersDiff  = M.fromList
                             [ ("s", SmartDiffRanking)
                             , ("S", SmartRanking True)
-                            , ("o", OracleRanking defaultOracle)
-                            , ("O", OracleSmartRanking defaultOracle)
+                            , ("o", OracleRanking False defaultOracle)
+                            , ("O", OracleSmartRanking False defaultOracle)
                             , ("c", UsefulGoalNrRanking)
                             , ("C", GoalNrRanking)
-                            , ("{.}", InternalTacticRanking defaultTactic)
+                            , ("{.}", InternalTacticRanking False defaultTactic)
                             ]
 
 goalRankingIdentifiersDiffNoOracle :: M.Map String (GoalRanking ProofContext)
@@ -669,7 +669,7 @@ listGoalRankingsDiff noOracle = M.foldMapWithKey
 
 
 filterHeuristic :: Bool -> String -> [GoalRanking ProofContext]
-filterHeuristic diff  ('{':t) = if '}' `elem` t then InternalTacticRanking (Tactic (takeWhile (/= '}') t) (SmartRanking False) [] []):(filterHeuristic diff $ tail $ dropWhile (/= '}') t) else error "A call to a tactic is supposed to end by '}' "
+filterHeuristic diff  ('{':t) = if '}' `elem` t then InternalTacticRanking False (Tactic (takeWhile (/= '}') t) (SmartRanking False) [] []):(filterHeuristic diff $ tail $ dropWhile (/= '}') t) else error "A call to a tactic is supposed to end by '}' "
 filterHeuristic False (c:t)   = (stringToGoalRanking False [c]):(filterHeuristic False t)
 filterHeuristic True  (c:t)   = (stringToGoalRankingDiff False [c]):(filterHeuristic True t)
 filterHeuristic   _   ("")    = []
@@ -679,15 +679,15 @@ goalRankingName :: GoalRanking ProofContext -> String
 goalRankingName ranking =
     "Goals sorted according to " ++ case ranking of
         GoalNrRanking                 -> "their order of creation"
-        OracleRanking oracle          -> "an oracle for ranking, located at " ++ printOracle oracle
-        OracleSmartRanking oracle     -> "an oracle for ranking based on 'smart' heuristic, located at " ++ printOracle oracle
+        OracleRanking _ oracle        -> "an oracle for ranking, located at " ++ printOracle oracle
+        OracleSmartRanking _ oracle   -> "an oracle for ranking based on 'smart' heuristic, located at " ++ printOracle oracle
         UsefulGoalNrRanking           -> "their usefulness and order of creation"
         SapicRanking                  -> "heuristics adapted for processes"
         SapicPKCS11Ranking            -> "heuristics adapted to a specific model of PKCS#11 expressed using SAPIC. deprecated."
         SmartRanking useLoopBreakers  -> "the 'smart' heuristic" ++ loopStatus useLoopBreakers
         SmartDiffRanking              -> "the 'smart' heuristic (for diff proofs)"
         InjRanking useLoopBreakers    -> "heuristics adapted to stateful injective protocols" ++ loopStatus useLoopBreakers
-        InternalTacticRanking tactic  -> "the tactic written in the theory file: "++ _name tactic
+        InternalTacticRanking _ tactic -> "the tactic written in the theory file: "++ _name tactic
    where
      loopStatus b = " (loop breakers " ++ (if b then "allowed" else "delayed") ++ ")"
      printOracle o@(Oracle workDir relPath) =
@@ -700,9 +700,9 @@ prettyGoalRankings rs = unwords (map prettyGoalRanking rs)
 
 prettyGoalRanking :: GoalRanking ProofContext -> String
 prettyGoalRanking ranking = case ranking of
-    OracleRanking oracle            -> findIdentifier ranking ++ " \"" ++ fromMaybe "" (oracleRelPath oracle) ++ "\""
-    OracleSmartRanking oracle       -> findIdentifier ranking ++ " \"" ++ fromMaybe "" (oracleRelPath oracle) ++ "\""
-    InternalTacticRanking tactic    -> '{':_name tactic++"}"
+    OracleRanking _ oracle          -> findIdentifier ranking ++ " \"" ++ fromMaybe "" (oracleRelPath oracle) ++ "\""
+    OracleSmartRanking _ oracle     -> findIdentifier ranking ++ " \"" ++ fromMaybe "" (oracleRelPath oracle) ++ "\""
+    InternalTacticRanking _ tactic  -> '{':_name tactic++"}"
     _                         -> findIdentifier ranking
   where
     findIdentifier r = case find (compareRankings r . snd) combinedIdentifiers of
@@ -713,9 +713,9 @@ prettyGoalRanking ranking = case ranking of
     -- this assumes the diff rankings don't use a different character for the same goal ranking.
     combinedIdentifiers = M.toList goalRankingIdentifiers ++ M.toList goalRankingIdentifiersDiff
 
-    compareRankings (OracleRanking _) (OracleRanking _) = True
-    compareRankings (OracleSmartRanking _) (OracleSmartRanking _) = True
-    compareRankings (InternalTacticRanking _ ) (InternalTacticRanking _ ) = True
+    compareRankings (OracleRanking _ _) (OracleRanking _ _) = True
+    compareRankings (OracleSmartRanking _ _) (OracleSmartRanking _ _) = True
+    compareRankings (InternalTacticRanking _ _) (InternalTacticRanking _ _) = True
     compareRankings r1 r2 = r1 == r2
 
 

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -38,6 +38,7 @@ module Theory.Constraint.System (
   , Deprio(..)
   -- , Ranking(..)
   , defaultTactic
+  , usesOracle
   , mapInternalTacticRanking
   , maybeSetInternalTacticName
 
@@ -533,6 +534,14 @@ defaultHeuristic = Heuristic . defaultRankings
 defaultTactic :: Tactic ProofContext
 defaultTactic = Tactic "default" (SmartRanking False) [] []
 
+usesOracle :: Heuristic a -> Bool
+usesOracle (Heuristic rs) = all isOracleRanking rs
+  where
+    isOracleRanking :: GoalRanking a -> Bool
+    isOracleRanking (OracleRanking _ _) = True
+    isOracleRanking (OracleSmartRanking _ _) = True
+    isOracleRanking (InternalTacticRanking _ _) = True
+    isOracleRanking _ = False
 
 -- Default to "./oracle" in the current working directory.
 defaultOracle :: Oracle

--- a/lib/theory/src/Theory/Proof.hs
+++ b/lib/theory/src/Theory/Proof.hs
@@ -752,12 +752,22 @@ data AutoProver = AutoProver
     , apDefaultTactic   :: Maybe [Tactic ProofContext]
     , apBound            :: Maybe Int
     , apCut              :: SolutionExtractor
+    , quitOnEmptyOracle  :: Bool
     }
     deriving ( Generic, NFData, Binary )
 
 selectHeuristic :: AutoProver -> ProofContext -> Heuristic ProofContext
-selectHeuristic prover ctx = fromMaybe (defaultHeuristic False)
+selectHeuristic prover ctx = setQuitOnEmpty $ fromMaybe (defaultHeuristic False)
                              (apDefaultHeuristic prover <|> L.get pcHeuristic ctx)
+  where
+    setQuitOnEmpty :: Heuristic ProofContext -> Heuristic ProofContext
+    setQuitOnEmpty (Heuristic rankings) = Heuristic (map aux rankings)
+
+    aux :: GoalRanking a -> GoalRanking a
+    aux (OracleRanking _ o) = OracleRanking (quitOnEmptyOracle prover) o
+    aux (OracleSmartRanking _ o) = OracleSmartRanking (quitOnEmptyOracle prover) o
+    aux (InternalTacticRanking _ t) = InternalTacticRanking (quitOnEmptyOracle prover) t
+    aux gr = gr
 
 selectDiffHeuristic :: AutoProver -> DiffProofContext -> Heuristic ProofContext
 selectDiffHeuristic prover ctx = fromMaybe (defaultHeuristic True)
@@ -772,7 +782,7 @@ selectDiffTactic prover ctx = fromMaybe [defaultTactic]
                                  (apDefaultTactic prover <|> L.get pcTactic (L.get dpcPCLeft ctx))
 
 runAutoProver :: AutoProver -> Prover
-runAutoProver aut@(AutoProver _ _  bound cut) =
+runAutoProver aut@(AutoProver _ _  bound cut _) =
     mapProverProof cutSolved $ maybe id boundProver bound autoProver
   where
     cutSolved = case cut of
@@ -795,7 +805,7 @@ runAutoProver aut@(AutoProver _ _  bound cut) =
         boundProofDepth b <$> runProver p ctxt d se prf
 
 runAutoDiffProver :: AutoProver -> DiffProver
-runAutoDiffProver aut@(AutoProver _ _ bound cut) =
+runAutoDiffProver aut@(AutoProver _ _ bound cut _) =
     mapDiffProverDiffProof cutSolved $ maybe id boundProver bound autoProver
   where
     cutSolved = case cut of

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -560,6 +560,7 @@ constructAutoProver thyOpts =
                Nothing
                (L.get oProofBound thyOpts)
                (fromMaybe CutDFS $ L.get oStopOnTrace thyOpts)
+               False
 
 -----------------------------------------------
 -- Add Options parameters in an OpenTheory

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -754,11 +754,15 @@ getProverDiffAllR (name, mkProver, mkDiffProver) idx  = do
 getAutoProverR :: TheoryIdx
                -> SolutionExtractor
                -> Int                             -- autoprover bound to use
+               -> Bool                            -- Quit on empty oracle
                -> TheoryPath -> Handler RepJson
-getAutoProverR idx extractor bound =
+getAutoProverR idx extractor bound quitOnEmpty =
     getProverR (fullName, runAutoProver . adapt) idx
   where
-    adapt autoProver = autoProver { apBound = actualBound, apCut = extractor }
+    adapt autoProver = autoProver
+      { apBound = actualBound
+      , apCut = extractor
+      , quitOnEmptyOracle = quitOnEmpty }
 
     withCommas = intersperse ", "
     fullName   = mconcat $ proverName : " (" : withCommas qualifiers ++ [")"]

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -81,6 +81,7 @@ import           TheoryObject
 
 import           Web.Settings
 import           Web.Types
+import Theory.Constraint.System (usesOracle)
 
 ------------------------------------------------------------------------------
 -- Various other functions
@@ -540,10 +541,10 @@ subProofSnippet renderUrl renderImgUrl tidx ti lemma proofPath ctxt prf =
                              comment_ (goalRankingName ranking))
           , preformatted (Just "methods") (numbered' $ map prettyPM $ zip [1..] pms)
           , autoProverLinks 'a' ""         emptyDoc      0
-          , autoProverLinks 'b' "bounded-" boundDesc bound
-          , autoProverLinks 'o' "oracle-"  oracleDesc    0
-          , autoProverLinks 's' "all-"     allProve      0
-          ]
+          , autoProverLinks 'b' "bounded-" boundDesc bound ] ++
+          [ autoProverLinks 'o' "oracle-"  oracleDesc    0
+          | usesOracle heuristic ] ++
+          [ autoProverLinks 's' "all-"     allProve      0 ]
         where
           boundDesc = text $ " with proof-depth bound " ++ show bound
           bound     = fromMaybe 5 $ apBound $ tiAutoProver ti

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -541,11 +541,13 @@ subProofSnippet renderUrl renderImgUrl tidx ti lemma proofPath ctxt prf =
           , preformatted (Just "methods") (numbered' $ map prettyPM $ zip [1..] pms)
           , autoProverLinks 'a' ""         emptyDoc      0
           , autoProverLinks 'b' "bounded-" boundDesc bound
+          , autoProverLinks 'o' "oracle-"  oracleDesc    0
           , autoProverLinks 's' "all-"     allProve      0
           ]
         where
           boundDesc = text $ " with proof-depth bound " ++ show bound
           bound     = fromMaybe 5 $ apBound $ tiAutoProver ti
+          oracleDesc = text "until oracle returns nothing"
           allProve  = text $ " for all lemmas "
     autoProverLinks key "all-" nameSuffix bound = hsep
       [ text (key : ".")
@@ -561,16 +563,23 @@ subProofSnippet renderUrl renderImgUrl tidx ti lemma proofPath ctxt prf =
               (keyword_ "for all solutions")
       , nameSuffix
       ]
+    autoProverLinks key "oracle-" nameSuffix bound = hsep
+      [ text (key : ".")
+      , linkToPath renderUrl
+            (AutoProverR tidx CutDFS bound True (TheoryProof lemma proofPath))
+            ["oracle-autoprove"]
+            (keyword_ "autoprove")
+      , nameSuffix ]
     autoProverLinks key classPrefix nameSuffix bound = hsep
       [ text (key : ".")
       , linkToPath renderUrl
-            (AutoProverR tidx CutDFS bound (TheoryProof lemma proofPath))
+            (AutoProverR tidx CutDFS bound False (TheoryProof lemma proofPath))
             [classPrefix ++ "autoprove"]
             (keyword_ $ "autoprove")
       , parens $
           text (toUpper key : ".") <->
           linkToPath renderUrl
-              (AutoProverR tidx CutNothing bound (TheoryProof lemma proofPath))
+              (AutoProverR tidx CutNothing bound False (TheoryProof lemma proofPath))
               [classPrefix ++ "characterization"]
               (keyword_ "for all solutions")
       , nameSuffix

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -577,7 +577,7 @@ mkYesodData "WebUI" [parseRoutes|
 /thy/trace/#Int/main/*TheoryPath              TheoryPathMR            GET
 -- /thy/trace/#Int/debug/*TheoryPath             TheoryPathDR            GET
 /thy/trace/#Int/graph/*TheoryPath             TheoryGraphR            GET
-/thy/trace/#Int/autoprove/#SolutionExtractor/#Int/*TheoryPath AutoProverR             GET
+/thy/trace/#Int/autoprove/#SolutionExtractor/#Int/#Bool/*TheoryPath AutoProverR             GET
 /thy/trace/#Int/autoproveAll/#SolutionExtractor/#Int/*TheoryPath AutoProverAllR             GET
 /thy/trace/#Int/next/#String/*TheoryPath      NextTheoryPathR         GET
 /thy/trace/#Int/prev/#String/*TheoryPath      PrevTheoryPathR         GET


### PR DESCRIPTION
I implemented a proof-method for the interactive prover that autoproves unless the oracle returns no ranking. I often had to deal with complicated theories that don't terminate in one case. Finding this case was a pain. This method should help in these cases.

I also think that the new `Ranking` type can be extended with more interesting "instructions" as I call them alter as well, i.e., this typing framework is desirable in its own right. For example, backtracking could be implemented using this framework.

<img width="1066" alt="image" src="https://github.com/tamarin-prover/tamarin-prover/assets/9728715/bc8212fd-ed0a-4c06-965c-7bb4d4a1a7c7">