### PR TITLE
MANUAL: Uncomment offending option in latex template

### DIFF
--- a/manual/templates/template.latex
+++ b/manual/templates/template.latex
@@ -13,7 +13,7 @@
 \usepackage{fvextra}
 \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\\\\{\\}, breaklines, breaknonspaceingroup, breakanywhere}
 \fvset{breaklines}
-\fvset{breaknonspaceingroup}
+% \fvset{breaknonspaceingroup}
 \fvset{breakanywhere}
 
 \newcommand\blankpage{%


### PR DESCRIPTION
Deployment fails in compiling the PDF manual:

> Package keyval Error: breaknonspaceingroup undefined.

Which was introduced in https://github.com/tamarin-prover/tamarin-prover/pull/677 and works locally for me.

I do not find this issue online; the latest version of the package does not mention removal and locally it works even if I update MacTeX. However, removing this option results in an okay PDF, so let's try this.

If somebody known the right option in the latest fvextra package, please chime in. This option is for compatability with pandoc (ha!) and allows breaking within macros, according to the manual.