### PR TITLE
Enhance manual to be more self explanatory

### DIFF
--- a/manual/src/003_example.md
+++ b/manual/src/003_example.md
@@ -111,7 +111,7 @@ incomparable subsorts `fresh`, `pub` and `nat` of that top sort. Timepoint
 variables of sort `temporal` are unconnected.
 
 The above rule can therefore be read as follows. First, generate
-a fresh name `~ltk` (of sort fresh), which is the new private key, and
+a fresh name `~ltk` (of sort fresh), which is the new private (long term) key, and
 non-deterministically choose a public name `A`, for the agent for whom we
 are generating the key-pair.  Afterward, generate the fact `!Ltk($A, ~ltk)`
 (the exclamation mark `!` denotes that the fact is persistent, i.e., it


### PR DESCRIPTION
I am currently learning the Tamarin Prover and it took me a while to understand what the abbreviation “ltk” stands for in context of the [first example](https://tamarin-prover.com/manual/master/book/003_example.html). My guess would be “long term key”. To make the manual a little more obvious, I have inserted this keyword in the appropriate place. Let me know what you think.