### PR TITLE
Cut proofs on sorry for new oracle-prover

### DIFF
--- a/lib/theory/src/Theory/Proof.hs
+++ b/lib/theory/src/Theory/Proof.hs
@@ -744,7 +744,7 @@ contradictionDiffProver = DiffProver $ \ctxt d sys prf ->
 -- Automatic Prover's
 ------------------------------------------------------------------------------
 
-data SolutionExtractor = CutDFS | CutBFS | CutSingleThreadDFS | CutNothing
+data SolutionExtractor = CutDFS | CutBFS | CutSingleThreadDFS | CutNothing | CutAfterSorry
     deriving( Eq, Ord, Show, Read, Generic, NFData, Binary )
 
 data AutoProver = AutoProver
@@ -790,6 +790,7 @@ runAutoProver aut@(AutoProver _ _  bound cut _) =
       CutBFS             -> cutOnSolvedBFS
       CutSingleThreadDFS -> cutOnSolvedSingleThreadDFS
       CutNothing         -> id
+      CutAfterSorry      -> cutAfterFirstSorry
 
     -- | The standard automatic prover that ignores the existing proof and
     -- tries to find one by itself.
@@ -812,6 +813,7 @@ runAutoDiffProver aut@(AutoProver _ _ bound cut _) =
       CutDFS             -> cutOnSolvedDFSDiff
       CutBFS             -> cutOnSolvedBFSDiff
       CutSingleThreadDFS -> cutOnSolvedSingleThreadDFSDiff
+      CutAfterSorry      -> cutAfterFirstSorryDiff
       CutNothing         -> id
 
     -- | The standard automatic prover that ignores the existing proof and
@@ -1039,6 +1041,33 @@ cutOnSolvedBFSDiff =
     checkLevel l prf@(LNode step cs)
       | isNothing (dpsInfo step) = return prf
       | otherwise                = LNode step <$> traverse (checkLevel (l-1)) cs
+
+cutAfterFirstSorry :: Proof (Maybe a) -> Proof (Maybe a)
+cutAfterFirstSorry = snd . go False
+  where
+    go :: Bool -> Proof (Maybe a) -> (Bool, Proof (Maybe a))
+    go _      n@(LNode (ProofStep (Sorry _) _) _)         = (True, n)
+    go abort  n@(LNode (ProofStep Solved _) _)            = (abort, n)
+    go abort  n@(LNode (ProofStep Unfinishable _) _)      = (abort, n)
+    go abort  n@(LNode (ProofStep (Contradiction _) _) _) = (abort, n)
+    go True     (LNode (ProofStep _ ann) _)               = (True, LNode (ProofStep (Sorry Nothing) ann) M.empty)
+    go False    (LNode r cs) =
+      let (abort, cs') = M.mapAccum go False cs
+      in (abort, LNode r cs')
+
+
+cutAfterFirstSorryDiff :: DiffProof (Maybe a) -> DiffProof (Maybe a)
+cutAfterFirstSorryDiff = snd . go False
+  where
+    go :: Bool -> DiffProof (Maybe a) -> (Bool, DiffProof (Maybe a))
+    go _      n@(LNode (DiffProofStep (DiffSorry _) _) _)     = (True, n)
+    go abort  n@(LNode (DiffProofStep DiffMirrored _) _)      = (abort, n)
+    go abort  n@(LNode (DiffProofStep DiffUnfinishable _) _)  = (abort, n)
+    go abort  n@(LNode (DiffProofStep DiffAttack _) _)        = (abort, n)
+    go True     (LNode (DiffProofStep _ ann) _)               = (True, LNode (DiffProofStep (DiffSorry Nothing) ann) M.empty)
+    go False    (LNode r cs) =
+      let (abort, cs') = M.mapAccum go False cs
+      in (abort, LNode r cs')
 
 -- | @proveSystemDFS rules se@ explores all solutions of the initial
 -- constraint system using a depth-first-search strategy to resolve the

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -761,7 +761,7 @@ getAutoProverR idx extractor bound quitOnEmpty =
   where
     adapt autoProver = autoProver
       { apBound = actualBound
-      , apCut = extractor
+      , apCut = if quitOnEmpty then CutAfterSorry else extractor
       , quitOnEmptyOracle = quitOnEmpty }
 
     withCommas = intersperse ", "


### PR DESCRIPTION
This PR improves upon #644 by cutting proofs after the first `Sorry` is encountered. This means that users will receive feedback earlier whenever their oracle returns nothing in a given case. Previously, the prover would try to prove all remaining branches before returning control to the user.