### PR TITLE
Rewrite execProofMethod

### DIFF
--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
@@ -148,7 +148,6 @@ induction
   by contradiction // from formulas
 next
   case non_empty_trace
-  simplify
   solve( (∀ pid otc1 tc1 otc2 tc2 #t1 #t2.
            (LoginCounter( pid, otc1, tc1 ) @ #t1) ∧
            (LoginCounter( pid, otc2, tc2 ) @ #t2)

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
@@ -271,7 +271,6 @@ induction
   by contradiction // from formulas
 next
   case non_empty_trace
-  simplify
   solve( !S_AEAD( pid,
                   <xorc(senc(keystream(kh, pid), k), <k2, sid>), mac(<k2, sid>, k)>
          ) ▶₂ #t2 )

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
@@ -225,7 +225,6 @@ induction
   by contradiction // from formulas
 next
   case non_empty_trace
-  simplify
   solve( (¬(#t1 < #t2))  ∥ (∀ z.2. ((otc2+z.1) = (otc1+z+z.2)) ⇒ ⊥) )
     case case_1
     solve( (#t2 = #t1)  ∥ (#t1 < #t2) )

--- a/lib/theory/src/OpenTheory.hs
+++ b/lib/theory/src/OpenTheory.hs
@@ -655,7 +655,7 @@ normalizeTheory =
     stripProofStepAnnotations (ProofStep method ()) = ProofStep
       (case method of
         Sorry _         -> Sorry Nothing
-        Contradiction _ -> Contradiction Nothing
+        Finished (Contradictory _) -> Finished (Contradictory Nothing)
         _               -> method)
       ()
 

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -37,9 +37,6 @@ import           Control.Basics
 import           Control.Category
 import           Control.Monad.Disj
 import           Control.Monad.State                     (gets)
-import           Control.Monad.Trans.State.Lazy          hiding (get,gets)
-import           Control.Monad.Trans.FastFresh           -- GHC7.10 needs: hiding (get,gets)
-import           Control.Monad.Trans.Reader              -- GHC7.10 needs: hiding (get,gets)
 
 import           Extension.Data.Label                    as L
 
@@ -344,9 +341,7 @@ solveChain rules (c, p) = do
          _ -> error "solveChain: not a down fact"
   where
     extendAndMark :: NodeId -> RuleACInst -> PremIdx -> LNFact -> LNFact
-      -> Control.Monad.Trans.State.Lazy.StateT System
-      (Control.Monad.Trans.FastFresh.FreshT
-      (DisjT (Control.Monad.Trans.Reader.Reader ProofContext))) String
+      -> Reduction String
     extendAndMark i ru v faPrem faConc = do
         insertEdges [(c, faConc, faPrem, (i, v))]
         markGoalAsSolved "directly" (PremiseG (i, v) faPrem)

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -16,9 +16,12 @@ module Theory.Constraint.Solver.ProofMethod (
   -- * Proof methods
     CaseName
   , ProofMethod(..)
+  , Result(..)
   , DiffProofMethod(..)
+  , checkAndExecProofMethod
   , execProofMethod
   , execDiffProofMethod
+  , isFinished
 
   -- ** Heuristics
   , rankProofMethods
@@ -39,9 +42,10 @@ import           Data.Binary
 import           Data.Function                             (on)
 import           Data.Label                                hiding (get)
 import qualified Data.Label                                as L
-import           Data.List                                 (intersperse,partition,groupBy,sortBy,isPrefixOf,findIndex,intercalate)
+import           Data.List                                 (partition,groupBy,sortBy,isPrefixOf,findIndex,intercalate, uncons)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map                                  as M
-import           Data.Maybe                                (catMaybes, fromMaybe, mapMaybe)
+import           Data.Maybe                                (catMaybes, fromMaybe, mapMaybe, isNothing, isJust)
 -- import           Data.Monoid
 import           Data.Ord                                  (comparing)
 import qualified Data.Set                                  as S
@@ -51,6 +55,7 @@ import qualified Data.ByteString.Char8 as BC
 import           Control.Basics
 import           Control.DeepSeq
 import qualified Control.Monad.Trans.PreciseFresh          as Precise
+import qualified Control.Monad.Trans.State                 as St
 
 import           Debug.Trace
 import           Safe
@@ -67,6 +72,9 @@ import           Theory.Constraint.Solver.Simplify
 import           Theory.Constraint.System
 import           Theory.Model
 import           Theory.Text.Pretty
+import qualified Extension.Data.Label as L
+import Control.Monad.Disj (disjunctionOfList)
+import Data.Bool (bool)
 
 
 
@@ -84,7 +92,7 @@ uniqueListBy :: (a -> a -> Ordering) -> (a -> a) -> (Int -> [a -> a]) -> [a] -> 
 uniqueListBy ord single distinguish xs0 =
       map fst
     $ sortBy (comparing snd)
-    $ concat $ map uniquify $ groupBy (\x y -> ord (fst x) (fst y) == EQ)
+    $ concatMap uniquify $ groupBy (\x y -> ord (fst x) (fst y) == EQ)
     $ sortBy (ord `on` fst)
     $ zip xs0 [(0::Int)..]
   where
@@ -183,18 +191,26 @@ unmarkPremiseG annGoal                        = annGoal
 -- | Every case in a proof is uniquely named.
 type CaseName = String
 
+data Result =
+    Solved
+  -- ^ A dependency graph was found.
+  | Contradictory (Maybe Contradiction)
+  -- ^ A contradiction could be derived, possibly with a reason. The single
+  --    formula constraint in the system.
+  | Unfinishable
+  -- ^ The proof cannot be finished (due to reducible operators in subterms or
+  --   because a solution was found after weakening).
+  deriving( Eq, Ord, Show, Generic, NFData, Binary )
+
 -- | Sound transformations of sequents.
 data ProofMethod =
     Sorry (Maybe String)                 -- ^ Proof was not completed
-  | Solved                               -- ^ An attack was found.
-  | Unfinishable                         -- ^ The proof cannot be finished (due to reducible operators in subterms)
   | Simplify                             -- ^ A simplification step.
   | SolveGoal Goal                       -- ^ A goal that was solved.
-  | Contradiction (Maybe Contradiction)  -- ^ A contradiction could be
-                                         -- derived, possibly with a reason.
   | Induction                            -- ^ Use inductive strengthening on
                                          -- the single formula constraint in
                                          -- the system.
+  | Finished Result
   deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Sound transformations of diff sequents.
@@ -211,13 +227,13 @@ data DiffProofMethod =
   
 instance HasFrees ProofMethod where
     foldFrees f (SolveGoal g)     = foldFrees f g
-    foldFrees f (Contradiction c) = foldFrees f c
+    foldFrees f (Finished (Contradictory c)) = foldFrees f c
     foldFrees _ _                 = mempty
 
     foldFreesOcc  _ _ = const mempty
 
     mapFrees f (SolveGoal g)     = SolveGoal <$> mapFrees f g
-    mapFrees f (Contradiction c) = Contradiction <$> mapFrees f c
+    mapFrees f (Finished (Contradictory c)) = Finished . Contradictory <$> mapFrees f c
     mapFrees _ method            = pure method
 
 instance HasFrees DiffProofMethod where
@@ -232,100 +248,94 @@ instance HasFrees DiffProofMethod where
 -- Proof method execution
 -------------------------
 
--- @execMethod rules method se@ checks first if the @method@ is applicable to
--- the sequent @se@. Then, it applies the @method@ to the sequent under the
--- assumption that the @rules@ describe all rewriting rules in scope.
+-- @checkAndExecMethod rules method se@ checks first if the @method@ is
+-- applicable to the sequent @se@ and, if so, applies it.
+checkAndExecProofMethod :: ProofContext -> ProofMethod -> System -> Maybe (M.Map CaseName System)
+checkAndExecProofMethod ctxt method sys = do
+    case method of
+      Finished r -> isFinished ctxt sys >>= guard . equalReason r
+      Induction -> canApplyInduction
+      SolveGoal goal -> guard (goal `M.member` L.get sGoals sys)
+      Simplify -> Just ()
+      Sorry _ -> Just ()
+    execProofMethod ctxt method sys
+  where
+    canApplyInduction :: Maybe ()
+    canApplyInduction = do
+      guard (M.null $ L.get sNodes sys)
+      guard (S.null $ L.get sSolvedFormulas sys)
+      guard (M.null $ L.get sGoals sys)
+      (_, t) <- uncons $ S.toList $ L.get sFormulas sys
+      guard (null t)
+
+    equalReason :: Result -> Result -> Bool
+    equalReason (Contradictory _) (Contradictory _) = True
+    equalReason r1 r2 = r1 == r2
+    -- ^ all other reasons don't have an argument
+
+-- @execMethod rules method se@ applies the @method@ to the sequent under the
+-- assumption that it is sound to apply the method and that the @rules@ describe
+-- all rewriting rules in scope.
 --
 -- NOTE that the returned systems have their free substitution fully applied
 -- and all variable indices reset.
 execProofMethod :: ProofContext
                 -> ProofMethod -> System -> Maybe (M.Map CaseName System)
 execProofMethod ctxt method sys =
-      case method of
-        Sorry _                                -> return M.empty
-        Solved
-          | null (openGoals sys)  && not (contradictorySystem ctxt sys)
-            && finishedSubterms ctxt sys       -> return M.empty
-          | otherwise                          -> Nothing
-        Unfinishable
-          | null (openGoals sys)  && not (contradictorySystem ctxt sys)
-            && not (finishedSubterms ctxt sys) -> return M.empty
-          | otherwise                          -> Nothing
-        SolveGoal goal
-          | goal `M.member` L.get sGoals sys   -> execSolveGoal goal
-          | otherwise                          -> Nothing
-        Simplify                               -> singleCase simplifySystem
-        Induction                              -> M.map cleanupSystem <$> execInduction
-        Contradiction _
-          | null (contradictions ctxt sys)     -> Nothing
-          | otherwise                          -> Just M.empty
+    case method of
+      Sorry _               -> return M.empty
+      Finished _            -> return M.empty
+      Simplify              ->
+        let cases = process (return "") -- @process@ simplifies
+        in case M.toList cases of
+          -- Check whether simplified system is equal to previous one; if so,
+          -- fail in applying this method.
+          [(_, sys')] -> guard (sys' /= cleanup sys) >> return cases
+          -- If simplifying resulted in multiple cases, the resulting ones
+          -- cannot be equal to the original one so there's nothing to check.
+          _ -> return cases
+      Induction             -> process . induction <$> getInductionCases sys
+      SolveGoal goal        -> return $ process $ solve goal
   where
-    -- at this point it is safe to remove the free substitution, as all
-    -- systems have it fully applied (by the virtue of a call to
-    -- simplifySystem). We also reset the variable indices here.
-    cleanupSystem =
-         (`Precise.evalFresh` Precise.nothingUsed)
-       . renamePrecise
-       . set sSubst emptySubst
+    process :: Reduction CaseName -> M.Map CaseName System
+    process m =
+      let cases =   removeRedundantCases ctxt [] snd
+                  . map (fmap cleanup . fst)
+                  . getDisj $ runReduction (m <* simplifySystem) ctxt sys (avoid sys)
+      in  M.fromListWith (error "case names not unique")
+            $ uniqueListBy (comparing fst) id distinguish cases
 
-
-    -- expect only one or no subcase in the given case distinction
-    singleCase m =
-        case    removeRedundantCases ctxt [] id . map cleanupSystem
-              . map fst . getDisj $ execReduction m ctxt sys (avoid sys) of
-          []                  -> return $ M.empty
-          [sys'] | check sys' -> return $ M.singleton "" sys'
-                 | otherwise  -> mzero
-          syss                ->
-               return $ M.fromList (zip (map show [(1::Int)..]) syss)
-      where check sys' = cleanupSystem sys /= sys'
+    cleanup :: System -> System
+    cleanup s = L.set sSubst emptySubst (Precise.evalFresh (renamePrecise s) Precise.nothingUsed)
 
     -- solve the given goal
     -- PRE: Goal must be valid in this system.
-    execSolveGoal :: Goal -> Maybe (M.Map CaseName System)
-    execSolveGoal goal =
-        return . makeCaseNames . removeRedundantCases ctxt [] snd
-               . map (second cleanupSystem) . map fst . getDisj
-               $ reduc
-      where
-        reduc  = runReduction solver ctxt sys (avoid sys)
-        ths    = L.get pcSources ctxt
-        solver = do name <- maybe (solveGoal goal)
-                                  (fmap $ concat . intersperse "_")
-                                  (solveWithSource ctxt ths goal)
-                    simplifySystem
-                    return name
+    solve :: Goal -> Reduction CaseName
+    solve goal =
+      let ths = L.get pcSources ctxt
+      in maybe  (solveGoal goal)
+                (intercalate "_" <$>)
+                (solveWithSource ctxt ths goal)
 
-        makeCaseNames =
-            M.fromListWith (error "case names not unique")
-          . uniqueListBy (comparing fst) id distinguish
-          where
-            distinguish n =
-                [ (\(x,y) -> (x ++ "_case_" ++ pad (show i), y))
-                | i <- [(1::Int)..] ]
-              where
-                l      = length (show n)
-                pad cs = replicate (l - length cs) '0' ++ cs
-
-    -- Apply induction: possible if the system contains only
+    -- Induction is only possible if the system contains only
     -- a single, last-free, closed formula.
-    execInduction
-      | sys == sys0 =
-          case S.toList $ L.get sFormulas sys of
-            [gf] -> case ginduct gf of
-                      Right (bc, sc) -> Just $ insCase "empty_trace"     bc
-                                             $ insCase "non_empty_trace" sc
-                                             $ M.empty
-                      _              -> Nothing
-            _    -> Nothing
+    getInductionCases :: System -> Maybe (LNGuarded, LNGuarded)
+    getInductionCases s = do
+      (h, _) <- uncons $ S.toList $ L.get sFormulas s
+      either (const Nothing) Just (ginduct h)
 
-      | otherwise = Nothing
+    induction :: (LNGuarded, LNGuarded) -> Reduction String
+    induction (baseCase, stepCase) = do
+      (caseName, caseFormula) <- disjunctionOfList [("empty_trace", baseCase), ("non_empty_trace", stepCase)]
+      L.setM sFormulas (S.singleton caseFormula)
+      return caseName
+
+    distinguish n =
+        [ (\(x,y) -> (if null x then show i else x ++ "_case_" ++ pad (show i), y))
+        | i <- [(1::Int)..] ]
       where
-        sys0 = set sFormulas (L.get sFormulas sys)
-             $ set sLemmas (L.get sLemmas sys)
-             $ emptySystem (L.get sSourceKind sys) (L.get sDiffSystem sys)
-
-        insCase name gf = M.insert name (set sFormulas (S.singleton gf) sys)
+        l      = length (show n)
+        pad cs = replicate (l - length cs) '0' ++ cs
 
 -- @execDiffMethod rules method se@ checks first if the @method@ is applicable to
 -- the sequent @se@. Then, it applies the @method@ to the sequent under the
@@ -335,63 +345,69 @@ execProofMethod ctxt method sys =
 -- and all variable indices reset.
 execDiffProofMethod :: DiffProofContext
                 -> DiffProofMethod -> DiffSystem -> Maybe (M.Map CaseName DiffSystem)
-execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ show sys -- return M.empty
-      case method of
-        DiffSorry _                                           -> return M.empty
-        DiffBackwardSearch
-          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys) of
-                                                                      (Just rule, Nothing) -> Just $ startBackwardSearch rule
-                                                                      (_ , _)              -> Nothing
-          | otherwise                                         -> Nothing
-        DiffBackwardSearchStep meth
-          | (L.get dsProofType sys) == (Just RuleEquivalence)
-            && (meth /= Induction)
-            && (meth /= (Contradiction (Just ForbiddenKD)))   -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
-                                                                      (Just _, Just s, Just sys') -> applyStep meth s sys'
-                                                                      (_ , _ , _)                 -> Nothing
-          | otherwise                                         -> Nothing
-        DiffMirrored
-          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
-                                                                      (Just _, Just s, Just sys') -> if isTrivial sys' && allSubtermsFinished && (fst (evaluateRestrictions ctxt sys mirrorSyss (isSolved s sys')) == TTrue)
-                                                                                                        then return M.empty
-                                                                                                        else Nothing
-                                                                                                    where
-                                                                                                        mirrorSyss = getMirrorDG ctxt s sys'
-                                                                                                        mirrorCtxt = eitherProofContext ctxt (opposite s)
-                                                                                                        allSubtermsFinished = finishedSubterms (eitherProofContext ctxt s) sys' && all (finishedSubterms mirrorCtxt) mirrorSyss
-                                                                      (_ , _ , _)                 -> Nothing                                                       
-          | otherwise                                         -> Nothing
-        DiffAttack
-          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
-                                                                      (Just _, Just s, Just sys') -> if (isSolved s sys' || (isTrivial sys' && not (contradictorySystem (eitherProofContext ctxt s) sys'))) &&
-                                                                                                        (allSubtermsFinished && (fst (evaluateRestrictions ctxt sys mirrorSyss (isSolved s sys')) == TFalse))
-                                                                                                      then return M.empty
-                                                                                                        -- In the second case, the system is trivial, has no mirror and restrictions do not get in the way.
-                                                                                                        -- If we solve arbitrarily the last remaining trivial goals,
-                                                                                                        -- then there will be an attack.                                                                                                        then 
-                                                                                                      else Nothing
-                                                                                                        where
-                                                                                                          mirrorSyss = getMirrorDG ctxt s sys'
-                                                                                                          mirrorCtxt = eitherProofContext ctxt (opposite s)
-                                                                                                          allSubtermsFinished = finishedSubterms (eitherProofContext ctxt s) sys' && all (finishedSubterms mirrorCtxt) mirrorSyss
-                                                                      (_ , _ , _)                 -> Nothing
-          | otherwise                                         -> Nothing
-        DiffRuleEquivalence
-          | (L.get dsProofType sys) == Nothing                -> Just ruleEquivalence
-          | otherwise                                         -> Nothing
-        DiffUnfinishable
-          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
-                                                                      (Just _, Just s, Just sys') -> if isSolved s sys' && not allSubtermsFinished
-                                                                                                        then return M.empty
-                                                                                                        else Nothing
-                                                                                                      where
-                                                                                                        mirrorSyss = getMirrorDG ctxt s sys'
-                                                                                                        mirrorCtxt = eitherProofContext ctxt (opposite s)
-                                                                                                        allSubtermsFinished = finishedSubterms (eitherProofContext ctxt s) sys' && all (finishedSubterms mirrorCtxt) mirrorSyss
-                                                                      (_ , _ , _)                 -> Nothing
-          | otherwise                                         -> Nothing
-          
+execDiffProofMethod ctxt method sys =
+  case method of
+    DiffSorry _ -> return M.empty
+    DiffBackwardSearch -> do
+      guard (L.get dsProofType sys == Just RuleEquivalence)
+      rule <- L.get dsCurrentRule sys
+      guard (isNothing $ L.get dsSide sys)
+      return $ startBackwardSearch rule
+    DiffBackwardSearchStep meth -> do
+      guard (L.get dsProofType sys == Just RuleEquivalence)
+      guard (meth /= Induction)
+      guard (meth /= Finished (Contradictory (Just ForbiddenKD)))
+      _ <- L.get dsCurrentRule sys
+      s <- L.get dsSide sys
+      applyStep meth s =<< sequent
+    DiffMirrored -> do
+      guard (L.get dsProofType sys == Just RuleEquivalence)
+      guard (isJust $ L.get dsCurrentRule sys)
+      msys' >>= guard . trivial
+      mallSubtermsFinished >>= guard
+      mirrorSyss <- mmirrorSyss
+      solved <- isSolved <$> mside <*> msys'
+      guard (fst (evaluateRestrictions ctxt sys mirrorSyss solved) == TTrue)
+      return M.empty
+    DiffAttack -> do
+      guard (L.get dsProofType sys == Just RuleEquivalence)
+      guard (isJust $ L.get dsCurrentRule sys)
+      s <- L.get dsSide sys
+      solved <- isSolved <$> mside <*> msys'
+      sys' <- L.get dsSystem sys
+      notContradictory <- not . contradictorySystem (eitherProofContext ctxt s) <$> sequent
+      -- In the second case, the system is trivial, has no mirror and restrictions do not get in the way.
+      -- If we solve arbitrarily the last remaining trivial goals,
+      -- then there will be an attack.
+      guard (solved || (trivial sys' && notContradictory))
+      allSubtermsFinished <- mallSubtermsFinished
+      guard allSubtermsFinished
+      mirrorSyss <- mmirrorSyss
+      guard (fst (evaluateRestrictions ctxt sys mirrorSyss solved) == TFalse)
+      return M.empty
+    DiffRuleEquivalence -> do
+      guard (isNothing $ L.get dsProofType sys)
+      return ruleEquivalence
+    DiffUnfinishable -> do
+      guard (L.get dsProofType sys == Just RuleEquivalence)
+      guard (isJust $ L.get dsCurrentRule sys)
+      solved <- isSolved <$> mside <*> msys'
+      allSubtermsFinished <- mallSubtermsFinished
+      guard solved
+      guard (not allSubtermsFinished)
+      return M.empty
   where
+    sequent              = L.get dsSystem sys
+    mside                = L.get dsSide sys
+    msys'                = L.get dsSystem sys
+    mmirrorSyss          = getMirrorDG ctxt <$> mside <*> msys'
+    mctxt                = eitherProofContext ctxt <$> mside
+    mmirrorCtxt          = eitherProofContext ctxt . opposite <$> mside
+    mallSubtermsFinished = do
+      finished <- finishedSubterms <$> mctxt <*> msys'
+      finishedMirrored <- (all . finishedSubterms <$> mmirrorCtxt) <*> mmirrorSyss
+      return $ finished && finishedMirrored
+
     protoRules       = L.get dpcProtoRules  ctxt
     destrRules       = L.get dpcDestrRules  ctxt
     constrRules      = L.get dpcConstrRules ctxt
@@ -418,10 +434,10 @@ execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ sho
     -- LHS or RHS is not important in this case as we only need the names of the rules.
     ruleEquivalence :: M.Map CaseName DiffSystem
     ruleEquivalence = foldl ruleEquivalenceCase (foldl ruleEquivalenceCase {-(foldl ruleEquivalenceCase-} M.empty {-constrRules)-} destrRules) (protoRulesAC LHS)
-    
-    isTrivial :: System -> Bool
-    isTrivial sys' = (dgIsNotEmpty sys') && (allOpenGoalsAreSimpleFacts ctxt sys') && (allOpenFactGoalsAreIndependent sys')
-    
+
+    trivial :: System -> Bool
+    trivial sys' = (dgIsNotEmpty sys') && (allOpenGoalsAreSimpleFacts ctxt sys') && (allOpenFactGoalsAreIndependent sys')
+
     backwardSearchSystem :: Side -> DiffSystem -> String -> DiffSystem
     backwardSearchSystem s sys' rulename = L.set dsSide (Just s)
       $ L.set dsSystem (Just ruleSys) sys'
@@ -431,15 +447,14 @@ execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ sho
 
     startBackwardSearch :: String -> M.Map CaseName DiffSystem
     startBackwardSearch rulename = M.insert ("LHS") (backwardSearchSystem LHS sys rulename) $ M.insert ("RHS") (backwardSearchSystem RHS sys rulename) $ M.empty
-    
-    applyStep :: ProofMethod -> Side -> System -> Maybe (M.Map CaseName DiffSystem)
-    applyStep m s sys' = case (execProofMethod (eitherProofContext ctxt s) m sys') of
-                           Nothing    -> Nothing
-                           Just cases -> Just $ M.map (\x -> L.set dsSystem (Just x) sys) cases
 
     isSolved :: Side -> System -> Bool
-    isSolved s sys' = (rankProofMethods GoalNrRanking [defaultTactic] (eitherProofContext ctxt s) sys') == [] -- checks if the system is solved
+    isSolved s sys' = isJust $ isFinished (eitherProofContext ctxt s) sys' >>= guard . (== Solved)
 
+    applyStep :: ProofMethod -> Side -> System -> Maybe (M.Map CaseName DiffSystem)
+    applyStep m s dsSys = do
+      cases <- execProofMethod (eitherProofContext ctxt s) m dsSys
+      return $ M.map (\x -> L.set dsSystem (Just x) sys) cases
 
 -- | returns True if there are no reducible operators on top of a right side of a subterm in the subterm store
 finishedSubterms :: ProofContext -> System -> Bool
@@ -485,31 +500,37 @@ rankGoals ctxt ranking tacticsList sys = case ranking of
       chooseError [] _ = error $ "No tactic has been written in the theory file"
       chooseError _  t = error $ "The tactic specified ( "++(show $ _name t)++" ) is not written in the theory file, please chose among the following: "++(show definedHeuristic)
 
+isFinished :: ProofContext -> System -> Maybe Result
+isFinished ctxt sys
+  | isInitialSystem sys = Nothing
+  | not $ null cs = Just $ Contradictory (Just $ head cs)
+  | null ogs && stFinished = Just Solved
+  | null ogs && not stFinished = Just Unfinishable
+  | otherwise = Nothing
+  where
+    cs = contradictions ctxt sys
+    ogs = openGoals sys
+    stFinished = finishedSubterms ctxt sys
+
 -- | Use a 'GoalRanking' to generate the ranked, list of possible
 -- 'ProofMethod's and their corresponding results in this 'ProofContext' and
--- for this 'System'. If the resulting list is empty, then the constraint
--- system is solved.
+-- for this 'System'.
 rankProofMethods :: GoalRanking ProofContext -> [Tactic ProofContext] -> ProofContext -> System
                  -> [(ProofMethod, (M.Map CaseName System, String))]
 rankProofMethods ranking tactics ctxt sys =
-  let rankedGoals = rankGoals ctxt ranking tactics sys $ openGoals sys
-      cs = contradictions ctxt sys
-  in case rankedGoals of
-    Ranking gs (Just ApplySorry)
-      | null cs && not (null gs) -> [(Sorry (Just "Oracle ranked no proof methods"), (M.empty, ""))]
-    Ranking gs _ -> do
-      (m, expl) <-
-              (contradiction <$> cs)
-          <|> (case L.get pcUseInduction ctxt of
-                AvoidInduction -> [(Simplify, ""), (Induction, "")]
-                UseInduction   -> [(Induction, ""), (Simplify, "")]
-              )
-          <|> (solveGoalMethod <$> gs)
-      case execProofMethod ctxt m sys of
-        Just cases -> return (m, (cases, expl))
-        Nothing    -> []
+  let Ranking (map solveGoalMethod -> goals) instr = rankGoals ctxt ranking tactics sys (openGoals sys)
+      insertInduction (simplify NE.:| gs) = case L.get pcUseInduction ctxt of
+        AvoidInduction -> simplify : (Induction, "") : gs
+        UseInduction   -> (Induction, "") : simplify : gs
+      proofMethods = bool NE.toList insertInduction (isInitialSystem sys) ((Simplify, "") NE.:| goals)
+      stoppingMethod =    (Finished <$> isFinished ctxt sys)
+                      <|> (Sorry (Just "Oracle ranked no proof methods") <$ instr)
+  in execMethods $ maybe proofMethods ((:[]) . (,"")) stoppingMethod
   where
-    contradiction c                    = (Contradiction (Just c), "")
+    execMethods = mapMaybe execMethod
+    execMethod (m, expl) = do
+      cases <- execProofMethod ctxt m sys
+      return (m, (cases, expl))
 
     sourceRule goal = case goalRule sys goal of
         Just ru -> " (from rule " ++ getRuleName ru ++ ")"
@@ -532,19 +553,21 @@ rankDiffProofMethods :: GoalRanking ProofContext -> [Tactic ProofContext] -> Dif
                  -> [(DiffProofMethod, (M.Map CaseName DiffSystem, String))]
 rankDiffProofMethods ranking tactics ctxt sys = do
     (m, expl) <-
-            [(DiffRuleEquivalence, "Prove equivalence using rule equivalence")]
-        <|> [(DiffMirrored, "Backward search completed")]
-        <|> [(DiffAttack, "Found attack")]
-        <|> [(DiffUnfinishable, "Proof cannot be finished")]
-        <|> [(DiffBackwardSearch, "Do backward search from rule")]
-        <|> (case (L.get dsSide sys, L.get dsSystem sys) of
-                  (Just s, Just sys') -> map (\x -> (DiffBackwardSearchStep (fst x), "Do backward search step"))
-                                          $ filter (\x -> not $ fst x == Induction)
-                                          $ rankProofMethods ranking tactics (eitherProofContext ctxt s) sys'
-                  (_     , _        ) -> [])
-    case execDiffProofMethod ctxt m sys of
-      Just cases -> return (m, (cases, expl))
-      Nothing    -> []
+            [ (DiffRuleEquivalence, "Prove equivalence using rule equivalence")
+            , (DiffMirrored, "Backward search completed")
+            , (DiffAttack, "Found attack")
+            , (DiffUnfinishable, "Proof cannot be finished")
+            , (DiffBackwardSearch, "Do backward search from rule")]
+        ++  maybe []
+              (map (\x -> (DiffBackwardSearchStep (fst x), "Do backward search step")) . filter (isDiffApplicable . fst))
+              ((rankProofMethods ranking tactics . eitherProofContext ctxt <$> L.get dsSide sys) <*> sys')
+    maybe [] (return . (m,) . (,expl)) (execDiffProofMethod ctxt m sys)
+  where
+    sys' = L.get dsSystem sys
+    isDiffApplicable (Finished (Contradictory _)) = True
+    isDiffApplicable Simplify = True
+    isDiffApplicable (SolveGoal _) = True
+    isDiffApplicable _ = False
 
 -- | Smart constructor for heuristics. Schedules the proof method rankings in a
 -- round-robin fashion dependent on the proof depth.
@@ -1148,15 +1171,14 @@ smartDiffRanking ctxt sys =
 -- | Pretty-print a proof method.
 prettyProofMethod :: HighlightDocument d => ProofMethod -> d
 prettyProofMethod method = case method of
-    Solved               -> keyword_ "SOLVED" <-> lineComment_ "trace found"
-    Unfinishable         -> keyword_ "UNFINISHABLE" <-> lineComment_ "reducible operator in subterm"
-    Induction            -> keyword_ "induction"
-    Sorry reason         ->
+    Finished Solved -> keyword_ "SOLVED" <-> lineComment_ "trace found"
+    Induction  -> keyword_ "induction"
+    Finished Unfinishable -> keyword_ "UNFINISHABLE" <-> lineComment_ "reducible operator in subterm"
+    Sorry reason ->
         fsep [keyword_ "sorry", maybe emptyDoc closedComment_ reason]
-    SolveGoal goal       ->
-        keyword_ "solve(" <-> prettyGoal goal <-> keyword_ ")"
-    Simplify             -> keyword_ "simplify"
-    Contradiction reason ->
+    SolveGoal goal -> keyword_ "solve(" <-> prettyGoal goal <-> keyword_ ")"
+    Simplify -> keyword_ "simplify"
+    Finished (Contradictory reason) ->
         sep [ keyword_ "contradiction"
             , maybe emptyDoc (closedComment . prettyContradiction) reason
             ]

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -125,6 +125,7 @@ module Theory.Constraint.System (
 
   -- ** Construction
   , emptySystem
+  , isInitialSystem
   , emptyDiffSystem
 
   , SystemTraceQuantifier(..)
@@ -822,6 +823,11 @@ emptySystem d isdiff = System
     M.empty S.empty S.empty Nothing emptySubtermStore emptyEqStore
     S.empty S.empty S.empty
     M.empty 0 d isdiff
+
+-- TODO: I do not like the second conjunct; this should be done cleaner
+isInitialSystem :: System -> Bool
+isInitialSystem sys = null (L.get sSolvedFormulas sys) && not (S.member bot (L.get sFormulas sys))
+  where bot = GDisj (Disj [])
 
 -- | The empty diff constraint system.
 emptyDiffSystem :: DiffSystem

--- a/lib/theory/src/Theory/Proof.hs
+++ b/lib/theory/src/Theory/Proof.hs
@@ -45,6 +45,7 @@ module Theory.Proof (
   -- ** Unfinished proofs
   , sorry
   , unproven
+  , unprovenLookAhead
   , diffSorry
   , diffUnproven
 
@@ -254,6 +255,13 @@ unproven :: a -> Proof a
 unproven = sorry Nothing
 
 -- | A proof denoting an unproven part of the proof.
+unprovenLookAhead :: ProofContext -> System -> IncrementalProof
+unprovenLookAhead ctxt sys = maybe (sorry Nothing (Just sys)) toNode (isFinished ctxt sys)
+  where
+    toNode :: Result -> IncrementalProof
+    toNode r = LNode (ProofStep (Finished r) (Just sys)) M.empty
+
+-- | A proof denoting an unproven part of the proof.
 diffUnproven :: a -> DiffProof a
 diffUnproven = diffSorry Nothing
 
@@ -414,8 +422,8 @@ instance Monoid ProofStatus where
 -- | The status of a 'ProofStep'.
 proofStepStatus :: ProofStep (Maybe a) -> ProofStatus
 proofStepStatus (ProofStep _            Nothing ) = UndeterminedProof
-proofStepStatus (ProofStep Solved       (Just _)) = TraceFound
-proofStepStatus (ProofStep Unfinishable (Just _)) = UnfinishableProof
+proofStepStatus (ProofStep (Finished Solved) (Just _)) = TraceFound
+proofStepStatus (ProofStep (Finished Unfinishable) (Just _)) = UnfinishableProof
 proofStepStatus (ProofStep (Sorry _)    (Just _)) = IncompleteProof
 proofStepStatus (ProofStep _            (Just _)) = CompleteProof
 
@@ -427,30 +435,6 @@ diffProofStepStatus (DiffProofStep (DiffSorry _)    (Just _)) = IncompleteProof
 diffProofStepStatus (DiffProofStep DiffUnfinishable (Just _)) = UnfinishableProof
 diffProofStepStatus (DiffProofStep _                (Just _)) = CompleteProof
 
-
-{- TODO: Test and probably improve
-
--- | @proveSystem rules se@ tries to construct a proof that @se@ is valid.
--- This proof may contain 'Sorry' steps, if the prover is stuck. It can also be
--- of infinite depth, if the proof strategy loops.
-proveSystemIterDeep :: ProofContext -> System -> Proof System
-proveSystemIterDeep rules se0 =
-    fromJust $ asum $ map (prove se0 . round) $ iterate (*1.5) (3::Double)
-  where
-    prove :: System -> Int -> Maybe (Proof System)
-    prove se bound
-      | bound < 0 = Nothing
-      | otherwise =
-          case next of
-            [] -> pure $ sorry "prover stuck => possible attack found" se
-            xs -> asum $ map mkProof xs
-      where
-        next = do m <- possibleProofMethods se
-                  (m,) <$> maybe mzero return (execProofMethod rules m se)
-        mkProof (method, cases) =
-            LNode (ProofStep method se) <$> traverse (`prove` (bound - 1)) cases
--}
-
 -- | @checkProof rules se prf@ replays the proof @prf@ against the start
 -- sequent @se@. A failure to apply a proof method is denoted by a resulting
 -- proof step without an annotated sequent. An unhandled case is denoted using
@@ -461,22 +445,21 @@ checkProof :: ProofContext
            -> System
            -> Proof a
            -> Proof (Maybe a, Maybe System)
-checkProof ctxt prover d sys prf@(LNode (ProofStep method info) cs) =
-    case (method, execProofMethod ctxt method sys) of
-        (Sorry reason, _         ) -> sorryNode reason cs
-        (_           , Just cases) -> node method $ checkChildren cases
-        (_           , Nothing   ) ->
-            sorryNode (Just "invalid proof step encountered")
-                      (M.singleton "" prf)
+checkProof ctxt prover =
+    go
   where
-    node m                 = LNode (ProofStep m (Just info, Just sys))
-    sorryNode reason cases = node (Sorry reason) (M.map noSystemPrf cases)
-    noSystemPrf            = mapProofInfo (\i -> (Just i, Nothing))
-
-    checkChildren cases = mergeMapsWith
-        unhandledCase noSystemPrf (checkProof ctxt prover (d + 1)) cases cs
+    go d sys prf@(LNode (ProofStep method info) cs) = case (method, checkAndExecProofMethod ctxt method sys) of
+      (Sorry reason, _         ) -> sorryNode reason cs
+      (_           , Just cases) -> node method $ checkChildren cases
+      (_           , Nothing   ) -> sorryNode (Just "invalid proof step encountered")
+                                      (M.singleton "" prf)
       where
-        unhandledCase = mapProofInfo ((,) Nothing) . prover d
+        unhandledCase = mapProofInfo (Nothing,) . prover d
+        checkChildren cases = mergeMapsWith unhandledCase noSystemPrf (go (d + 1)) cases cs
+
+        node m                 = LNode (ProofStep m (Just info, Just sys))
+        sorryNode reason cases = node (Sorry reason) (M.map noSystemPrf cases)
+        noSystemPrf            = mapProofInfo (\i -> (Just i, Nothing))
 
 -- | @checkDiffProof rules se prf@ replays the proof @prf@ against the start
 -- sequent @se@. A failure to apply a proof method is denoted by a resulting
@@ -488,65 +471,22 @@ checkDiffProof :: DiffProofContext
            -> DiffSystem
            -> DiffProof a
            -> DiffProof (Maybe a, Maybe DiffSystem)
-checkDiffProof ctxt prover d sys prf@(LNode (DiffProofStep method info) cs) =
-    case (method, execDiffProofMethod ctxt method sys) of
-        (DiffSorry reason, _         ) -> sorryNode reason cs
-        (_               , Just cases) -> node method $ checkChildren cases
-        (_               , Nothing   ) ->
-            sorryNode (Just "invalid proof step encountered")
-                      (M.singleton "" prf)
-  where
-    node m                 = LNode (DiffProofStep m (Just info, Just sys))
-    sorryNode reason cases = node (DiffSorry reason) (M.map noSystemPrf cases)
-    noSystemPrf            = mapDiffProofInfo (\i -> (Just i, Nothing))
-
-    checkChildren cases = mergeMapsWith
-        unhandledCase noSystemPrf (checkDiffProof ctxt prover (d + 1)) cases cs
-      where
-        unhandledCase = mapDiffProofInfo ((,) Nothing) . prover d
-
-
--- | Annotate a proof with the constraint systems of all intermediate steps
--- under the assumption that all proof steps are valid. If some proof steps
--- might be invalid, then you must use 'checkProof', which handles them
--- gracefully.
-annotateWithSystems :: ProofContext -> System -> Proof () -> Proof System
-annotateWithSystems ctxt =
+checkDiffProof ctxt prover =
     go
   where
-    -- Here we are careful to construct the result such that an inspection of
-    -- the proof does not force the recomputed constraint systems.
-    go sysOrig (LNode (ProofStep method _) csOrig) =
-      LNode (ProofStep method sysOrig) $ M.fromList $ do
-          (name, prf) <- M.toList csOrig
-          let sysAnn = extract ("case '" ++ name ++ "' non-existent") $
-                       M.lookup name csAnn
-          return (name, go sysAnn prf)
+    go d s prf@(LNode (DiffProofStep method info) cs) = case (method, execDiffProofMethod ctxt method s) of
+      (DiffSorry reason, _         ) -> sorryNode reason cs
+      (_               , Just cases) -> node method $ checkChildren cases
+      (_               , Nothing   ) ->
+          sorryNode (Just "invalid proof step encountered")
+                    (M.singleton "" prf)
       where
-        extract msg = fromMaybe (error $ "annotateWithSystems: " ++ msg)
-        csAnn       = extract "proof method execution failed" $
-                      execProofMethod ctxt method sysOrig
+        unhandledCase = mapDiffProofInfo (Nothing,) . prover d
+        checkChildren cases = mergeMapsWith unhandledCase noSystemPrf (go (d + 1)) cases cs
 
--- | Annotate a proof with the constraint systems of all intermediate steps
--- under the assumption that all proof steps are valid. If some proof steps
--- might be invalid, then you must use 'checkProof', which handles them
--- gracefully.
-annotateWithDiffSystems :: DiffProofContext -> DiffSystem -> DiffProof () -> DiffProof DiffSystem
-annotateWithDiffSystems ctxt =
-    go
-  where
-    -- Here we are careful to construct the result such that an inspection of
-    -- the proof does not force the recomputed constraint systems.
-    go sysOrig (LNode (DiffProofStep method _) csOrig) =
-      LNode (DiffProofStep method sysOrig) $ M.fromList $ do
-          (name, prf) <- M.toList csOrig
-          let sysAnn = extract ("case '" ++ name ++ "' non-existent") $
-                       M.lookup name csAnn
-          return (name, go sysAnn prf)
-      where
-        extract msg = fromMaybe (error $ "annotateWithSystems: " ++ msg)
-        csAnn       = extract "diff proof method execution failed" $
-                      execDiffProofMethod ctxt method sysOrig
+        node m                 = LNode (DiffProofStep m (Just info, Just s))
+        sorryNode reason cases = node (DiffSorry reason) (M.map noSystemPrf cases)
+        noSystemPrf            = mapDiffProofInfo (\i -> (Just i, Nothing))
 
 ------------------------------------------------------------------------------
 -- Provers: the interface to the outside world.
@@ -637,7 +577,7 @@ tryProver =  (`orelse` mempty)
 oneStepProver :: ProofMethod -> Prover
 oneStepProver method = Prover $ \ctxt _ se _ -> do
     cases <- execProofMethod ctxt method se
-    return $ LNode (ProofStep method (Just se)) (M.map (unproven . Just) cases)
+    return $ LNode (ProofStep method (Just se)) (M.map (unprovenLookAhead ctxt) cases)
 
 -- | Try to execute one proof step using the given proof method.
 oneStepDiffProver :: DiffProofMethod -> DiffProver
@@ -723,8 +663,8 @@ firstProver = foldr orelse failProver
 contradictionProver :: Prover
 contradictionProver = Prover $ \ctxt d sys prf ->
     runProver
-        (firstProver $ map oneStepProver $
-            (Contradiction . Just <$> contradictions ctxt sys))
+        (firstProver $ map oneStepProver
+            (Finished . Contradictory . Just <$> contradictions ctxt sys))
         ctxt d sys prf
 
 -- | Use the first diff prover that works.
@@ -737,7 +677,7 @@ contradictionDiffProver = DiffProver $ \ctxt d sys prf ->
   case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
     (Just _, Just s, Just sys') -> runDiffProver
               (firstDiffProver $ map oneStepDiffProver $
-                  (DiffBackwardSearchStep . Contradiction . Just <$> contradictions (eitherProofContext ctxt s) sys'))
+                  (DiffBackwardSearchStep . Finished . Contradictory . Just <$> contradictions (eitherProofContext ctxt s) sys'))
           ctxt d sys prf
     (_     , _     , _        ) -> Nothing
 
@@ -796,10 +736,8 @@ runAutoProver aut@(AutoProver _ _  bound cut _) =
     -- | The standard automatic prover that ignores the existing proof and
     -- tries to find one by itself.
     autoProver :: Prover
-    autoProver = Prover $ \ctxt depth sys _ ->
-        return $ fmap (fmap Just)
-               $ annotateWithSystems ctxt sys
-               $ proveSystemDFS (selectHeuristic aut ctxt) (selectTactic aut ctxt) ctxt depth sys
+    autoProver = Prover $ \ctxt depth sysPath _ ->
+        return $ proveSystemDFS (selectHeuristic aut ctxt) (selectTactic aut ctxt) ctxt depth sysPath
 
     -- | Bound the depth of proofs generated by the given prover.
     boundProver :: Int -> Prover -> Prover
@@ -820,10 +758,8 @@ runAutoDiffProver aut@(AutoProver _ _ bound cut _) =
     -- | The standard automatic prover that ignores the existing proof and
     -- tries to find one by itself.
     autoProver :: DiffProver
-    autoProver = DiffProver $ \ctxt depth sys _ ->
-        return $ fmap (fmap Just)
-               $ annotateWithDiffSystems ctxt sys
-               $ proveDiffSystemDFS (selectDiffHeuristic aut ctxt) (selectDiffTactic aut ctxt) ctxt depth sys
+    autoProver = DiffProver $ \ctxt depth syss _ ->
+        return $ proveDiffSystemDFS (selectDiffHeuristic aut ctxt) (selectDiffTactic aut ctxt) ctxt depth syss
 
     -- | Bound the depth of proofs generated by the given prover.
     boundProver :: Int -> DiffProver -> DiffProver
@@ -861,7 +797,7 @@ cutOnSolvedSingleThreadDFS prf0 =
         findSolved node = case node of
               -- do not search in nodes that are not annotated
               LNode (ProofStep _      (Nothing, _   )) _  -> NoSolution
-              LNode (ProofStep Solved (Just _ , path)) _  -> Solution path
+              LNode (ProofStep (Finished Solved) (Just _ , path)) _  -> Solution path
               LNode (ProofStep _      (Just _ , _   )) cs ->
                   foldMap findSolved cs
 
@@ -924,7 +860,7 @@ cutOnSolvedDFS prf0 =
           | otherwise = case node of
               -- do not search in nodes that are not annotated
               LNode (ProofStep _      (Nothing, _   )) _  -> NoSolution
-              LNode (ProofStep Solved (Just _ , path)) _  -> Solution path
+              LNode (ProofStep (Finished Solved) (Just _ , path)) _  -> Solution path
               LNode (ProofStep _      (Just _ , _   )) cs ->
                   foldMap (findSolved (succ d))
                       (cs `using` parTraversable nfProofMethod)
@@ -999,7 +935,7 @@ cutOnSolvedBFS =
           (prf', TraceFound)     ->
               trace ("attack found at depth: " ++ show l) prf'
 
-    checkLevel 0 (LNode  step@(ProofStep Solved (Just _)) _) =
+    checkLevel 0 (LNode  step@(ProofStep (Finished Solved) (Just _)) _) =
         S.put TraceFound >> return (LNode step M.empty)
     checkLevel 0 prf@(LNode (ProofStep _ x) cs)
       | M.null cs = return prf
@@ -1047,11 +983,9 @@ cutAfterFirstSorry :: Proof (Maybe a) -> Proof (Maybe a)
 cutAfterFirstSorry = snd . go False
   where
     go :: Bool -> Proof (Maybe a) -> (Bool, Proof (Maybe a))
-    go _      n@(LNode (ProofStep (Sorry _) _) _)         = (True, n)
-    go abort  n@(LNode (ProofStep Solved _) _)            = (abort, n)
-    go abort  n@(LNode (ProofStep Unfinishable _) _)      = (abort, n)
-    go abort  n@(LNode (ProofStep (Contradiction _) _) _) = (abort, n)
-    go True     (LNode (ProofStep _ ann) _)               = (True, LNode (ProofStep (Sorry Nothing) ann) M.empty)
+    go _      n@(LNode (ProofStep (Sorry _) _) _)     = (True, n)
+    go abort  n@(LNode (ProofStep (Finished _) _) _)  = (abort, n)
+    go True     (LNode (ProofStep _ ann) _)           = (True, LNode (ProofStep (Sorry Nothing) ann) M.empty)
     go False    (LNode r cs) =
       let (abort, cs') = M.mapAccum go False cs
       in (abort, LNode r cs')
@@ -1074,33 +1008,26 @@ cutAfterFirstSorryDiff = snd . go False
 -- constraint system using a depth-first-search strategy to resolve the
 -- non-determinism wrt. what goal to solve next.  This proof can be of
 -- infinite depth, if the proof strategy loops.
---
--- Use 'annotateWithSystems' to annotate the proof tree with the constraint
--- systems.
-proveSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> ProofContext -> Int -> System -> Proof ()
-proveSystemDFS heuristic tactics ctxt d0 sys0 =
-    prove d0 sys0
+proveSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> ProofContext -> Int -> System -> Proof (Maybe System)
+proveSystemDFS heuristic tactics ctxt =
+    prove
   where
     prove !depth sys =
         case rankProofMethods (useHeuristic heuristic depth) tactics ctxt sys of
-          [] | finishedSubterms ctxt sys -> node Solved M.empty
-          []                             -> node Unfinishable M.empty
-          (method, (cases, _expl)):_     -> node method cases
+          [] | finishedSubterms ctxt sys  -> node (Finished Solved) M.empty
+          []                              -> node (Finished Unfinishable) M.empty
+          (method, (cases, _expl)):_      -> node method cases
       where
-
         node method cases =
-          LNode (ProofStep method ()) (M.map (prove (succ depth)) cases)
+          LNode (ProofStep method (Just sys)) (M.map (prove (succ depth)) cases)
 
 -- | @proveSystemDFS rules se@ explores all solutions of the initial
 -- constraint system using a depth-first-search strategy to resolve the
 -- non-determinism wrt. what goal to solve next.  This proof can be of
 -- infinite depth, if the proof strategy loops.
---
--- Use 'annotateWithSystems' to annotate the proof tree with the constraint
--- systems.
-proveDiffSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> DiffProofContext -> Int -> DiffSystem -> DiffProof ()
-proveDiffSystemDFS heuristic tactics ctxt d0 sys0 =
-    prove d0 sys0
+proveDiffSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> DiffProofContext -> Int -> DiffSystem -> DiffProof (Maybe DiffSystem)
+proveDiffSystemDFS heuristic tactics ctxt =
+    prove
   where
     prove !depth sys =
         case rankDiffProofMethods (useHeuristic heuristic depth) tactics ctxt sys of
@@ -1108,7 +1035,7 @@ proveDiffSystemDFS heuristic tactics ctxt d0 sys0 =
           (method, (cases, _expl)):_ -> node method cases
       where
         node method cases =
-          LNode (DiffProofStep method ()) (M.map (prove (succ depth)) cases)
+          LNode (DiffProofStep method (Just sys)) (M.map (prove (succ depth)) cases)
 
 ------------------------------------------------------------------------------
 -- Pretty printing
@@ -1128,7 +1055,7 @@ prettyProofWith prettyStep prettyCase =
   where
     ppPrf (LNode ps cs) = ppCases ps (M.toList cs)
 
-    ppCases ps@(ProofStep Solved _) [] = prettyStep ps
+    ppCases ps@(ProofStep (Finished Solved) _) [] = prettyStep ps
     ppCases ps []                      = prettyCase ps (kwBy <> text " ")
                                            <> prettyStep ps
     ppCases ps [("", prf)]             = prettyStep ps $-$ ppPrf prf

--- a/lib/theory/src/Theory/Text/Parser/Proof.hs
+++ b/lib/theory/src/Theory/Text/Parser/Proof.hs
@@ -78,9 +78,9 @@ proofMethod = asum
   [ symbol "sorry"         *> pure (Sorry Nothing)
   , symbol "simplify"      *> pure Simplify
   , symbol "solve"         *> (SolveGoal <$> parens goal)
-  , symbol "contradiction" *> pure (Contradiction Nothing)
+  , symbol "contradiction" *> pure (Finished (Contradictory Nothing))
   , symbol "induction"     *> pure Induction
-  , symbol "UNFINISHABLE"  *> pure Unfinishable
+  , symbol "UNFINISHABLE"  *> pure (Finished Unfinishable)
   ]
 
 -- | Start parsing a proof skeleton.
@@ -99,7 +99,7 @@ proofSkeleton =
     solvedProof <|> finalProof <|> interProof
   where
     solvedProof =
-        symbol "SOLVED" *> pure (LNode (ProofStep Solved ()) M.empty)
+        symbol "SOLVED" *> pure (LNode (ProofStep (Finished Solved) ()) M.empty)
 
     finalProof = do
         method <- symbol "by" *> proofMethod

--- a/src/Main/Mode/Batch.hs
+++ b/src/Main/Mode/Batch.hs
@@ -40,6 +40,7 @@ import Theory.Constraint.System.Dot
 import Text.Dot qualified as D
 import Theory.Constraint.System.Graph.Graph
 import Theory.Constraint.System.JSON (sequentsToJSONPretty)
+import Theory.Constraint.Solver (ProofMethod(Finished))
 
 import ClosedTheory (prettyPrecomputation,prettyDiffPrecomputation)
 
@@ -279,9 +280,9 @@ run thisMode as
             -- | Collect all solved (i.e. a trace was found) systems of the theory along with their
             -- path in the proof.
             proofSystems :: IncrementalProof -> [(ProofPath, System)]
-            proofSystems (LNode (ProofStep Solved (Just rootSystem)) _) =  [([], rootSystem)]
-            proofSystems (LNode (ProofStep _ _) children) =
-              [(l : ls, system) | (l, subProof) <- M.toList children
+            proofSystems (LNode (ProofStep (Finished Solved) (Just rootSystem)) _) =  [([], rootSystem)]
+            proofSystems (LNode (ProofStep _ _) children) =  
+              [(l : ls, system) | (l, subProof) <- M.toList children 
                                 , (ls, system) <- proofSystems subProof ]
 
             -- | Make a label for use in the trace output out of all relevant information for a constraint system.


### PR DESCRIPTION
This PR essentially rewrites `execProofMethod` and, following from that, applies some other changes. Overall, this PR should be "idempotent", i.e., Tamarin should function exactly as before. I personally find the code cleaner than before, but this is a matter of taste.

The intention behind this PR is to factor out changes to Tamarin that I did as part of a research project with @cascremers. They are necessary for that project, but we would like to check that they indeed do not change Tamarin's behavior. But still, I think that some benefit to the added clarity of the code (more deletions than insertions).

Some notes on the changes:
- I added a new proof method `Finished Result` that replaces `Solved`, `Contradiction` and `Unfinishable`. I think it makes sense to reflect in the type system which kind of methods mean that no further proving needs to be done.
- I do not check in `execProofMethod` whether the applied method is valid in the given constraint system. In most cases, these checks are redundant because they come from the system. Instead, I implemented `checkAndExecProofMethod` that is now used whenever one must check validity, e.g., upon loading a theory.
- I deleted the `annotateWith(Diff)Systems` functions. They performed tasks fully redundant with `execProofMethod`. First, you would apply a proof method and delete the resulting constraint system, then you would annotate it again.
- I now always simplify after applying a proof method. This makes the every now and then appearing "simplify" steps obsolete. To maintain backwards compatibility, I do *not* anymore return `Nothing` when simplify results in the same constraint system in `execProofMethod`. If I were to do that, applying a redundant simplify step (e.g., while loading older proofs) would invalidated the proof.
- `execProofMethod` now checks for all ways in which a proof could be finished. Therefore, `applyProverAtPath` need not "guess" anymore which other provers we maybe should try to apply.

Fast regression tests pass in about the same time as before on my machine. Only difference is that there are slightly fewer steps which results from the now dropped `simplify` steps.

I'd appreciate a thorough review and am curious about any feedback!