### PR TITLE
Fix example sources lemma such that the OUT must occur before the IN

### DIFF
--- a/manual/code/NSLPK3.spthy
+++ b/manual/code/NSLPK3.spthy
@@ -89,14 +89,14 @@ lemma types [sources]:
        IN_R_1_ni( ni, m1) @ i
        ==>
        ( (Ex #j. KU(ni) @ j & j < i)
-       | (Ex #j. OUT_I_1( m1 ) @ j)
+       | (Ex #j. OUT_I_1( m1 ) @ j & j < i)
        )
     )
   & (All nr m2 #i.
        IN_I_2_nr( nr, m2) @ i
        ==>
        ( (Ex #j. KU(nr) @ j & j < i)
-       | (Ex #j. OUT_R_1( m2 ) @ j)
+       | (Ex #j. OUT_R_1( m2 ) @ j & j < i)
        )
     )
   "

--- a/manual/src/009_precomputation.md
+++ b/manual/src/009_precomputation.md
@@ -123,11 +123,11 @@ the raw sources.
 
 This lemma relates the point of instantiation to the point of sending by either
 the adversary or the communicating partner. In other words, it says that
-whenever the responder receives the first nonce, either the nonce was known to
-the adversary or the initiator sent the first message prior to that moment.
+whenever the responder receives the first nonce, then prior to that moment either
+the nonce was known to the adversary or the initiator had sent the first message.
 Similarly, the second part states that whenever the initiator receives the
-second message, either the adversary knew the corresponding nonce or the
-responder has sent the second message before.
+second message, then prior to that moment either the adversary knew the
+corresponding nonce or the responder had sent the second message.
 Generally, in a protocol with partial deconstructions left it is advisable to try if the problem
 can be solved by a sources lemma that considers where a term could be coming
 from.


### PR DESCRIPTION
It's written in the manual that this is the case, and --auto-sources generates sources lemmas of this form, but it was missing from this example. I've also reworded the manual entry slightly to make it a bit clearer.