### PR TITLE
Stop proving other branches when encountering Sorry

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -16,6 +16,7 @@ module Theory.Constraint.Solver.ProofMethod (
   -- * Proof methods
     CaseName
   , ProofMethod(..)
+  , isSorry
   , DiffProofMethod(..)
   , execProofMethod
   , execDiffProofMethod
@@ -196,6 +197,10 @@ data ProofMethod =
                                          -- the single formula constraint in
                                          -- the system.
   deriving( Eq, Ord, Show, Generic, NFData, Binary )
+
+isSorry :: ProofMethod -> Bool
+isSorry (Sorry _) = True
+isSorry _ = False
 
 -- | Sound transformations of diff sequents.
 data DiffProofMethod =


### PR DESCRIPTION
Improvement to #644. Previously, the new oracle-prover would only stop proving in the current branch of the proof tree when the oracle outputs nothing. Now, the prover will also stop proving on all subsequent branches to provide feedback to the user earlier. I am open to feedback whether my implementation using the state monad is maybe a tad to "clever."

Note: This changes behavior also in all other cases where (for whatever reason) `rankProofMethods` suggests to apply `Sorry`. I am quite certain, though, that this should only happen using my new oracle prover.

Suggestion is to rebase and merge.

Screenshot of new behavior:
![image](https://github.com/tamarin-prover/tamarin-prover/assets/9728715/bfeec675-b627-4b2f-872e-a1510dd26d94)