### PR TITLE
Lemma editing in the GUI

### DIFF
--- a/examples/features/multiset/counter.spthy
+++ b/examples/features/multiset/counter.spthy
@@ -35,4 +35,3 @@ lemma lesser_senc_secret[use_induction]:
       ==> (#i < #j | Ex z. y + z = x)"
 
 end
-

--- a/lib/accountability/src/Accountability/Generation.hs
+++ b/lib/accountability/src/Accountability/Generation.hs
@@ -27,7 +27,7 @@ import           Theory.Tools.Wellformedness (WfErrorReport)
 -- | Create a lemma from a formula with quantifier. Copies accLemma's name (plus suffix) and attributes.
 toLemma :: AccLemma -> TraceQuantifier -> String -> SyntacticLNFormula -> ProtoLemma SyntacticLNFormula ProofSkeleton
 toLemma accLemma quantifier suffix formula =
-        skeletonLemma (L.get aName accLemma ++ suffix) (L.get aAttributes accLemma) quantifier formula (unproven ())
+        skeletonLemma (L.get aName accLemma ++ suffix) "generation" False (L.get aAttributes accLemma) quantifier formula (unproven ())
 
 -- | Quantify the given variables
 quantifyVars :: ((String, LSort) -> LVar -> SyntacticLNFormula -> SyntacticLNFormula) -> [LVar] -> SyntacticLNFormula -> SyntacticLNFormula

--- a/lib/theory/src/Items/LemmaItem.hs
+++ b/lib/theory/src/Items/LemmaItem.hs
@@ -47,6 +47,8 @@ data TraceQuantifier = ExistsTrace | AllTraces
 -- together with a proof of its correctness.
 data ProtoLemma f p = Lemma
        { _lName            :: String
+       , _lPlaintext       :: String
+       , _lModified        :: Bool
        , _lTraceQuantifier :: TraceQuantifier
        , _lFormula         :: f
        , _lAttributes      :: [LemmaAttribute]
@@ -85,6 +87,12 @@ instance HasField "lName" (ProtoLemma f p) String where
 instance HasField "lName" (DiffLemma p) String where
   getField = _lDiffName
 
+type HasLemmaPlaintext l = HasField "lPlaintext" l String
+
+instance HasField "lPlaintext" (ProtoLemma f p) String where
+  getField = _lPlaintext
+
+
 type HasLemmaAttributes l = HasField "lAttributes" l [LemmaAttribute]
 
 instance HasField "lAttributes" (ProtoLemma f p) [LemmaAttribute] where
@@ -97,13 +105,13 @@ instance HasField "lAttributes" (DiffLemma p) [LemmaAttribute] where
 ------------
 
 instance Functor Lemma where
-    fmap f (Lemma n qua fm atts prf) = Lemma n qua fm atts (f prf)
+    fmap f (Lemma n p m qua fm atts prf) = Lemma n p m qua fm atts (f prf)
 
 instance Foldable Lemma where
     foldMap f = f . L.get lProof
 
 instance Traversable Lemma where
-    traverse f (Lemma n qua fm atts prf) = Lemma n qua fm atts <$> f prf
+    traverse f (Lemma n p m qua fm atts prf) = Lemma n p m qua fm atts <$> f prf
 
 instance Functor DiffLemma where
     fmap f (DiffLemma n atts prf) = DiffLemma n atts (f prf)

--- a/lib/theory/src/Lemma.hs
+++ b/lib/theory/src/Lemma.hs
@@ -164,5 +164,4 @@ prettyDiffLemma ppPrf lem =
 prettyTraceQuantifier :: Document d => TraceQuantifier -> d
 prettyTraceQuantifier ExistsTrace = text "exists-trace"
 prettyTraceQuantifier AllTraces   = text "all-traces"
-
 -- FIXME: Sort instances into the right files

--- a/lib/theory/src/OpenTheory.hs
+++ b/lib/theory/src/OpenTheory.hs
@@ -146,7 +146,7 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
     runMaude   = (`runReader` hnd)
 
     -- searching for the lemma
-    lemma (LemmaItem (Lemma name _ _ _ _)) | name == lemmaName = True
+    lemma (LemmaItem (Lemma name _ _ _ _ _ _)) | name == lemmaName = True
     lemma _                                                    = False
 
     -- build the lemma

--- a/lib/theory/src/Prover.hs
+++ b/lib/theory/src/Prover.hs
@@ -454,7 +454,7 @@ openDiffTheory :: ClosedDiffTheory -> OpenDiffTheory
 openDiffTheory  (DiffTheory n f h t sig c1 c2 c3 c4 items opts sapic) =
     -- We merge duplicate rules if they were split into variants
     DiffTheory n f h t (toSignaturePure sig) (openRuleCache c1) (openRuleCache c2) (openRuleCache c3) (openRuleCache c4)
-      (mergeOpenProtoRulesDiff $ map (mapDiffTheoryItem id (\(x, y) -> (x, (openProtoRule y))) (\(DiffLemma s a p) -> (DiffLemma s a (incrementalToSkeletonDiffProof p))) (\(x, Lemma a b c d e) -> (x, Lemma a b c d (incrementalToSkeletonProof e)))) items)
+      (mergeOpenProtoRulesDiff $ map (mapDiffTheoryItem id (\(x, y) -> (x, (openProtoRule y))) (\(DiffLemma s a p) -> (DiffLemma s a (incrementalToSkeletonDiffProof p))) (\(x, Lemma a p m b c d e) -> (x, Lemma a p m b c d (incrementalToSkeletonProof e)))) items)
       opts sapic
 
 ------------------------------------------------------------------------------

--- a/lib/theory/src/Theory.hs
+++ b/lib/theory/src/Theory.hs
@@ -78,6 +78,7 @@ module Theory (
   , lFormula
   , lAttributes
   , lProof
+  , lPlaintext
   , aName
   , aAttributes
   , aCaseIdentifiers
@@ -135,6 +136,8 @@ module Theory (
   , addTactic
   , addRestriction
   , addLemma
+  , addLemmaAtIndex
+  , modifyLemma
   , addAccLemma
   , addCaseTest
   , addRestrictionDiff
@@ -148,6 +151,8 @@ module Theory (
   , filterLemma
   , removeDiffLemma
   , lookupLemma
+  , lookupLemmaIndex
+  , getLemmaPreItems
   , lookupDiffLemma
   , lookupAccLemma
   , lookupCaseTest
@@ -228,7 +233,8 @@ module Theory (
 
   , getSource
   , getDiffSource
-
+  -- ** Alice
+  , Theory
   -- ** Proving
   , ProofSkeleton
   , DiffProofSkeleton
@@ -280,7 +286,6 @@ module Theory (
 import           Prelude                             hiding (id, (.))
 
 --import           GHC.Generics                        (Generic)
-
 -- import           Data.Typeable
 --import           Data.Binary
 --import           Data.List

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -195,6 +195,7 @@ data ProofMethod =
   | Induction                            -- ^ Use inductive strengthening on
                                          -- the single formula constraint in
                                          -- the system.
+  | Invalidated                          -- ^ mark as invalidated as a result of editing other lemmas
   deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Sound transformations of diff sequents.
@@ -259,6 +260,7 @@ execProofMethod ctxt method sys =
         Contradiction _
           | null (contradictions ctxt sys)     -> Nothing
           | otherwise                          -> Just M.empty
+        Invalidated                            -> Nothing
   where
     -- at this point it is safe to remove the free substitution, as all
     -- systems have it fully applied (by the virtue of a call to
@@ -1148,6 +1150,7 @@ smartDiffRanking ctxt sys =
 -- | Pretty-print a proof method.
 prettyProofMethod :: HighlightDocument d => ProofMethod -> d
 prettyProofMethod method = case method of
+    Invalidated          -> lineComment_ "proof may have been invalidated by editing a reuse lemma above. You should "
     Solved               -> keyword_ "SOLVED" <-> lineComment_ "trace found"
     Unfinishable         -> keyword_ "UNFINISHABLE" <-> lineComment_ "reducible operator in subterm"
     Induction            -> keyword_ "induction"

--- a/lib/theory/src/Theory/Model/Formula.hs
+++ b/lib/theory/src/Theory/Model/Formula.hs
@@ -508,3 +508,4 @@ prettyLNFormula fm =
 prettySyntacticLNFormula :: HighlightDocument d => SyntacticLNFormula -> d
 prettySyntacticLNFormula fm =
     Precise.evalFresh (prettyLFormula prettySyntacticNAtom fm) (avoidPrecise fm)
+

--- a/lib/theory/src/Theory/Proof.hs
+++ b/lib/theory/src/Theory/Proof.hs
@@ -72,6 +72,7 @@ module Theory.Proof (
   , focusDiff
   , checkAndExtendProver
   , checkAndExtendDiffProver
+  , checkProof
   , replaceSorryProver
   , replaceDiffSorryProver
   , contradictionProver
@@ -393,9 +394,12 @@ data ProofStatus =
        | TraceFound         -- ^ There is an annotated solved step
        | UnfinishableProof  -- ^ The proof cannot be finished (due to reducible operators in subterms)
                             --   i.e. all ends are either Completed or Unfinishable (if a trace is found, then the status is TraceFound)
+       | InvalidatedProof   -- ^ The proof has been Invalidated (eg. by editing a reuse lemma)
     deriving ( Show, Generic, NFData, Binary, Eq )
 
 instance Semigroup ProofStatus where
+    InvalidatedProof <> _                  = InvalidatedProof
+    _ <> InvalidatedProof                  = InvalidatedProof
     TraceFound <> _                        = TraceFound
     _ <> TraceFound                        = TraceFound
     IncompleteProof <> _                   = IncompleteProof
@@ -416,6 +420,7 @@ proofStepStatus (ProofStep _            Nothing ) = UndeterminedProof
 proofStepStatus (ProofStep Solved       (Just _)) = TraceFound
 proofStepStatus (ProofStep Unfinishable (Just _)) = UnfinishableProof
 proofStepStatus (ProofStep (Sorry _)    (Just _)) = IncompleteProof
+proofStepStatus (ProofStep Invalidated  (Just _)) = InvalidatedProof
 proofStepStatus (ProofStep _            (Just _)) = CompleteProof
 
 -- | The status of a 'DiffProofStep'.
@@ -1175,6 +1180,7 @@ showProofStatus ExistsSomeTrace TraceFound        = "verified"
 showProofStatus _               UnfinishableProof = "analysis cannot be finished (reducible operators in subterms)"
 showProofStatus _               IncompleteProof   = "analysis incomplete"
 showProofStatus _               UndeterminedProof = "analysis undetermined"
+showProofStatus _               InvalidatedProof  = "proof has been invalidated"
 
 -- | Convert a proof status to a readable string.
 showDiffProofStatus :: ProofStatus -> String
@@ -1183,6 +1189,7 @@ showDiffProofStatus CompleteProof     = "verified"
 showDiffProofStatus UnfinishableProof = "analysis cannot be finished (reducible operators in subterms)"
 showDiffProofStatus IncompleteProof   = "analysis incomplete"
 showDiffProofStatus UndeterminedProof = "analysis undetermined"
+showDiffProofStatus InvalidatedProof  = "proof has been invalidated" 
 
 -- Instances
 --------------------

--- a/lib/theory/src/Theory/ProofSkeleton.hs
+++ b/lib/theory/src/Theory/ProofSkeleton.hs
@@ -58,10 +58,10 @@ incrementalToSkeletonDiffProof = fmap (fmap (const ()))
 -- | Create a new unproven lemma from a formula modulo E.
 unprovenLemma :: String -> [LemmaAttribute] -> TraceQuantifier -> LNFormula
               -> Lemma ProofSkeleton
-unprovenLemma name atts qua fm = Lemma name qua fm atts (unproven ())
+unprovenLemma name atts qua fm = Lemma name "Unpr_inSkeleton" False qua fm atts (unproven ())
 
-skeletonLemma :: String -> [LemmaAttribute] -> TraceQuantifier -> f -> p -> ProtoLemma f p
-skeletonLemma name atts qua fm = Lemma name qua fm atts
+skeletonLemma :: String -> String -> Bool -> [LemmaAttribute] -> TraceQuantifier -> f -> p -> ProtoLemma f p
+skeletonLemma name ptxt m atts qua fm = Lemma name ptxt m qua fm atts
 
 -- | Create a new unproven diff lemma.
 unprovenDiffLemma :: String -> [LemmaAttribute]

--- a/lib/theory/src/Theory/Text/Parser/Formula.hs
+++ b/lib/theory/src/Theory/Text/Parser/Formula.hs
@@ -30,7 +30,7 @@ import Control.Basics
 smallerp :: Ord v => Parser v -> Parser (ProtoAtom SyntacticSugar (Term (Lit Name v)))
 smallerp varp = do
     mset <- enableMSet . sig <$> getState
-    unless mset (fail "Need builtins: multiset to use multiset comparisson operator.")
+    unless mset (fail "Need builtins: multiset to use multiset comparison operator.")
     a <- try (termp <* opLessTerm)
     b <- termp
     return $ (Syntactic . Pred) $ protoFact Linear "Smaller" [a,b]

--- a/lib/theory/src/Theory/Text/Parser/Proof.hs
+++ b/lib/theory/src/Theory/Text/Parser/Proof.hs
@@ -80,6 +80,7 @@ proofMethod = asum
   , symbol "solve"         *> (SolveGoal <$> parens goal)
   , symbol "contradiction" *> pure (Contradiction Nothing)
   , symbol "induction"     *> pure Induction
+  , symbol "INVALIDATED"   *> pure Invalidated 
   , symbol "UNFINISHABLE"  *> pure Unfinishable
   ]
 

--- a/lib/theory/src/Theory/Text/Parser/Signature.hs
+++ b/lib/theory/src/Theory/Text/Parser/Signature.hs
@@ -43,6 +43,7 @@ import Theory.Text.Parser.Fact
 import Theory.Text.Parser.Term
 import Theory.Text.Parser.Formula
 import Theory.Text.Parser.Exceptions
+import Debug.Trace (traceM)
 
 import Data.Label.Total
 import Data.Label.Mono (Lens)

--- a/lib/theory/src/Theory/Text/Parser/Term.hs
+++ b/lib/theory/src/Theory/Text/Parser/Term.hs
@@ -79,7 +79,6 @@ reservedBuiltins =  map unpackChars [
 naryOpApp :: Ord l => Bool -> Parser (Term l) -> Parser (Term l)
 naryOpApp eqn plit = do
     op <- identifier
-    --traceM $ show op ++ " " ++ show eqn
     when (eqn && op `elem` reservedBuiltins)
       $ error $ "`" ++ show op ++ "` is a reserved function name for builtins."
     ar@(k,_,_) <- lookupArity op

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -116,6 +116,7 @@ module Theory.Text.Parser.Token (
   , parseFile
   , parseFileWState
   , parseString
+  , parseStringWState
   ,opLessTerm) where
 
 import           Prelude             hiding (id, (.))

--- a/lib/theory/src/Theory/Tools/MessageDerivationChecks.hs
+++ b/lib/theory/src/Theory/Tools/MessageDerivationChecks.hs
@@ -179,7 +179,7 @@ generateAction :: [LVar] ->Int -> LNFact
 generateAction vars idx = protoFact Persistent ("Generated_" ++ show idx) (map lvarToLnterm (deleteGlobals vars))
 
 generateSeparatedLemmas :: Int -> [LVar]-> [ProtoLemma (ProtoFormula Unit2 (String, LSort) Name LVar) (Proof ())]
-generateSeparatedLemmas idx vars = map (\v -> Lemma (show v) ExistsTrace (existsTimeFormula $ existFormula $ landFormula $ generateAction vars idx : [(lntermToKUFact (lvarToLnterm v))]) [] (unproven ())) vars
+generateSeparatedLemmas idx vars = map (\v -> Lemma (show v) "message_deriv" False ExistsTrace (existsTimeFormula $ existFormula $ landFormula $ generateAction vars idx : [(lntermToKUFact (lvarToLnterm v))]) [] (unproven ())) vars
 
 deleteGlobals :: [LVar] -> [LVar]
 deleteGlobals = filter (\v -> lvarSort v /= LSortPub)

--- a/src/Web/Hamlet.hs
+++ b/src/Web/Hamlet.hs
@@ -48,6 +48,7 @@ import           Data.Version          (showVersion)
 -- import           System.Locale
 
 import           Paths_tamarin_prover  (version)
+import           System.FilePath 
 
 --
 -- Templates
@@ -191,6 +192,7 @@ headerTpl info = [whamlet|
     <div #header-links>
       <a class=plain-link href=@{RootR}>Index</a>
       <a class=plain-link href=@{DownloadTheoryR idx filename}>Download</a>
+      <a class=save-link  href=@{AppendNewLemmasR idx filename}>Append modified Lemmas to file</a>
       <ul #navigation>
         <li><a href="#">Actions</a>
           <ul>
@@ -204,8 +206,6 @@ headerTpl info = [whamlet|
             <li><a id=lvl1-toggle href="#">Graph simplification L1</a>
             <li><a id=lvl2-toggle href="#">Graph simplification L2</a>
             <li><a id=lvl3-toggle href="#">Graph simplification L3</a>
-            
-            
   |]
   where
             -- <li><a id=debug-toggle href="#">Debug pane</a>
@@ -214,9 +214,9 @@ headerTpl info = [whamlet|
             -- <li><a class=edit-link href=@{EditPathR idx (TheoryLemma "")}>Add lemma</a>
             --
     idx = tiIndex info
-    filename = get thyName (tiTheory info) ++ ".spthy"
+    filename = get thyName (tiTheory info) ++ ".spthy" 
 
-    {- use this snipped to reactivate saving local theories
+      {- use this snipped to reactivate saving local theories
     localTheory (Local _) = True
     localTheory _         = False
 
@@ -291,10 +291,11 @@ overviewTpl :: RenderUrl
             -> RenderUrl -- ^ URL renderer that includes GET parameters for the image.
             -> TheoryInfo -- ^ Theory information
             -> TheoryPath -- ^ Theory path to load into main
+            -> String     -- ^ The lemma plaintext for editing
             -> IO Widget
-overviewTpl renderUrl renderImgUrl info path = do
+overviewTpl renderUrl renderImgUrl info path lptxt = do
   proofState <- proofStateTpl renderUrl info
-  mainView <- pathTpl renderUrl renderImgUrl info path
+  mainView <- pathTpl renderUrl renderImgUrl info path lptxt
   return [whamlet|
     $newline never
     <div .ui-layout-north>
@@ -349,11 +350,12 @@ pathTpl :: RenderUrl
         -> RenderUrl      -- ^ URL renderer that includes GET parameters for the image.
         -> TheoryInfo     -- ^ The theory
         -> TheoryPath     -- ^ Path to display on load
+        -> String         -- ^ plaintext of lemma for editing
         -> IO Widget
-pathTpl renderUrl renderImgUrl info path =
+pathTpl renderUrl renderImgUrl info path lptxt =
     return $ [whamlet|
                 $newline never
-                #{htmlThyPath renderUrl renderImgUrl info path} |]
+                #{htmlThyPath renderUrl renderImgUrl info path lptxt} |]
 
 -- | Theory path, displayed when loading main screen for first time.
 pathDiffTpl :: RenderUrl

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -217,11 +217,13 @@ preformatted cl = withTag "div" [("class", classes cl)]
 
 -- | Render a proof index relative to a theory path constructor.
 proofIndex :: HtmlDocument d
-           => RenderUrl
+           => String
+           -> Int
+           -> RenderUrl
            -> (ProofPath -> Route WebUI)         -- ^ Relative addressing function
            -> Proof (Maybe System, ProofStepColor) -- ^ The annotated incremental proof
            -> d
-proofIndex renderUrl mkRoute =
+proofIndex l tidx renderUrl mkRoute =
     prettyProofWith ppStep ppCase . insertPaths
   where
     ppCase step = markStatus (fst $ psInfo step)
@@ -231,7 +233,7 @@ proofIndex renderUrl mkRoute =
                (Nothing, _)  -> superfluousStep
                (_, Unmarked) -> stepLink ["sorry-step"]
                (_, Green)    -> stepLink ["hl_good"]
-               (_, Yellow)   -> stepLink ["hl_medium"]
+               (_, Yellow)   -> invalidatedStep
                (_, Red)      -> stepLink ["hl_bad"]
         <> case psMethod step of
                Sorry _ -> emptyDoc
@@ -243,6 +245,12 @@ proofIndex renderUrl mkRoute =
             ("proof-step" : cls) ppMethod
 
         superfluousStep = withTag "span" [("class","hl_superfluous")] ppMethod
+
+        invalidatedStep = if psMethod step == Invalidated 
+                            then stepLink ["hl_medium"] <-> 
+                                  (linkToPath renderUrl (TheoryVerifyR tidx $ TheoryProof l []) ["hl_medium"] $ text "verify it")
+                            else stepLink ["hl_medium"]
+
 
         removeStep = linkToPath renderUrl (mkRoute . snd . psInfo $ step)
           ["remove-step"] emptyDoc
@@ -289,21 +297,29 @@ lemmaIndex :: HtmlDocument d
 lemmaIndex renderUrl tidx l =
     ( markStatus (psInfo $ root annPrf) $
         (kwLemma <-> prettyLemmaName l <> colon)
-        -- FIXME: Reactivate theory editing.
-        -- <->
-        -- (linkToPath renderUrl lemmaRoute  ["edit-link"] editPng <->
-        -- linkToPath renderUrl lemmaRoute ["delete-link"] deletePng)
         $-$
         nest 2 ( sep [ prettyTraceQuantifier $ get lTraceQuantifier l
                      , doubleQuotes $ prettyLNFormula $ get lFormula l
                      ] )
+
+        $-$
+        (linkToPath renderUrl lemmaEdit ["edit"] $ text "edit lemma") 
+        <->
+        text " or " 
+        <->
+        (linkToPath renderUrl lemmaDelete ["delete"] $ text "delete lemma")
+
     ) $-$
-    proofIndex renderUrl mkRoute annPrf
+    proofIndex (get lName l) tidx renderUrl mkRoute annPrf
+    $-$
+    text ""
+    $-$
+    (linkToPath renderUrl lemmaAdd ["add"] $ text "add lemma")
   where
-    -- editPng = png "/static/img/edit.png"
-    -- deletePng = png "/static/img/delete.png"
-    -- png path = closedTag "img" [("class","icon"),("src",path)]
-    -- lemmaRoute = TheoryPathMR tidx (TheoryLemma $ get lName l)
+
+    lemmaEdit = TheoryPathMR tidx $ TheoryEdit $ get lName l
+    lemmaDelete = TheoryPathMR tidx $ TheoryDelete $ get lName l
+    lemmaAdd = TheoryPathMR tidx $ TheoryAdd $ get lName l
 
     annPrf = annotateLemmaProof l
     mkRoute proofPath = TheoryPathMR tidx (TheoryProof (get lName l) proofPath)
@@ -319,22 +335,13 @@ lemmaIndexDiff renderUrl tidx s l =
 --     error (show annPrf)
     ( markStatus (psInfo $ root annPrf) $
         (kwLemma <-> prettyLemmaName l <> colon)
-        -- FIXME: Reactivate theory editing.
-        -- <->
-        -- (linkToPath renderUrl lemmaRoute  ["edit-link"] editPng <->
-        -- linkToPath renderUrl lemmaRoute ["delete-link"] deletePng)
         $-$
         nest 2 ( sep [ prettyTraceQuantifier $ get lTraceQuantifier l
                      , doubleQuotes $ prettyLNFormula $ get lFormula l
                      ] )
     ) $-$
-    proofIndex renderUrl mkRoute annPrf
+    proofIndex (get lName l) tidx renderUrl mkRoute annPrf
   where
-    -- editPng = png "/static/img/edit.png"
-    -- deletePng = png "/static/img/delete.png"
-    -- png path = closedTag "img" [("class","icon"),("src",path)]
-    -- lemmaRoute = TheoryPathMR tidx (TheoryLemma $ get lName l)
-
     annPrf = annotateLemmaProof l
     mkRoute proofPath = TheoryPathDiffMR tidx (DiffTheoryProof s (get lName l) proofPath)
 
@@ -348,21 +355,9 @@ diffLemmaIndex renderUrl tidx l =
 --     error (show annPrf)
     ( markStatusDiff (dpsInfo $ root annPrf) $
         (kwLemma <-> prettyDiffLemmaName l {-<> text (show annPrf)-} <> colon)
-        -- FIXME: Reactivate theory editing.
-        -- <->
-        -- (linkToPath renderUrl lemmaRoute  ["edit-link"] editPng <->
-        -- linkToPath renderUrl lemmaRoute ["delete-link"] deletePng)
---         $-$
---         nest 2 ( sep [ prettyTraceQuantifier $ get lTraceQuantifier l
---                      , doubleQuotes $ prettyLNFormula $ get lFormula l
---                      ] )
     ) $-$
     diffProofIndex renderUrl mkRoute annPrf
   where
-    -- editPng = png "/static/img/edit.png"
-    -- deletePng = png "/static/img/delete.png"
-    -- png path = closedTag "img" [("class","icon"),("src",path)]
-    -- lemmaRoute = TheoryPathMR tidx (TheoryLemma $ get lName l)
 
     annPrf = annotateDiffLemmaProof l
     mkRoute proofPath = TheoryPathDiffMR tidx (DiffTheoryDiffProof (get lDiffName l) proofPath)
@@ -384,6 +379,8 @@ theoryIndex renderUrl tidx thy = foldr1 ($-$)
     , reqCasesLink "Raw sources" RawSource
     , text ""
     , reqCasesLink "Refined sources " RefinedSource
+    , text ""
+    , (linkToPath renderUrl (TheoryPathMR tidx $ TheoryAdd $ "<first>") ["add"] $ text "add lemma")
     , text ""
     , vcat $ intersperse (text "") lemmas
     , text ""
@@ -996,8 +993,9 @@ htmlThyPath :: RenderUrl      -- ^ The function for rendering Urls.
             -> RenderUrl      -- ^ URL renderer that includes GET parameters for the image.
             -> TheoryInfo     -- ^ The info of the theory to render
             -> TheoryPath     -- ^ Path to render
+            -> String         -- ^ the lemma's plaintext
             -> Html
-htmlThyPath renderUrl renderImgUrl info = go
+htmlThyPath renderUrl renderImgUrl info path lPlaintext =   go path
   where
     thy  = tiTheory info
     tidx = tiIndex  info
@@ -1021,7 +1019,128 @@ htmlThyPath renderUrl renderImgUrl info = go
            subProofSnippet renderUrl renderImgUrl tidx info l p (getProofContext lemma thy)
              <$> resolveProofPath thy l p
 
-    go (TheoryLemma _)         = pp $ text "Implement lemma pretty printing!"
+    go (TheoryEdit name) = do
+        let p = "../../edit/edit/"++name
+        [hamlet|
+             <form method="post" action=#{p}>
+                <div contenteditable="true">
+                    <label for="lemmaTextArea"> Edit Lemma #{name}
+                    <textarea name="lemma-text" id="lemmaTextArea" rows=#{textHeight}>#{lPlaintext}
+                <button type="submit">Submit
+                <p>
+                <h3> Introduction to Lemma Edit:
+                <noscript>
+                  <div class="warning">
+                    Warning: JavaScript must be enabled for the
+                    <span class="tamarin">Tamarin</span>
+                    prover GUI to function properly.
+                <p>
+                  <ul .wrap-text>
+                    <li>
+                     Modifying the lemma in the box above and clicking the submit button will attempt to modify the Lemma in the current theory.
+                     <br>&zwnj;
+                    <li>
+                     Failures in parsing the Lemma or verifying its well-formedness will result in an Error, and the lemma will NOT be modified.
+                     However, your changes will be kept in this page until you leave this right panel.
+                     <br>&zwnj;
+                    <li>
+                     Editing a Lemma will NOT modify the file it was loaded from.
+                     <br>&zwnj;
+                    <li>
+                     Clicking on the "append lemmas to file" button adds all modified lemmas as a comment at the end of the file they were loaded from.
+                     <br>&zwnj;
+                    <li>
+                     Clicking on the Download button will download the modified version of the theory (so with the modified lemmas).
+                     <br>&zwnj;
+                    <li>
+                     Modifying a Reuse Lemma will invalidate all subsequent proofs.
+                     <br>&zwnj;
+                    <li>
+                     Modifying a Sources Lemma has not yet been implemented and will result in an error.
+                  <style>
+                     .wrap-text li {
+                         white-space: normal;
+                         word-wrap: break-word;
+                     }
+                  |] renderUrl
+        where textHeight = 2 + (length $ filter (=='\n') lPlaintext)
+
+    go (TheoryLemma _)         = pp $ text "this is a mistake"
+
+    go (TheoryDelete name)        = do
+        let p = "../../edit/delete/" ++ name
+        [hamlet|
+        <p> Do you want to delete lemma #{name}?
+        <form method="post" action=#{p}>
+            <button type="submit">Yes
+          <p>
+          <h3> Introduction to Lemma Delete:
+          <noscript>
+            <div class="warning">
+              Warning: JavaScript must be enabled for the
+              <span class="tamarin">Tamarin</span>
+              prover GUI to function properly.
+          <p>
+            <ul .wrap-text>
+              <li>
+               Clicking on the button above will delete the lemma from the loaded theory.
+               <br>&zwnj;
+              <li>
+               Deleting a Lemma will NOT modify the file it was loaded from.
+               <br>&zwnj;
+              <li>
+               Clicking on the Download button will download the modified version of the theory (so without deleted lemmas)
+               <br>&zwnj;
+              <li>
+               Deleting a Reuse Lemma will invalidate all subsequent proofs
+               <br>&zwnj;
+              <li>
+               Deleting a Source Lemma has not yet been implemented and will result in an error
+             <style>
+                 .wrap-text li {
+                     white-space: normal;
+                     word-wrap: break-word;
+                 }
+             |] renderUrl
+
+    go (TheoryAdd name)  = do
+        let p = "../../edit/add/" ++ name
+        [hamlet|
+             <form method="post" action=#{p}>
+                <div contenteditable="true">
+                    <label for="lemmaTextArea">LemmaText
+                    <textarea name="lemma-text" id="lemmaTextArea">#{lPlaintext}
+                <button type="submit">Submit
+              <p>
+              <h3> Introduction to Adding Lemmas:
+              <noscript>
+                <div class="warning">
+                  Warning: JavaScript must be enabled for the
+                  <span class="tamarin">Tamarin</span>
+                  prover GUI to function properly.
+              <p>
+                <ul .wrap-text>
+                  <li>
+                   Adds the lemma in the current position in the Theory.
+                   <br>&zwnj;
+                  <li>
+                   Clicking on the "append lemmas to file" button appends all added lemmas as a comment at the end of the current theory file.
+                   <br>&zwnj;
+                  <li>
+                   Adding a Lemma will NOT modify the loaded source file.
+                   <br>&zwnj;
+                  <li>
+                   Clicking on the Download button will download the modified version of the theory (so with the added lemmas)
+                   <br>&zwnj;
+                  <li>
+                   Will throw an error if a Lemma with the same name exists, the parsing fails, or the lemma isn't well-formed.
+                <style>
+                    .wrap-text li {
+                        white-space: normal;
+                        word-wrap: break-word;
+                    }
+                |] renderUrl
+
 
     go TheoryHelp              = do
       [hamlet|
@@ -1518,6 +1637,9 @@ titleThyPath thy path = go path
     go TheoryTactic                     = "Tactics"
     go (TheorySource RawSource _ _)     = "Raw sources"
     go (TheorySource RefinedSource _ _) = "Refined sources"
+    go (TheoryEdit l)                   = "Edit Lemma: " ++ l
+    go (TheoryAdd _)                    = "Add new Lemma"
+    go (TheoryDelete l)                 = "Delete " ++ l
     go (TheoryLemma l)                  = "Lemma: " ++ l
     go (TheoryProof l [])               = "Lemma: " ++ l
     go (TheoryProof l p)
@@ -1608,6 +1730,9 @@ nextThyPath thy = go
     go (TheorySource RawSource _ _)     = TheorySource RefinedSource 0 0
     go (TheorySource RefinedSource _ _) = fromMaybe TheoryHelp firstLemma
     go (TheoryLemma lemma)              = TheoryProof lemma []
+    go (TheoryEdit _)                   = TheoryHelp 
+    go (TheoryAdd _)                    = TheoryHelp
+    go (TheoryDelete _)                 = TheoryHelp
     go (TheoryProof l p)
       | Just nextPath <- getNextPath l p = TheoryProof l nextPath
       | Just nextLemma <- getNextLemma l = TheoryProof nextLemma []
@@ -1699,6 +1824,9 @@ prevThyPath thy = go
     go TheoryTactic                      = TheoryRules
     go (TheorySource RawSource _ _)      = TheoryTactic
     go (TheorySource RefinedSource _ _)  = TheorySource RawSource 0 0
+    go (TheoryEdit  _ )                  = TheoryHelp 
+    go (TheoryAdd _)                     = TheoryHelp
+    go (TheoryDelete _)                  = TheoryHelp
     go (TheoryLemma l)
       | Just prevLemma <- getPrevLemma l = TheoryProof prevLemma (lastPath prevLemma)
       | otherwise                        = TheorySource RefinedSource 0 0
@@ -1815,6 +1943,9 @@ nextSmartThyPath thy = go
     go TheoryTactic                       = TheorySource RawSource 0 0
     go (TheorySource RawSource _ _)       = TheorySource RefinedSource 0 0
     go (TheorySource RefinedSource   _ _) = fromMaybe TheoryHelp firstLemma
+    go (TheoryEdit  _ )                   = TheoryHelp 
+    go (TheoryAdd _ )                     = TheoryHelp
+    go (TheoryDelete _)                   = TheoryHelp
     go (TheoryLemma lemma)                = TheoryProof lemma []
     go (TheoryProof l p)
       | Just nextPath <- getNextPath l p = TheoryProof l nextPath
@@ -1913,6 +2044,9 @@ prevSmartThyPath thy = go
     go TheoryTactic                        = TheoryRules
     go (TheorySource RawSource _ _)        = TheoryTactic
     go (TheorySource RefinedSource   _ _)  = TheorySource RawSource 0 0
+    go (TheoryEdit  _)                     = TheoryHelp 
+    go (TheoryAdd _ )                      = TheoryHelp
+    go (TheoryDelete _ )                   = TheoryHelp
     go (TheoryLemma l)
       | Just prevLemma <- getPrevLemma l   = TheoryProof prevLemma (lastPath prevLemma)
       | otherwise                          = TheorySource RefinedSource 0 0
@@ -2093,21 +2227,22 @@ annotateLemmaProof lem =
     mapProofInfo (second interpret) prf
   where
     prf = annotateProof annotate $ get lProof lem
-    annotate step cs =
-        ( psInfo step
-        , mconcat $ proofStepStatus step : incomplete ++ map snd cs
-        )
+    annotate step cs  =
+        case get lProof lem of
+           LNode (ProofStep  Invalidated _) _ -> (psInfo step, InvalidatedProof)
+           _                                  -> ( psInfo step, mconcat $ proofStepStatus step : incomplete ++ map snd cs)
       where
         incomplete = if isNothing (psInfo step) then [IncompleteProof] else []
 
     interpret status = case (get lTraceQuantifier lem, status) of
-      (_,           IncompleteProof)   -> Unmarked
-      (_,           UndeterminedProof) -> Unmarked
-      (_,           UnfinishableProof) -> Yellow
-      (AllTraces,   TraceFound)        -> Red
-      (AllTraces,   CompleteProof)     -> Green
-      (ExistsTrace, TraceFound)        -> Green
-      (ExistsTrace, CompleteProof)     -> Red
+      (_,                IncompleteProof)   -> Unmarked
+      (_,                UndeterminedProof) -> Unmarked
+      (_,                UnfinishableProof) -> Yellow
+      (_,                InvalidatedProof)  -> Yellow
+      (AllTraces,        TraceFound)        -> Red
+      (AllTraces,        CompleteProof)     -> Green
+      (ExistsTrace,      TraceFound)        -> Green
+      (ExistsTrace,      CompleteProof)     -> Red
 
 -- | Annotate a proof for pretty printing.
 -- The boolean flag indicates that the given proof step's children
@@ -2129,5 +2264,6 @@ annotateDiffLemmaProof lem =
       IncompleteProof   -> Unmarked
       UndeterminedProof -> Unmarked
       UnfinishableProof -> Yellow
+      InvalidatedProof -> Yellow
       TraceFound        -> Red
       CompleteProof     -> Green


### PR DESCRIPTION
@rsasse and I supervised @4-Pawn's (Alice La Porta) Bachelor thesis, which was about editing lemmas in the GUI. Changes are (more or less) straightforward.

You can now:
- Add lemmas in the GUI
- Delete lemmas from the GUI
- Edit lemmas in the GUI

The hope is this will save the modeler's time by requiring them to restart Tamarin less.

Here's a screenshot of the new GUI:

![image](https://github.com/user-attachments/assets/90f28b50-1bf8-4add-800d-524e3855bdca)

Moreover, we implemented the following:
- When you edit/delete reuse lemmas, subsequent proofs are marked as invalidated, but they are not discarded. There is a button to verify them again.
- There is a button at the top to append all edited/added lemmas to your theory file to persist changes. Some manual merging must be done still, but we thought that appending changes is safer than overwriting. Modelers will certainly not lose any content accidentally. Appending is also safe to the parser, which will stop after reading `end`.

Here's a screenshot of how invalidated proofs look:
![image](https://github.com/user-attachments/assets/42f75a86-08ec-4012-9005-b633a3648f29)
