### PR TITLE
Improving calculating abbreviations.

### DIFF
--- a/lib/term/src/Term/Term/Raw.hs
+++ b/lib/term/src/Term/Term/Raw.hs
@@ -40,6 +40,8 @@ module Term.Term.Raw (
     , isProperSubterm
     , replaceSubterm
     , replaceProperSubterm
+    , countSubterms
+    , countProperSubterms
 
     ) where
 
@@ -246,6 +248,13 @@ isSubterm t1 t2 = (t1 == t2) || isProperSubterm t1 t2
 isProperSubterm :: Eq a => Term a -> Term a -> Bool
 isProperSubterm t (viewTerm -> FApp _ ts) = any (isSubterm t) ts
 isProperSubterm _ _ = False
+
+countSubterms :: Eq a => Term a -> Term a -> Int
+countSubterms t1 t2 = if t1 == t2 then 1 else countProperSubterms t1 t2
+
+countProperSubterms :: Eq a => Term a -> Term a -> Int 
+countProperSubterms t (viewTerm -> FApp _ ts) = sum $ map (countSubterms t) ts
+countProperSubterms _ _ = 0
 
 -- | Replace all subterms of a term top-down according to the supplied replacement function.
 replaceSubterm :: (Term a -> Term a) -> Term a -> Term a

--- a/lib/theory/src/Theory/Constraint/System/Dot.hs
+++ b/lib/theory/src/Theory/Constraint/System/Dot.hs
@@ -164,7 +164,7 @@ renderLNFact fact = do
   (graph, _, _) <- ask
   let abbreviate = get ((L..) goAbbreviate gOptions) graph
       abbrevs = get gAbbreviations graph
-      replacedFact = applyAbbreviationsFact abbrevs fact
+      replacedFact = applyAbbreviationsFact (lookupAbbreviation abbrevs) fact
   if abbreviate 
     then return $ prettyLNFact replacedFact
     else return $ prettyLNFact fact


### PR DESCRIPTION
This changes the way abbreviations are weighted

We compute the weight only as screen size * occurrences now.
Additionally we keep track of the abbreviations that have already been generated so that we can
1. subtract a number of occurrences. If term B appears n times as a subterm of A and we make an abbreviation of A, then we tentatively subtract n occurrences from B, i.e. B's weight is reduced.
2. compute the screen size more accurrately. If term B appears as a subterm of A and we make an abbreviation of B, then when we next compute the screen size of A we use the abbreviation of B to get a more accurrate measurement.

This is not perfectly precise because future abbreviations are not considered. However, it seems to be good enough and it's easier than computing a global maximum of saved screen space by a fixed-point search.