### PR TITLE
Remove nat constructor if natural-numbers is not used

### DIFF
--- a/lib/term/src/Term/Maude/Parser.hs
+++ b/lib/term/src/Term/Maude/Parser.hs
@@ -162,22 +162,39 @@ ppMaude t = case viewTerm t of
 ppTheory :: MaudeSig -> ByteString
 ppTheory msig = BC.unlines $
     [ "fmod MSG is"
-    , "  protecting NAT ."
-    , "  sort Pub Fresh Msg Node TamNat TOP ."
-    , "  subsort Pub < Msg ."
-    , "  subsort Fresh < Msg ."
-    , "  subsort TamNat < Msg ."
-    , "  subsort Msg < TOP ."
+    , "  protecting NAT ." ]
+    ++
+    (if enableNat msig
+      then
+        [ "  sort Pub Fresh Msg Node TamNat TOP ." ]
+      else
+        [ "  sort Pub Fresh Msg Node TOP ." ]
+    )
+    ++
+    [ "  subsort Pub < Msg ."
+    , "  subsort Fresh < Msg ." ]
+    ++
+    (if enableNat msig
+      then
+        ["  subsort TamNat < Msg ."]
+      else [])
+    ++
+    [  "  subsort Msg < TOP ."
     , "  subsort Node < TOP ."
     -- constants
     , "  op f : Nat -> Fresh ."
     , "  op p : Nat -> Pub ."
     , "  op c : Nat -> Msg ."
-    , "  op n : Nat -> Node ."
-    , "  op t : Nat -> TamNat ."
+    , "  op n : Nat -> Node ." ]
+    ++
+    (if enableNat msig
+      then
+        ["  op t : Nat -> TamNat ."]
+      else [])
+    ++
     -- used for encoding FApp List [t1,..,tk]
     -- list(cons(t1,cons(t2,..,cons(tk,nil)..)))
-    , "  op list : TOP -> TOP ."
+    [ "  op list : TOP -> TOP ."
     , "  op cons : TOP TOP -> TOP ."
     , "  op nil  : -> TOP ." ]
     ++

--- a/lib/theory/src/Theory/Tools/IntruderRules.hs
+++ b/lib/theory/src/Theory/Tools/IntruderRules.hs
@@ -16,6 +16,7 @@ module Theory.Tools.IntruderRules (
   , multisetIntruderRules
   , mkDUnionRule
   , specialIntruderRules
+  , natIntruderRules
   , variantsIntruder
 
   -- ** Classifiers
@@ -63,9 +64,6 @@ rule coerce:
 rule pub:
    [ ] --[ KU( $x ) ]-> [ KU( $x ) ]
    
-rule nat:
-   [ ] --[ KU( x:nat ) ]-> [ KU( x:nat ) ]
-
 rule gen_fresh:
    [ Fr( ~x ) ] --[ KU( ~x ) ]-> [ KU( ~x ) ]
 
@@ -85,7 +83,6 @@ specialIntruderRules :: Bool -> [IntrRuleAC]
 specialIntruderRules diff =
     [ kuRule CoerceRule      [kdFact x_var]                 (x_var)         [] 
     , kuRule PubConstrRule   []                             (x_pub_var)     [(x_pub_var)]
-    , kuRule NatConstrRule   []                             (x_nat_var)     [(x_nat_var)]
     , kuRule FreshConstrRule [freshFact x_fresh_var] (x_fresh_var)          []
     , Rule ISendRule [kuFact x_var]  [inFact x_var] [kLogFact x_var]        []
     , Rule IRecvRule [outFact x_var] [kdFact x_var] []                      []
@@ -98,9 +95,30 @@ specialIntruderRules diff =
 
     x_var       = varTerm (LVar "x"  LSortMsg   0)
     x_pub_var   = varTerm (LVar "x"  LSortPub   0)
-    x_nat_var   = varTerm (LVar "x"  LSortNat   0)
     x_fresh_var = varTerm (LVar "x"  LSortFresh 0)
 
+
+------------------------------------------------------------------------------
+-- Natural numbers
+------------------------------------------------------------------------------
+
+{-
+When using the natural-numbers plugin, the following rule is included.
+
+rule nat:
+   [ ] --[ KU( x:nat ) ]-> [ KU( x:nat ) ]
+
+-}
+
+-- | @natIntruderRules@ returns the natural numbers constructor
+natIntruderRules :: [IntrRuleAC]
+natIntruderRules =
+    [ kuRule NatConstrRule [] (x_nat_var) [(x_nat_var)]
+    ]
+  where
+    kuRule name prems t nvs = Rule name prems [kuFact t] [kuFact t] nvs
+
+    x_nat_var   = varTerm (LVar "x"  LSortNat   0)
 
 ------------------------------------------------------------------------------
 -- Subterm Intruder theory

--- a/manual/src/002_installation.md
+++ b/manual/src/002_installation.md
@@ -100,13 +100,23 @@ restart Tamarin and start over on the proof.
 Tamarin Code Editors
 --------------------
 
+## VSCode
+
+Tamarin has an official plugin for [Visual Studio Code](https://code.visualstudio.com/) providing
+syntax highlighting, detection of syntax errors, and numerous wellformedness checks. It is available from the
+[VSCode marketplace](https://marketplace.visualstudio.com/items?itemName=tamarin-prover.tamarin-prover)
+or from [Open VSX](https://open-vsx.org/extension/tamarin-prover/tamarin-prover).
+Its source code can be found in [vscode-tamarin](https://github.com/tamarin-prover/vscode-tamarin) repository.
+
+## Other editors
+
 Under the [etc](https://github.com/tamarin-prover/tamarin-prover/tree/develop/etc) folder contained
 in the Tamarin Prover project, plug-ins are available for VIM, Sublime Text 3, Emacs and
 Notepad++. Below we details the steps required to install your preferred plug-in.
 
-#### VIM
+### VIM
 
-##### Using Vim plugin managers
+#### Using Vim plugin managers
 
 This example will use [Vundle](https://github.com/VundleVim/Vundle.vim) to install the plugin directly
 from this repository. The instructions below should be translatable to other plugin managers.
@@ -122,14 +132,14 @@ Plugin 'tamarin-prover/editors'
 
 You can install updates through `:PluginUpdate`.
 
-##### Manual installation (not recommended)
+#### Manual installation (not recommended)
 
 If you install the Vim support files using this method, you will need to keep the files up-to-date yourself.
 
 1. Create `~/.vim/` directory if not already existing, which is the typical location for `$VIMRUNTIME`
 2. Copy the contents of `etc/vim` to `~/.vim/`, including the folders.
 
-#### Sublime Text 3
+### Sublime Text 3
 
 [editor-sublime](https://github.com/tamarin-prover/editor-sublime) is a plug-in developed for the Sublime Text 3 editor. The plug-in has the following functionality:
 - Basic Syntaxes
@@ -154,17 +164,17 @@ the `git` tool installed.
 
 *Please be aware that this plugin is under active development and as such, several of the features are still implemented in a prototypical manner. If you experience any problems or have any questions on running any parts of the plug-in please [visit the project GitHub page](https://github.com/tamarin-prover/editor-sublime).*
 
-#### Notepad++
+### Notepad++
 
 Follow steps from the [Notepad++ Wiki](http://docs.notepad-plus-plus.org/index.php/User_Defined_Language_Files#How_to_install_user_defined_language_files) using the [notepad_plus_plus_spthy.xml](https://github.com/tamarin-prover/tamarin-prover/blob/develop/etc/notepad_plus_plus_spthy.xml) file.
 
-#### Emacs
+### Emacs
 
 The [spthy.el](https://github.com/tamarin-prover/tamarin-prover/blob/develop/etc/spthy-mode.el)
 implements a SPTHY major mode. You can load it with `M-x load-file`, or add it to your `.emacs` in
 your favourite way.
 
-#### Atom
+### Atom
 
 The [language-tamarin](https://atom.io/packages/language-tamarin) package provides Tamarin syntax
 highlighting for Atom. To install it, run `apm install language-tamarin`.

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -73,7 +73,8 @@ import Theory.Text.Pretty qualified as Pretty
 import Theory.Tools.AbstractInterpretation (EvaluationStyle(..))
 import Theory.Tools.IntruderRules
   ( specialIntruderRules, subtermIntruderRules
-  , multisetIntruderRules, xorIntruderRules )
+  , multisetIntruderRules, xorIntruderRules
+  , natIntruderRules )
 import Theory.Tools.MessageDerivationChecks
 import Theory.Tools.Wellformedness
 
@@ -660,6 +661,7 @@ addMessageDeductionRuleVariants thy0
   where
     msig  = thy0._thySignature._sigMaudeInfo
     rules = subtermIntruderRules False msig ++ specialIntruderRules False
+              ++ (if enableNat msig then natIntruderRules else [])
               ++ (if enableMSet msig then multisetIntruderRules else [])
               ++ (if enableXor msig then xorIntruderRules else [])
     thy   = addIntrRuleACsAfterTranslate rules thy0
@@ -677,6 +679,7 @@ addMessageDeductionRuleVariantsDiff thy0
   where
     msig        = thy0._diffThySignature._sigMaudeInfo
     rules diff' = subtermIntruderRules diff' msig ++ specialIntruderRules diff'
+                   ++ (if enableNat msig then natIntruderRules else [])
                    ++ (if enableMSet msig then multisetIntruderRules else [])
                    ++ (if enableXor msig then xorIntruderRules else [])
     thy         = addIntrRuleACsDiffBoth (rules False) $ addIntrRuleACsDiffBothDiff (rules True) thy0


### PR DESCRIPTION
Following [issue 682](https://github.com/tamarin-prover/tamarin-prover/issues/682), this PR modifies Tamarin to not include the `nat` constructor if the `natural-numbers` builtin is not used.