### PR TITLE
Add Maude version 3.4 as supported

### DIFF
--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -173,7 +173,7 @@ ensureMaude as = do
 
     --  Maude versions prior to 2.7.1 are no longer supported,
     --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1"]
+    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1", "3.4"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
I would like to add support for [Maude version 3.4](https://github.com/maude-lang/Maude/releases/tag/Maude3.4), which was recently released. I am not aware of any breaking changes.

I am currently updating the Nixos Maude package to 3.4, and this currently breaks the tamarin-prover Nixos package built. See here: https://github.com/NixOS/nixpkgs/pull/331988.
Thus, updating and releasing a new package for Nixos would be greatly appreciated.

Running the regressions tests with Maude 3.4 seems fine:

```
❯ maude
                     \||||||||||||||||||/
                   --- Welcome to Maude ---
                     /||||||||||||||||||\
             Maude 3.4 built: Mar 19 2024 22:43:00
             Copyright 1997-2024 SRI International
                   Sun Aug  4 21:24:12 2024
Maude> q
Bye.
❯ python3 regressionTests.py
running 'stack install' ...
running 'make -j 1 fast-case-studies FAST=y 2>/dev/null' ...

--------------------------------------------------------------------------------

The total amount of time  changed from 548s to 242s - this is 44%
The total amount of steps did not change
The rules did not change
The functions did not change
The builtins did not change
The config blocks did not change
The equations did not change
The macros did not change
The warnings did not change

Time elapsed: 0:04:10s
❯
```
