### PR TITLE
Add VSCode plugin to manual

### DIFF
--- a/manual/src/002_installation.md
+++ b/manual/src/002_installation.md
@@ -100,13 +100,23 @@ restart Tamarin and start over on the proof.
 Tamarin Code Editors
 --------------------
 
+## VSCode
+
+Tamarin has an official plugin for [Visual Studio Code](https://code.visualstudio.com/) providing
+syntax highlighting, detection of syntax errors, and numerous wellformedness checks. It is available from the
+[VSCode marketplace](https://marketplace.visualstudio.com/items?itemName=tamarin-prover.tamarin-prover)
+or from [Open VSX](https://open-vsx.org/extension/tamarin-prover/tamarin-prover).
+Its source code can be found in [vscode-tamarin](https://github.com/tamarin-prover/vscode-tamarin) repository.
+
+## Other editors
+
 Under the [etc](https://github.com/tamarin-prover/tamarin-prover/tree/develop/etc) folder contained
 in the Tamarin Prover project, plug-ins are available for VIM, Sublime Text 3, Emacs and
 Notepad++. Below we details the steps required to install your preferred plug-in.
 
-#### VIM
+### VIM
 
-##### Using Vim plugin managers
+#### Using Vim plugin managers
 
 This example will use [Vundle](https://github.com/VundleVim/Vundle.vim) to install the plugin directly
 from this repository. The instructions below should be translatable to other plugin managers.
@@ -122,14 +132,14 @@ Plugin 'tamarin-prover/editors'
 
 You can install updates through `:PluginUpdate`.
 
-##### Manual installation (not recommended)
+#### Manual installation (not recommended)
 
 If you install the Vim support files using this method, you will need to keep the files up-to-date yourself.
 
 1. Create `~/.vim/` directory if not already existing, which is the typical location for `$VIMRUNTIME`
 2. Copy the contents of `etc/vim` to `~/.vim/`, including the folders.
 
-#### Sublime Text 3
+### Sublime Text 3
 
 [editor-sublime](https://github.com/tamarin-prover/editor-sublime) is a plug-in developed for the Sublime Text 3 editor. The plug-in has the following functionality:
 - Basic Syntaxes
@@ -154,17 +164,17 @@ the `git` tool installed.
 
 *Please be aware that this plugin is under active development and as such, several of the features are still implemented in a prototypical manner. If you experience any problems or have any questions on running any parts of the plug-in please [visit the project GitHub page](https://github.com/tamarin-prover/editor-sublime).*
 
-#### Notepad++
+### Notepad++
 
 Follow steps from the [Notepad++ Wiki](http://docs.notepad-plus-plus.org/index.php/User_Defined_Language_Files#How_to_install_user_defined_language_files) using the [notepad_plus_plus_spthy.xml](https://github.com/tamarin-prover/tamarin-prover/blob/develop/etc/notepad_plus_plus_spthy.xml) file.
 
-#### Emacs
+### Emacs
 
 The [spthy.el](https://github.com/tamarin-prover/tamarin-prover/blob/develop/etc/spthy-mode.el)
 implements a SPTHY major mode. You can load it with `M-x load-file`, or add it to your `.emacs` in
 your favourite way.
 
-#### Atom
+### Atom
 
 The [language-tamarin](https://atom.io/packages/language-tamarin) package provides Tamarin syntax
 highlighting for Atom. To install it, run `apm install language-tamarin`.


### PR DESCRIPTION
This PR adds a pointer to the new official VSCode plugin to the manual.