### PR TITLE
click and open img in new tab

### DIFF
--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -174,15 +174,17 @@ applyDiffProverAtPath thy lemmaName proofPath prover =
 
 -- | Reference a dot graph for the given path.
 refDotPath :: HtmlDocument d => RenderUrl -> TheoryIdx -> TheoryPath -> d
-refDotPath renderUrl tidx path = closedTag "img" [("class", "graph"), ("src", imgPath)]
+refDotPath renderUrl tidx path = withTag "a" [("href", imgPath), ("target", "_blank")] $ closedTag "img" [("class", "graph"), ("src", imgPath)]
   where imgPath = T.unpack $ renderUrl (TheoryGraphR tidx path)
+
 
 -- | Reference a dot graph for the given diff path.
 refDotDiffPath :: HtmlDocument d => RenderUrl -> TheoryIdx -> DiffTheoryPath -> Bool -> d
-refDotDiffPath renderUrl tidx path mirror = closedTag "img" [("class", "graph"), ("src", imgPath)]
-    where imgPath = if mirror
-          then T.unpack $ renderUrl (TheoryMirrorDiffR tidx path)
-          else T.unpack $ renderUrl (TheoryGraphDiffR tidx path)
+refDotDiffPath renderUrl tidx path mirror = withTag "a" [("href", imgPath), ("target", "_blank")] $ closedTag "img" [("class", "graph"), ("src", imgPath)]
+  where
+    imgPath = if mirror
+              then T.unpack $ renderUrl (TheoryMirrorDiffR tidx path)
+              else T.unpack $ renderUrl (TheoryGraphDiffR tidx path)
 
 -- | Generate the dot file path for an intermediate dot output.
 getDotPath :: String -> FilePath


### PR DESCRIPTION
I propose a solution to the following issue : https://github.com/tamarin-prover/tamarin-prover/issues/604
We can now open images in new tab when we click on them.