### PR TITLE
Fix bug from issue 664

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -571,22 +571,22 @@ simpInjectiveFactEqMon = do
   --  :: (MonotonicBehaviour, (NodeId, LNTerm), (NodeId, LNTerm)) -> ([LNGuarded], [(NodeId, NodeId)])
   let simpSingle (behaviour, (i, s), (j, t)) = --trace (show ("simpSingle", behaviour, i, s, j, t)) $
          case behaviour of
-                                                Unspecified -> ([], [])
-                                                Unstable -> ([], [])
-                                                Decreasing -> simpSingle (Increasing, (j, s), (i, t))
-                                                StrictlyDecreasing -> simpSingle (StrictlyIncreasing, (j, s), (i, t))
-                                                Constant -> ([GAto $ EqE (lTermToBTerm s) (lTermToBTerm t) | s/=t], [])  -- (1)
-                                                StrictlyIncreasing ->
-                                                    ([GAto $ EqE (varTerm $ Free i) (varTerm $ Free j) | s==t, i/=j]  -- (2)
-                                                  ++ [gnotAtom $ EqE (lTermToBTerm s) (lTermToBTerm t) | alwaysBefore sys i j || alwaysBefore sys j i, i/=j, notIneq s t]   -- (4)
-                                                  -- ++ [GAto $ Subterm (lTermToBTerm s) (lTermToBTerm t) | alwaysBefore sys i j, i/=j, not $ triviallySmaller s t]   -- (6)
-                                                   , [(i, j) | triviallySmaller    s t, not $ alwaysBefore sys i j]   -- (3)
-                                                  ++ [(j, i) | triviallyNotSmaller s t, not $ alwaysBefore sys j i, ineq s t]) -- (5)
-                                                Increasing -> ([]--, [])
-                                                  --([ gdisj [--GAto $ Subterm (lTermToBTerm s) (lTermToBTerm t),
-                                                  --          GAto $ EqE (lTermToBTerm s) (lTermToBTerm t)]
-                                                  --  | alwaysBefore sys i j, i/=j, not $ triviallySmaller s t, s /= t]   -- (6.1)
-                                                  , snd $ simpSingle (StrictlyIncreasing, (i, s), (j, t)))
+            Unspecified -> ([], [])
+            Unstable -> ([], [])
+            Decreasing -> simpSingle (Increasing, (j, s), (i, t))
+            StrictlyDecreasing -> simpSingle (StrictlyIncreasing, (j, s), (i, t))
+            Constant -> ([GAto $ EqE (lTermToBTerm s) (lTermToBTerm t) | s/=t], [])  -- (1)
+            StrictlyIncreasing ->
+                ([GAto $ EqE (varTerm $ Free i) (varTerm $ Free j) | s==t, i/=j]  -- (2)
+              ++ [gnotAtom $ EqE (lTermToBTerm s) (lTermToBTerm t) | alwaysBefore sys i j || alwaysBefore sys j i, i/=j, notIneq s t]   -- (4)
+              -- ++ [GAto $ Subterm (lTermToBTerm s) (lTermToBTerm t) | alwaysBefore sys i j, i/=j, not $ triviallySmaller s t]   -- (6)
+                , [(i, j) | triviallySmaller    s t, not $ alwaysBefore sys i j]   -- (3)
+              ++ [(j, i) | triviallyNotSmaller s t, not $ alwaysBefore sys j i, ineq s t]) -- (5)
+            Increasing -> ([]--, [])
+              --([ gdisj [--GAto $ Subterm (lTermToBTerm s) (lTermToBTerm t),
+              --          GAto $ EqE (lTermToBTerm s) (lTermToBTerm t)]
+              --  | alwaysBefore sys i j, i/=j, not $ triviallySmaller s t, s /= t]   -- (6.1)
+              , snd $ simpSingle (StrictlyIncreasing, (i, s), (j, t)))
 
   -- generate and execute changes
   let (newFormulas, newLesses) = (concat *** concat) $ unzip $ map simpSingle (getPairs inj nodes)
@@ -606,17 +606,44 @@ simpInjectiveFactEqMon = do
       getPairs [] _ = []
       getPairs ((tag, behaviours):rest) nodes = paired ++ getPairs rest nodes
         where
-          getPairTerms :: LNTerm -> [LNTerm]
-          getPairTerms (viewTerm2 -> FPair t1 t2) = t1 : getPairTerms t2
-          getPairTerms t = [t]
+          -- Flatten a (n-1)-tuple by only expanding the right-hand side of the tuple
+          -- This function errors when n is bigger than the _length_ of the tuple
+          -- E.g., shapeTerm 2 <t1, t2> = [t1, t2]
+          -- E.g., shapeTerm 2 <<t1, t2>, t3> = [<t1, t2>, t3]
+          -- Note that the above list has only 2 elements as the first tuple is not flattened
+          -- E.g., shapeTerm 3 <t1, t2> throws an error
+          -- Note that this code is identical to existing code in `InjectiveFactInstances.hs`.
+          shapeTerm :: Int -> LNTerm -> [LNTerm]
+          shapeTerm x (viewTerm2 -> FPair t1 t2) | x>1 = t1 : shapeTerm (x-1) t2
+          shapeTerm x t | x>1 = error ("shapeTerm: the term (" ++ show t ++ ") does not have enough pairs."
+            ++ "\nOccured in fact: (" ++ show tag ++") with behavior " ++ show behaviours)
+          shapeTerm x t | x==1 = [t]
+          shapeTerm _ _ = error "shapeTerm: cannot take an integer with size less than 1"
 
+          -- Given an injective fact instance and the behaviour/shape of the corresponding FactTag
+          -- (bound by the behaviours variable introduced in 'getPairs'), return a tuple that contains
+          -- its _injective identitifer_ and 
+          -- E.g., For behaviour/shape = [[=, =]]
+          -- trimmedPairTerms S(~id, <a, b>) = (~id, [(=, a), (=, b)])
+          -- E.g., For behaviour/shape = [[=]]
+          -- trimmedPairTerms S(~id, <a, b>) = (~id, [(=, <a, b>)])
+          -- E.g., For behaviour/shape = [[=, <]]
+          -- trimmedPairTerms S(~id, <<a, b>, c>) = (~id, [(=, <a, b>), (<, c)])
           trimmedPairTerms :: LNFact -> (LNTerm, [(MonotonicBehaviour, LNTerm)])
-          trimmedPairTerms (factTerms -> firstTerm:terms) = (firstTerm, concat $ zipWith zip behaviours (map getPairTerms terms))  -- zip automatically orients itself on the shorter list
+          trimmedPairTerms (factTerms -> firstTerm:terms) = (firstTerm, concat $ zipWith (\behaviour term -> zip behaviour (shapeTerm (length behaviour) term)) behaviours terms )
           trimmedPairTerms _ = error "a fact with no terms cannot be injective"
 
+          -- For each rule instance, filter its rhs for the current injective fact 'tag'
+          -- and compute the pairs via 'trimmedPairTerms'
           behaviourTerms :: M.Map NodeId [(LNTerm, [(MonotonicBehaviour, LNTerm)])]
           behaviourTerms = M.map (map trimmedPairTerms . filter (\x -> factTag x == tag) . get rPrems) nodes  --all node premises with the matching tag
 
+          -- Returns a list of pairs (i, s), (j, t) together with the behaviour b
+          -- between s and t. i and j are the time points where the fact instances
+          -- occured that contain s and t respectively.
+          -- Example: For an injective fact S with behaviour/shape [[=, <]],
+          -- S(~id, <a, b>) @ i and S(~id, <c, d>) @ j, we have
+          -- paired = [(=, (i, a), (j, c)), (<, (i, b), (j, d))]
           paired :: [(MonotonicBehaviour, (NodeId, LNTerm), (NodeId, LNTerm))]
           paired = [(b, (i, s), (j,t)) |
             (i, l1) <- M.toList behaviourTerms,

--- a/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
+++ b/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+
 -- |
 -- Copyright   : (c) 2012 Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -11,47 +13,41 @@
 -- instances, i.e., fact whose instances never occur more than once in a
 -- state. We use this information to reason about protocols that exploit
 -- exclusivity of linear facts.
-module Theory.Tools.InjectiveFactInstances (
+module Theory.Tools.InjectiveFactInstances
+  ( -- * Computing injective fact instances.
+    MonotonicBehaviour (..),
+    simpleInjectiveFactInstances,
+  )
+where
 
-  -- * Computing injective fact instances.
-  MonotonicBehaviour(..)
-  , simpleInjectiveFactInstances
-  ) where
-
-import           Control.Monad.Fresh
-import           Control.DeepSeq
-import           Control.Applicative (empty)
-
-import           GHC.Generics        (Generic)
-
-import           Data.Label          as L
-import qualified Data.Set            as S
-import qualified Data.Map            as M
-import           Data.List
-import           Data.Maybe
-import           Data.Binary
-
-import           Theory.Model
-
-import           Safe                (headMay)
+import Control.Applicative (empty)
+import Control.DeepSeq
+import Control.Monad.Fresh
+import Data.Binary
+import Data.Label as L
+import Data.List
+import Data.Map qualified as M
+import Data.Maybe
+import Data.Set qualified as S
+import GHC.Generics (Generic)
+import Safe (headMay)
+import Theory.Model
 
 -- import           Debug.Trace
 
 -- unspecified = there is no rule using this fact
 -- unstable = increasing and decreasing or not at all related inputs and outputs
 data MonotonicBehaviour = Constant | Increasing | Decreasing | StrictlyIncreasing | StrictlyDecreasing | Unstable | Unspecified
-  deriving( Eq, Ord, Generic, NFData, Binary )
+  deriving (Eq, Ord, Generic, NFData, Binary)
 
 instance Show MonotonicBehaviour where
-    show Constant = "="
-    show Increasing = "≤"
-    show Decreasing = "≥"
-    show StrictlyIncreasing = "<"
-    show StrictlyDecreasing = ">"
-    show Unstable = "."
-    show Unspecified = "?"
-
-
+  show Constant = "="
+  show Increasing = "≤"
+  show Decreasing = "≥"
+  show StrictlyIncreasing = "<"
+  show StrictlyDecreasing = ">"
+  show Unstable = "."
+  show Unspecified = "?"
 
 -- | Compute a simple under-approximation to the set of facts with injective
 -- instances. A fact-tag is has injective instances, if there is no state of
@@ -70,55 +66,75 @@ instance Show MonotonicBehaviour where
 -- - Increasing/Decreasing according to `elemNotBelowReducible` and equality
 -- - Strictly Increasing/Decreasing according to `elemNotBelowReducible`
 --
--- Positions can also be inside tuples if these tuples are always explicitly used in the rules.
---
---   intersection-merge should be done with [4,1] representing [4,1,0] as well (as a kind of hierarchy)
---   i.e., { [4,1] } ∩ { [4,1,2] } = { [4,1,2] }
---   well, that intersection style probably does not work for subterms interfering with the pairs...
+-- We also try to detect these positions inside of tuples that occur at
+-- the top-level of an injective fact. For instance,
+-- if injective fact S is used like this: [S(~id, <a, b>)] --> [S(~id, <a, a>)]
+-- position two of S is not constant but position 2.2 is.
+
+-- To detect this, one needs to compute the _shape_ of a term at position i for
+-- each protocol rule (modulo E) by checking how it is pattern-matched inside of
+-- each rule. A natural choice would be to represent this shape via a binary tree
+-- that matches the tuples shape, however, we choose to implement an
+-- under-approximation of this by only flattening tuples to the right.
+-- E.g., <<a, b>, c> gets flattened into [<a, b>, c]. This allows us to
+-- detect constant/increasing etc. positions for the most common use case:
+-- a tuple that contains 'dynamic' state and is only expanded to the right.
+-- I.e., [S(~id, <a, b>)] --> [S(~id, <a, b, c>)]. In this example, the current
+-- implement can still detect that 'a' is constant, but not 'b'.
 --
 -- We exclude facts that are not copied in a rule, as they are already handled
 -- properly by the naive backwards reasoning.
 simpleInjectiveFactInstances :: FunSig -> [ProtoRuleE] -> S.Set (FactTag, [[MonotonicBehaviour]])
 simpleInjectiveFactInstances reducible rules = S.fromList $ do
-    tag <- M.keys candidates
-    let resultTag = combineAll (map (getMaybeEqStrict tag) rules) tag
-    case resultTag of
-      Just behaviours -> return (tag, behaviours)  -- remove the 0-position from eqPos as this is the ~fr
-      Nothing -> empty
+  tag <- M.keys candidates
+  let resultTag = combineAll (map (getMaybeEqStrict tag) rules) tag
+  case resultTag of
+    Just behaviours -> return (tag, behaviours) -- remove the 0-position from eqPos as this is the ~fr
+    Nothing -> empty
   where
-
+    -- Flatten only the right-hand side of a tuple
     getPairTerms :: LNTerm -> [LNTerm]
     getPairTerms (viewTerm2 -> FPair t1 t2) = t1 : getPairTerms t2
     getPairTerms t = [t]
 
+    -- Compute the potentially injective facts and their _shape_.
+    -- The shape `s` of a FactTag is a list of lists where the inner list
+    -- `s[i]` describes the shape of the term at position `i+1` in the fact.
+    -- The shape of a term is the right-handed flattening of it as computed
+    -- by 'getPairTerms'. E.g., shape (Var x) = [x], shape (<t1, t2>) = [t1, t2]
+    -- and shape (<<t1, t2>, t3>) = [<t1, t2>, t3].
+    -- Intuitively, if `length shape' = n, then `shape' can be unfolded to the
+    -- right n - 1 times.
     candidates :: M.Map FactTag [[MonotonicBehaviour]]
     candidates = M.fromListWith combineShapes $ do
-        ru  <- rules
-        conc <- L.get rConcs ru
-        let tag = factTag conc
-        guard $    (factTagMultiplicity tag == Linear)
-                && (tag `elem` (factTag <$> L.get rPrems ru))
-        prem <- L.get rPrems ru
-        guard (factTag prem == tag)
-        guard (not (null $ factTerms conc))
-        return (tag, combineShapes (getShape conc) (getShape prem))
-          where
+      ru <- rules
+      conc <- L.get rConcs ru
+      let tag = factTag conc
+      guard $
+        (factTagMultiplicity tag == Linear)
+          && (tag `elem` (factTag <$> L.get rPrems ru))
+      prem <- L.get rPrems ru
+      guard (factTag prem == tag)
+      guard (not (null $ factTerms conc))
+      return (tag, combineShapes (getShape conc) (getShape prem))
+      where
+        -- Compute the default shape of the fact. I.e., a correct shape
+        -- with unspecified behaviour.
+        getShape :: LNFact -> [[MonotonicBehaviour]]
+        getShape (factTerms -> _ : terms) = map (flip replicate Unspecified . length . getPairTerms) terms
+        getShape _ = error "a fact without terms cannot be injective"
 
-            getShape :: LNFact -> [[MonotonicBehaviour]]
-            getShape (factTerms->_:terms) = map (flip replicate Unspecified . length . getPairTerms) terms
-            getShape _ = error "a fact without terms cannot be injective"
-
-            combineShapes :: [[MonotonicBehaviour]] -> [[MonotonicBehaviour]] -> [[MonotonicBehaviour]]
-            combineShapes behaviours behaviours1 = map (map fst) $ zipWith zip behaviours behaviours1  -- zip automatically orients itself on the shorter list
-
-
+        -- Combining two shapes is simply taking the shorter list at each position
+        combineShapes :: [[MonotonicBehaviour]] -> [[MonotonicBehaviour]] -> [[MonotonicBehaviour]]
+        combineShapes behaviours behaviours1 = map (map fst) $ zipWith zip behaviours behaviours1 -- zip automatically orients itself on the shorter list
 
     combineAll :: [Maybe [[MonotonicBehaviour]]] -> FactTag -> Maybe [[MonotonicBehaviour]]
-    combineAll list _ | any isNothing list = Nothing  -- if any of the elements say that the tag is not injective, then return nothing
-    combineAll (Just behaviours : Just behaviours1 : rest) tag = --trace (show("combineAll", behaviours, behaviours1, (map (map combine) $ zipWith zip behaviours behaviours1))) $
-                                                                 combineAll (Just (map (map combine) $ zipWith zip behaviours behaviours1):rest) tag
+    combineAll list _ | any isNothing list = Nothing -- if any of the elements say that the tag is not injective, then return nothing
+    combineAll (Just behaviours : Just behaviours1 : rest) tag =
+      -- trace (show("combineAll", behaviours, behaviours1, (map (map combine) $ zipWith zip behaviours behaviours1))) $
+      combineAll (Just (map (map combine) $ zipWith zip behaviours behaviours1) : rest) tag
     combineAll [x] _ = x
-    combineAll [] tag = M.lookup tag candidates  --start with the empty shape of Unspecified
+    combineAll [] tag = M.lookup tag candidates -- start with the empty shape of Unspecified
     combineAll _ _ = error "the haskell compiler is too dumb to know that the pattern matching is actually exhaustive"
 
     combine :: (MonotonicBehaviour, MonotonicBehaviour) -> MonotonicBehaviour
@@ -129,65 +145,68 @@ simpleInjectiveFactInstances reducible rules = S.fromList $ do
     combine (x, Unspecified) = x
     combine (StrictlyIncreasing, y) | y `elem` [Increasing, Constant] = Increasing
     combine (StrictlyDecreasing, y) | y `elem` [Decreasing, Constant] = Decreasing
-    combine (StrictlyIncreasing, _) = Unstable  -- with [Strictly]Decreasing
-    combine (StrictlyDecreasing, _) = Unstable  -- with [Strictly]Increasing
+    combine (StrictlyIncreasing, _) = Unstable -- with [Strictly]Decreasing
+    combine (StrictlyDecreasing, _) = Unstable -- with [Strictly]Increasing
     combine (Increasing, Decreasing) = Unstable
     combine (Increasing, Constant) = Increasing
     combine (Decreasing, Constant) = Decreasing
     combine (x, y) = combine (y, x)
 
-    -- | returns Nothing if the fact $tag$ violates injectivity guidelines in rule $ru$
-    -- otherwise, two sets of positions are returned
-    --   - the first  to indicate where the arguments do not change
-    --   - the second to indicate where the arguments are strictly increasing
-    -- all conclusions of the given FactTag have to fulfill that
+    -- Returns Nothing if the fact $tag$ violates injectivity guidelines in rule $ru$
+    -- If the fact is injective, it computes the shape/behaviour of the fact.
     getMaybeEqStrict :: FactTag -> ProtoRuleE -> Maybe [[MonotonicBehaviour]]
-    getMaybeEqStrict tag ru = --trace (show ("getMaybeEqStrict", tag, ru, combineAll (map getMaybeEqMonConclusion copies) tag)) $
-        combineAll (map getMaybeEqMonConclusion copies) tag
+    getMaybeEqStrict tag ru =
+      -- trace (show ("getMaybeEqStrict", tag, ru, combineAll (map getMaybeEqMonConclusion copies) tag)) $
+      combineAll (map getMaybeEqMonConclusion copies) tag
       where
-        prems              = L.get rPrems ru
-        copies             = filter ((tag ==) . factTag) (L.get rConcs ru)
-        firstTerm          = headMay . factTerms
+        prems = L.get rPrems ru
+        copies = filter ((tag ==) . factTag) (L.get rConcs ru)
+        firstTerm = headMay . factTerms
 
         -- duplicateFirstTerms are the first terms that appear at least twice - i.e. the corresponding fact cannot be injective
         allFirstTerms = sort $ mapMaybe firstTerm copies
-        duplicateFirstTerms = S.fromList [a | (a, b) <- zip (drop 1 allFirstTerms) (take (length allFirstTerms - 1) allFirstTerms), a==b]
+        duplicateFirstTerms = S.fromList [a | (a, b) <- zip (drop 1 allFirstTerms) (take (length allFirstTerms - 1) allFirstTerms), a == b]
 
-        -- behaves like allCopiesGuarded, but specific to one conclusion instead of all conclusions
+        -- For a given fact, computes whether it is injective and, if so, computes its shape/behaviour in the rule
         getMaybeEqMonConclusion :: LNFact -> Maybe [[MonotonicBehaviour]]
         getMaybeEqMonConclusion faConc = case firstTerm faConc of
-            Nothing    -> Nothing  -- cannot be an injective fact if it has no arguments
-            Just tConc | tConc `S.member` duplicateFirstTerms -> Nothing  -- violating (2)
-            Just tConc | freshFact tConc `elem` prems -> M.lookup tag candidates  -- applying (2)(a)
-            Just tConc -> case getPrem tConc of
-              Nothing -> Nothing  -- violating (2)(b)
-              Just faPrem -> Just behaviours
-                where
-                  shape = fromJust $ M.lookup tag candidates
-                  
-                  shapeTerm :: LNTerm -> Int -> [LNTerm]
-                  shapeTerm (viewTerm2 -> FPair t1 t2) x | x>1 = t1 : shapeTerm t2 (x-1)
-                  shapeTerm _ x | x>1 = error "shapeTerm: the term does not have enough pairs"
-                  shapeTerm t x | x==1 = [t]
-                  shapeTerm _ _ = error "shapeTerm: cannot take an integer with size less than 1" 
-                  
-                  trimmedPairTerms :: LNFact -> [[LNTerm]]
-                  trimmedPairTerms (factTerms->_:terms) = zipWith shapeTerm terms (map length shape)
-                  trimmedPairTerms _ = error "a fact with no terms cannot be injective"
+          Nothing -> Nothing -- cannot be an injective fact if it has no arguments
+          Just tConc | tConc `S.member` duplicateFirstTerms -> Nothing -- violating (2)
+          Just tConc | freshFact tConc `elem` prems -> M.lookup tag candidates -- applying (2)(a)
+          Just tConc -> case getPrem tConc of
+            Nothing -> Nothing -- violating (2)(b)
+            Just faPrem -> Just behaviours
+              where
+                -- The default shape for this candidate
+                shape = fromJust $ M.lookup tag candidates
 
-                  zipped = zipWith zip (trimmedPairTerms faPrem) (trimmedPairTerms faConc)
+                -- Unfold the tuple to the right N -1 times.
+                shapeTerm :: LNTerm -> Int -> [LNTerm]
+                shapeTerm (viewTerm2 -> FPair t1 t2) x | x > 1 = t1 : shapeTerm t2 (x - 1)
+                shapeTerm _ x | x > 1 = error "shapeTerm: the term does not have enough pairs"
+                shapeTerm t x | x == 1 = [t]
+                shapeTerm _ _ = error "shapeTerm: cannot take an integer with size less than 1"
 
-                  getBehaviour :: (LNTerm, LNTerm) -> MonotonicBehaviour
-                  getBehaviour (t1, t2) | t1 == t2 = Constant
-                  getBehaviour (t1, t2) | elemNotBelowReducible reducible t1 t2 = StrictlyIncreasing
-                  getBehaviour (t1, t2) | elemNotBelowReducible reducible t2 t1 = StrictlyDecreasing
-                  getBehaviour _ = Unstable
+                -- Unfold each term according to the default shape
+                trimmedPairTerms :: LNFact -> [[LNTerm]]
+                trimmedPairTerms (factTerms -> _ : terms) = zipWith shapeTerm terms (map length shape)
+                trimmedPairTerms _ = error "a fact with no terms cannot be injective"
 
-                  behaviours = --trace (show("zipped,final", zipped, map (map getBehaviour) zipped)) $
-                               map (map getBehaviour) zipped
+                -- Zip the matching terms from premise instance and conclusion instance
+                zipped = zipWith zip (trimmedPairTerms faPrem) (trimmedPairTerms faConc)
+
+                -- Compute the behaviour for two matching terms as computed by zip
+                getBehaviour :: (LNTerm, LNTerm) -> MonotonicBehaviour
+                getBehaviour (t1, t2) | t1 == t2 = Constant
+                getBehaviour (t1, t2) | elemNotBelowReducible reducible t1 t2 = StrictlyIncreasing
+                getBehaviour (t1, t2) | elemNotBelowReducible reducible t2 t1 = StrictlyDecreasing
+                getBehaviour _ = Unstable
+
+                behaviours =
+                  -- trace (show("zipped,final", zipped, map (map getBehaviour) zipped)) $
+                  map (map getBehaviour) zipped
 
         -- get the corresponding fact in the premise
         getPrem tConc = case (`filter` prems) (\faPrem -> factTag faPrem == tag && Just tConc == firstTerm faPrem) of
-            [g] -> Just g
-            _   -> Nothing  -- if there are multiple such guards, the rule cannot be executed
-
+          [g] -> Just g
+          _ -> Nothing -- if there are multiple such guards, the rule cannot be executed


### PR DESCRIPTION
This PR fixes #664 by making the unfolding logic used during constraint solving consistent with the unfolding logic during computation of the behavior of positions in injective fact instances. As you can see below, the minimal example from #664 is now verifying again.

![Screenshot from 2024-07-10 16-46-41](https://github.com/tamarin-prover/tamarin-prover/assets/44230004/a1de48cc-a451-47cc-8712-eed28b9f115e)

### Changes to `InjectiveFactInstances.hs`
Here, I only added a few comments documenting the code and auto-formatted the file.

### Changes to `Simplify.hs`
Here, I made the unfolding logic consistent with the unfolding logic from `InjectiveFactInstances.hs` and added quite a few comments explaining what is going on. See lines 609 - 633 for the actual fix of the bug.

### Further Notes
To fix the bug as quickly as possible, I simply copied the `shapeTerm` function from `InjectiveFactInstances.hs` to `Simplify.hs`. While this is bad practice due to code reuse and the potential that the two implementations go out of sync, I don't believe that exporting `shapeTerm` from `InjectiveFactInstances.hs` is a much better option. After all, it is a very specific function that errors when the invariants on its arguments are not met.

I believe this bug could have been prevented by using data structures that are more resistant to misuse. Currently, the behavior/shape of a term is a list you get by flattening tuples and their right-hand sides, and this list has the type `[MonotonicBehaviour]`. The shape/behavior of a fact is simply `[[MonotonicBehaviour]]` where the first entry corresponds to the second term of the fact. Since there is no connection between the behavior/shape and the fact/term they were computed for, it is very easy to misuse them or use them in the wrong way.

@felixlinker requested a feature regarding injective facts in #627. If there ever is a rewrite of the injective fact logic, the current data structures should definitely be reworked. Another potential feature is the complete unfolding of tuples. I.e., also the left-hand side of a tuple should be further investigated for its behavior.

Regarding a regression test: I've read the _documentation_ on how to add one, and it was not clear to me. I'll add one later this week with @cascremers .