### PR TITLE
remove unuseful aes file

### DIFF
--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -650,6 +650,8 @@ instance Yesod WebUI where
   -- application is always served from the root of the server.
   approot = ApprootStatic T.empty
 
+  makeSessionBackend _ = return Nothing
+
   -- | The default layout for rendering.
   defaultLayout = defaultLayout'
 


### PR DESCRIPTION
I propose to remove the unuseful aes file, which is automatically created when we launch the app