### PR TITLE
Revert "Rewrite execProofMethod"

### DIFF
--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey.spthy
@@ -148,6 +148,7 @@ induction
   by contradiction // from formulas
 next
   case non_empty_trace
+  simplify
   solve( (∀ pid otc1 tc1 otc2 tc2 #t1 #t2.
            (LoginCounter( pid, otc1, tc1 ) @ #t1) ∧
            (LoginCounter( pid, otc2, tc2 ) @ #t2)

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM.spthy
@@ -271,6 +271,7 @@ induction
   by contradiction // from formulas
 next
   case non_empty_trace
+  simplify
   solve( !S_AEAD( pid,
                   <xorc(senc(keystream(kh, pid), k), <k2, sid>), mac(<k2, sid>, k)>
          ) ▶₂ #t2 )

--- a/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
+++ b/examples/related_work/YubiSecure_KS_STM12/Yubikey_and_YubiHSM_multiset.spthy
@@ -225,6 +225,7 @@ induction
   by contradiction // from formulas
 next
   case non_empty_trace
+  simplify
   solve( (¬(#t1 < #t2))  ∥ (∀ z.2. ((otc2+z.1) = (otc1+z+z.2)) ⇒ ⊥) )
     case case_1
     solve( (#t2 = #t1)  ∥ (#t1 < #t2) )

--- a/lib/theory/src/OpenTheory.hs
+++ b/lib/theory/src/OpenTheory.hs
@@ -655,7 +655,7 @@ normalizeTheory =
     stripProofStepAnnotations (ProofStep method ()) = ProofStep
       (case method of
         Sorry _         -> Sorry Nothing
-        Finished (Contradictory _) -> Finished (Contradictory Nothing)
+        Contradiction _ -> Contradiction Nothing
         _               -> method)
       ()
 

--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -37,6 +37,9 @@ import           Control.Basics
 import           Control.Category
 import           Control.Monad.Disj
 import           Control.Monad.State                     (gets)
+import           Control.Monad.Trans.State.Lazy          hiding (get,gets)
+import           Control.Monad.Trans.FastFresh           -- GHC7.10 needs: hiding (get,gets)
+import           Control.Monad.Trans.Reader              -- GHC7.10 needs: hiding (get,gets)
 
 import           Extension.Data.Label                    as L
 
@@ -341,7 +344,9 @@ solveChain rules (c, p) = do
          _ -> error "solveChain: not a down fact"
   where
     extendAndMark :: NodeId -> RuleACInst -> PremIdx -> LNFact -> LNFact
-      -> Reduction String
+      -> Control.Monad.Trans.State.Lazy.StateT System
+      (Control.Monad.Trans.FastFresh.FreshT
+      (DisjT (Control.Monad.Trans.Reader.Reader ProofContext))) String
     extendAndMark i ru v faPrem faConc = do
         insertEdges [(c, faConc, faPrem, (i, v))]
         markGoalAsSolved "directly" (PremiseG (i, v) faPrem)

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -16,12 +16,9 @@ module Theory.Constraint.Solver.ProofMethod (
   -- * Proof methods
     CaseName
   , ProofMethod(..)
-  , Result(..)
   , DiffProofMethod(..)
-  , checkAndExecProofMethod
   , execProofMethod
   , execDiffProofMethod
-  , isFinished
 
   -- ** Heuristics
   , rankProofMethods
@@ -42,10 +39,9 @@ import           Data.Binary
 import           Data.Function                             (on)
 import           Data.Label                                hiding (get)
 import qualified Data.Label                                as L
-import           Data.List                                 (partition,groupBy,sortBy,isPrefixOf,findIndex,intercalate, uncons)
-import qualified Data.List.NonEmpty as NE
+import           Data.List                                 (intersperse,partition,groupBy,sortBy,isPrefixOf,findIndex,intercalate)
 import qualified Data.Map                                  as M
-import           Data.Maybe                                (catMaybes, fromMaybe, mapMaybe, isNothing, isJust)
+import           Data.Maybe                                (catMaybes, fromMaybe, mapMaybe)
 -- import           Data.Monoid
 import           Data.Ord                                  (comparing)
 import qualified Data.Set                                  as S
@@ -55,7 +51,6 @@ import qualified Data.ByteString.Char8 as BC
 import           Control.Basics
 import           Control.DeepSeq
 import qualified Control.Monad.Trans.PreciseFresh          as Precise
-import qualified Control.Monad.Trans.State                 as St
 
 import           Debug.Trace
 import           Safe
@@ -72,9 +67,6 @@ import           Theory.Constraint.Solver.Simplify
 import           Theory.Constraint.System
 import           Theory.Model
 import           Theory.Text.Pretty
-import qualified Extension.Data.Label as L
-import Control.Monad.Disj (disjunctionOfList)
-import Data.Bool (bool)
 
 
 
@@ -92,7 +84,7 @@ uniqueListBy :: (a -> a -> Ordering) -> (a -> a) -> (Int -> [a -> a]) -> [a] -> 
 uniqueListBy ord single distinguish xs0 =
       map fst
     $ sortBy (comparing snd)
-    $ concatMap uniquify $ groupBy (\x y -> ord (fst x) (fst y) == EQ)
+    $ concat $ map uniquify $ groupBy (\x y -> ord (fst x) (fst y) == EQ)
     $ sortBy (ord `on` fst)
     $ zip xs0 [(0::Int)..]
   where
@@ -191,26 +183,18 @@ unmarkPremiseG annGoal                        = annGoal
 -- | Every case in a proof is uniquely named.
 type CaseName = String
 
-data Result =
-    Solved
-  -- ^ A dependency graph was found.
-  | Contradictory (Maybe Contradiction)
-  -- ^ A contradiction could be derived, possibly with a reason. The single
-  --    formula constraint in the system.
-  | Unfinishable
-  -- ^ The proof cannot be finished (due to reducible operators in subterms or
-  --   because a solution was found after weakening).
-  deriving( Eq, Ord, Show, Generic, NFData, Binary )
-
 -- | Sound transformations of sequents.
 data ProofMethod =
     Sorry (Maybe String)                 -- ^ Proof was not completed
+  | Solved                               -- ^ An attack was found.
+  | Unfinishable                         -- ^ The proof cannot be finished (due to reducible operators in subterms)
   | Simplify                             -- ^ A simplification step.
   | SolveGoal Goal                       -- ^ A goal that was solved.
+  | Contradiction (Maybe Contradiction)  -- ^ A contradiction could be
+                                         -- derived, possibly with a reason.
   | Induction                            -- ^ Use inductive strengthening on
                                          -- the single formula constraint in
                                          -- the system.
-  | Finished Result
   deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
 -- | Sound transformations of diff sequents.
@@ -227,13 +211,13 @@ data DiffProofMethod =
   
 instance HasFrees ProofMethod where
     foldFrees f (SolveGoal g)     = foldFrees f g
-    foldFrees f (Finished (Contradictory c)) = foldFrees f c
+    foldFrees f (Contradiction c) = foldFrees f c
     foldFrees _ _                 = mempty
 
     foldFreesOcc  _ _ = const mempty
 
     mapFrees f (SolveGoal g)     = SolveGoal <$> mapFrees f g
-    mapFrees f (Finished (Contradictory c)) = Finished . Contradictory <$> mapFrees f c
+    mapFrees f (Contradiction c) = Contradiction <$> mapFrees f c
     mapFrees _ method            = pure method
 
 instance HasFrees DiffProofMethod where
@@ -248,94 +232,100 @@ instance HasFrees DiffProofMethod where
 -- Proof method execution
 -------------------------
 
--- @checkAndExecMethod rules method se@ checks first if the @method@ is
--- applicable to the sequent @se@ and, if so, applies it.
-checkAndExecProofMethod :: ProofContext -> ProofMethod -> System -> Maybe (M.Map CaseName System)
-checkAndExecProofMethod ctxt method sys = do
-    case method of
-      Finished r -> isFinished ctxt sys >>= guard . equalReason r
-      Induction -> canApplyInduction
-      SolveGoal goal -> guard (goal `M.member` L.get sGoals sys)
-      Simplify -> Just ()
-      Sorry _ -> Just ()
-    execProofMethod ctxt method sys
-  where
-    canApplyInduction :: Maybe ()
-    canApplyInduction = do
-      guard (M.null $ L.get sNodes sys)
-      guard (S.null $ L.get sSolvedFormulas sys)
-      guard (M.null $ L.get sGoals sys)
-      (_, t) <- uncons $ S.toList $ L.get sFormulas sys
-      guard (null t)
-
-    equalReason :: Result -> Result -> Bool
-    equalReason (Contradictory _) (Contradictory _) = True
-    equalReason r1 r2 = r1 == r2
-    -- ^ all other reasons don't have an argument
-
--- @execMethod rules method se@ applies the @method@ to the sequent under the
--- assumption that it is sound to apply the method and that the @rules@ describe
--- all rewriting rules in scope.
+-- @execMethod rules method se@ checks first if the @method@ is applicable to
+-- the sequent @se@. Then, it applies the @method@ to the sequent under the
+-- assumption that the @rules@ describe all rewriting rules in scope.
 --
 -- NOTE that the returned systems have their free substitution fully applied
 -- and all variable indices reset.
 execProofMethod :: ProofContext
                 -> ProofMethod -> System -> Maybe (M.Map CaseName System)
 execProofMethod ctxt method sys =
-    case method of
-      Sorry _               -> return M.empty
-      Finished _            -> return M.empty
-      Simplify              ->
-        let cases = process (return "") -- @process@ simplifies
-        in case M.toList cases of
-          -- Check whether simplified system is equal to previous one; if so,
-          -- fail in applying this method.
-          [(_, sys')] -> guard (sys' /= cleanup sys) >> return cases
-          -- If simplifying resulted in multiple cases, the resulting ones
-          -- cannot be equal to the original one so there's nothing to check.
-          _ -> return cases
-      Induction             -> process . induction <$> getInductionCases sys
-      SolveGoal goal        -> return $ process $ solve goal
+      case method of
+        Sorry _                                -> return M.empty
+        Solved
+          | null (openGoals sys)  && not (contradictorySystem ctxt sys)
+            && finishedSubterms ctxt sys       -> return M.empty
+          | otherwise                          -> Nothing
+        Unfinishable
+          | null (openGoals sys)  && not (contradictorySystem ctxt sys)
+            && not (finishedSubterms ctxt sys) -> return M.empty
+          | otherwise                          -> Nothing
+        SolveGoal goal
+          | goal `M.member` L.get sGoals sys   -> execSolveGoal goal
+          | otherwise                          -> Nothing
+        Simplify                               -> singleCase simplifySystem
+        Induction                              -> M.map cleanupSystem <$> execInduction
+        Contradiction _
+          | null (contradictions ctxt sys)     -> Nothing
+          | otherwise                          -> Just M.empty
   where
-    process :: Reduction CaseName -> M.Map CaseName System
-    process m =
-      let cases =   removeRedundantCases ctxt [] snd
-                  . map (fmap cleanup . fst)
-                  . getDisj $ runReduction (m <* simplifySystem) ctxt sys (avoid sys)
-      in  M.fromListWith (error "case names not unique")
-            $ uniqueListBy (comparing fst) id distinguish cases
+    -- at this point it is safe to remove the free substitution, as all
+    -- systems have it fully applied (by the virtue of a call to
+    -- simplifySystem). We also reset the variable indices here.
+    cleanupSystem =
+         (`Precise.evalFresh` Precise.nothingUsed)
+       . renamePrecise
+       . set sSubst emptySubst
 
-    cleanup :: System -> System
-    cleanup s = L.set sSubst emptySubst (Precise.evalFresh (renamePrecise s) Precise.nothingUsed)
+
+    -- expect only one or no subcase in the given case distinction
+    singleCase m =
+        case    removeRedundantCases ctxt [] id . map cleanupSystem
+              . map fst . getDisj $ execReduction m ctxt sys (avoid sys) of
+          []                  -> return $ M.empty
+          [sys'] | check sys' -> return $ M.singleton "" sys'
+                 | otherwise  -> mzero
+          syss                ->
+               return $ M.fromList (zip (map show [(1::Int)..]) syss)
+      where check sys' = cleanupSystem sys /= sys'
 
     -- solve the given goal
     -- PRE: Goal must be valid in this system.
-    solve :: Goal -> Reduction CaseName
-    solve goal =
-      let ths = L.get pcSources ctxt
-      in maybe  (solveGoal goal)
-                (intercalate "_" <$>)
-                (solveWithSource ctxt ths goal)
-
-    -- Induction is only possible if the system contains only
-    -- a single, last-free, closed formula.
-    getInductionCases :: System -> Maybe (LNGuarded, LNGuarded)
-    getInductionCases s = do
-      (h, _) <- uncons $ S.toList $ L.get sFormulas s
-      either (const Nothing) Just (ginduct h)
-
-    induction :: (LNGuarded, LNGuarded) -> Reduction String
-    induction (baseCase, stepCase) = do
-      (caseName, caseFormula) <- disjunctionOfList [("empty_trace", baseCase), ("non_empty_trace", stepCase)]
-      L.setM sFormulas (S.singleton caseFormula)
-      return caseName
-
-    distinguish n =
-        [ (\(x,y) -> (if null x then show i else x ++ "_case_" ++ pad (show i), y))
-        | i <- [(1::Int)..] ]
+    execSolveGoal :: Goal -> Maybe (M.Map CaseName System)
+    execSolveGoal goal =
+        return . makeCaseNames . removeRedundantCases ctxt [] snd
+               . map (second cleanupSystem) . map fst . getDisj
+               $ reduc
       where
-        l      = length (show n)
-        pad cs = replicate (l - length cs) '0' ++ cs
+        reduc  = runReduction solver ctxt sys (avoid sys)
+        ths    = L.get pcSources ctxt
+        solver = do name <- maybe (solveGoal goal)
+                                  (fmap $ concat . intersperse "_")
+                                  (solveWithSource ctxt ths goal)
+                    simplifySystem
+                    return name
+
+        makeCaseNames =
+            M.fromListWith (error "case names not unique")
+          . uniqueListBy (comparing fst) id distinguish
+          where
+            distinguish n =
+                [ (\(x,y) -> (x ++ "_case_" ++ pad (show i), y))
+                | i <- [(1::Int)..] ]
+              where
+                l      = length (show n)
+                pad cs = replicate (l - length cs) '0' ++ cs
+
+    -- Apply induction: possible if the system contains only
+    -- a single, last-free, closed formula.
+    execInduction
+      | sys == sys0 =
+          case S.toList $ L.get sFormulas sys of
+            [gf] -> case ginduct gf of
+                      Right (bc, sc) -> Just $ insCase "empty_trace"     bc
+                                             $ insCase "non_empty_trace" sc
+                                             $ M.empty
+                      _              -> Nothing
+            _    -> Nothing
+
+      | otherwise = Nothing
+      where
+        sys0 = set sFormulas (L.get sFormulas sys)
+             $ set sLemmas (L.get sLemmas sys)
+             $ emptySystem (L.get sSourceKind sys) (L.get sDiffSystem sys)
+
+        insCase name gf = M.insert name (set sFormulas (S.singleton gf) sys)
 
 -- @execDiffMethod rules method se@ checks first if the @method@ is applicable to
 -- the sequent @se@. Then, it applies the @method@ to the sequent under the
@@ -345,69 +335,63 @@ execProofMethod ctxt method sys =
 -- and all variable indices reset.
 execDiffProofMethod :: DiffProofContext
                 -> DiffProofMethod -> DiffSystem -> Maybe (M.Map CaseName DiffSystem)
-execDiffProofMethod ctxt method sys =
-  case method of
-    DiffSorry _ -> return M.empty
-    DiffBackwardSearch -> do
-      guard (L.get dsProofType sys == Just RuleEquivalence)
-      rule <- L.get dsCurrentRule sys
-      guard (isNothing $ L.get dsSide sys)
-      return $ startBackwardSearch rule
-    DiffBackwardSearchStep meth -> do
-      guard (L.get dsProofType sys == Just RuleEquivalence)
-      guard (meth /= Induction)
-      guard (meth /= Finished (Contradictory (Just ForbiddenKD)))
-      _ <- L.get dsCurrentRule sys
-      s <- L.get dsSide sys
-      applyStep meth s =<< sequent
-    DiffMirrored -> do
-      guard (L.get dsProofType sys == Just RuleEquivalence)
-      guard (isJust $ L.get dsCurrentRule sys)
-      msys' >>= guard . trivial
-      mallSubtermsFinished >>= guard
-      mirrorSyss <- mmirrorSyss
-      solved <- isSolved <$> mside <*> msys'
-      guard (fst (evaluateRestrictions ctxt sys mirrorSyss solved) == TTrue)
-      return M.empty
-    DiffAttack -> do
-      guard (L.get dsProofType sys == Just RuleEquivalence)
-      guard (isJust $ L.get dsCurrentRule sys)
-      s <- L.get dsSide sys
-      solved <- isSolved <$> mside <*> msys'
-      sys' <- L.get dsSystem sys
-      notContradictory <- not . contradictorySystem (eitherProofContext ctxt s) <$> sequent
-      -- In the second case, the system is trivial, has no mirror and restrictions do not get in the way.
-      -- If we solve arbitrarily the last remaining trivial goals,
-      -- then there will be an attack.
-      guard (solved || (trivial sys' && notContradictory))
-      allSubtermsFinished <- mallSubtermsFinished
-      guard allSubtermsFinished
-      mirrorSyss <- mmirrorSyss
-      guard (fst (evaluateRestrictions ctxt sys mirrorSyss solved) == TFalse)
-      return M.empty
-    DiffRuleEquivalence -> do
-      guard (isNothing $ L.get dsProofType sys)
-      return ruleEquivalence
-    DiffUnfinishable -> do
-      guard (L.get dsProofType sys == Just RuleEquivalence)
-      guard (isJust $ L.get dsCurrentRule sys)
-      solved <- isSolved <$> mside <*> msys'
-      allSubtermsFinished <- mallSubtermsFinished
-      guard solved
-      guard (not allSubtermsFinished)
-      return M.empty
+execDiffProofMethod ctxt method sys = -- error $ show ctxt ++ show method ++ show sys -- return M.empty
+      case method of
+        DiffSorry _                                           -> return M.empty
+        DiffBackwardSearch
+          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys) of
+                                                                      (Just rule, Nothing) -> Just $ startBackwardSearch rule
+                                                                      (_ , _)              -> Nothing
+          | otherwise                                         -> Nothing
+        DiffBackwardSearchStep meth
+          | (L.get dsProofType sys) == (Just RuleEquivalence)
+            && (meth /= Induction)
+            && (meth /= (Contradiction (Just ForbiddenKD)))   -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
+                                                                      (Just _, Just s, Just sys') -> applyStep meth s sys'
+                                                                      (_ , _ , _)                 -> Nothing
+          | otherwise                                         -> Nothing
+        DiffMirrored
+          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
+                                                                      (Just _, Just s, Just sys') -> if isTrivial sys' && allSubtermsFinished && (fst (evaluateRestrictions ctxt sys mirrorSyss (isSolved s sys')) == TTrue)
+                                                                                                        then return M.empty
+                                                                                                        else Nothing
+                                                                                                    where
+                                                                                                        mirrorSyss = getMirrorDG ctxt s sys'
+                                                                                                        mirrorCtxt = eitherProofContext ctxt (opposite s)
+                                                                                                        allSubtermsFinished = finishedSubterms (eitherProofContext ctxt s) sys' && all (finishedSubterms mirrorCtxt) mirrorSyss
+                                                                      (_ , _ , _)                 -> Nothing                                                       
+          | otherwise                                         -> Nothing
+        DiffAttack
+          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
+                                                                      (Just _, Just s, Just sys') -> if (isSolved s sys' || (isTrivial sys' && not (contradictorySystem (eitherProofContext ctxt s) sys'))) &&
+                                                                                                        (allSubtermsFinished && (fst (evaluateRestrictions ctxt sys mirrorSyss (isSolved s sys')) == TFalse))
+                                                                                                      then return M.empty
+                                                                                                        -- In the second case, the system is trivial, has no mirror and restrictions do not get in the way.
+                                                                                                        -- If we solve arbitrarily the last remaining trivial goals,
+                                                                                                        -- then there will be an attack.                                                                                                        then 
+                                                                                                      else Nothing
+                                                                                                        where
+                                                                                                          mirrorSyss = getMirrorDG ctxt s sys'
+                                                                                                          mirrorCtxt = eitherProofContext ctxt (opposite s)
+                                                                                                          allSubtermsFinished = finishedSubterms (eitherProofContext ctxt s) sys' && all (finishedSubterms mirrorCtxt) mirrorSyss
+                                                                      (_ , _ , _)                 -> Nothing
+          | otherwise                                         -> Nothing
+        DiffRuleEquivalence
+          | (L.get dsProofType sys) == Nothing                -> Just ruleEquivalence
+          | otherwise                                         -> Nothing
+        DiffUnfinishable
+          | (L.get dsProofType sys) == (Just RuleEquivalence) -> case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
+                                                                      (Just _, Just s, Just sys') -> if isSolved s sys' && not allSubtermsFinished
+                                                                                                        then return M.empty
+                                                                                                        else Nothing
+                                                                                                      where
+                                                                                                        mirrorSyss = getMirrorDG ctxt s sys'
+                                                                                                        mirrorCtxt = eitherProofContext ctxt (opposite s)
+                                                                                                        allSubtermsFinished = finishedSubterms (eitherProofContext ctxt s) sys' && all (finishedSubterms mirrorCtxt) mirrorSyss
+                                                                      (_ , _ , _)                 -> Nothing
+          | otherwise                                         -> Nothing
+          
   where
-    sequent              = L.get dsSystem sys
-    mside                = L.get dsSide sys
-    msys'                = L.get dsSystem sys
-    mmirrorSyss          = getMirrorDG ctxt <$> mside <*> msys'
-    mctxt                = eitherProofContext ctxt <$> mside
-    mmirrorCtxt          = eitherProofContext ctxt . opposite <$> mside
-    mallSubtermsFinished = do
-      finished <- finishedSubterms <$> mctxt <*> msys'
-      finishedMirrored <- (all . finishedSubterms <$> mmirrorCtxt) <*> mmirrorSyss
-      return $ finished && finishedMirrored
-
     protoRules       = L.get dpcProtoRules  ctxt
     destrRules       = L.get dpcDestrRules  ctxt
     constrRules      = L.get dpcConstrRules ctxt
@@ -434,10 +418,10 @@ execDiffProofMethod ctxt method sys =
     -- LHS or RHS is not important in this case as we only need the names of the rules.
     ruleEquivalence :: M.Map CaseName DiffSystem
     ruleEquivalence = foldl ruleEquivalenceCase (foldl ruleEquivalenceCase {-(foldl ruleEquivalenceCase-} M.empty {-constrRules)-} destrRules) (protoRulesAC LHS)
-
-    trivial :: System -> Bool
-    trivial sys' = (dgIsNotEmpty sys') && (allOpenGoalsAreSimpleFacts ctxt sys') && (allOpenFactGoalsAreIndependent sys')
-
+    
+    isTrivial :: System -> Bool
+    isTrivial sys' = (dgIsNotEmpty sys') && (allOpenGoalsAreSimpleFacts ctxt sys') && (allOpenFactGoalsAreIndependent sys')
+    
     backwardSearchSystem :: Side -> DiffSystem -> String -> DiffSystem
     backwardSearchSystem s sys' rulename = L.set dsSide (Just s)
       $ L.set dsSystem (Just ruleSys) sys'
@@ -447,14 +431,15 @@ execDiffProofMethod ctxt method sys =
 
     startBackwardSearch :: String -> M.Map CaseName DiffSystem
     startBackwardSearch rulename = M.insert ("LHS") (backwardSearchSystem LHS sys rulename) $ M.insert ("RHS") (backwardSearchSystem RHS sys rulename) $ M.empty
+    
+    applyStep :: ProofMethod -> Side -> System -> Maybe (M.Map CaseName DiffSystem)
+    applyStep m s sys' = case (execProofMethod (eitherProofContext ctxt s) m sys') of
+                           Nothing    -> Nothing
+                           Just cases -> Just $ M.map (\x -> L.set dsSystem (Just x) sys) cases
 
     isSolved :: Side -> System -> Bool
-    isSolved s sys' = isJust $ isFinished (eitherProofContext ctxt s) sys' >>= guard . (== Solved)
+    isSolved s sys' = (rankProofMethods GoalNrRanking [defaultTactic] (eitherProofContext ctxt s) sys') == [] -- checks if the system is solved
 
-    applyStep :: ProofMethod -> Side -> System -> Maybe (M.Map CaseName DiffSystem)
-    applyStep m s dsSys = do
-      cases <- execProofMethod (eitherProofContext ctxt s) m dsSys
-      return $ M.map (\x -> L.set dsSystem (Just x) sys) cases
 
 -- | returns True if there are no reducible operators on top of a right side of a subterm in the subterm store
 finishedSubterms :: ProofContext -> System -> Bool
@@ -500,37 +485,31 @@ rankGoals ctxt ranking tacticsList sys = case ranking of
       chooseError [] _ = error $ "No tactic has been written in the theory file"
       chooseError _  t = error $ "The tactic specified ( "++(show $ _name t)++" ) is not written in the theory file, please chose among the following: "++(show definedHeuristic)
 
-isFinished :: ProofContext -> System -> Maybe Result
-isFinished ctxt sys
-  | isInitialSystem sys = Nothing
-  | not $ null cs = Just $ Contradictory (Just $ head cs)
-  | null ogs && stFinished = Just Solved
-  | null ogs && not stFinished = Just Unfinishable
-  | otherwise = Nothing
-  where
-    cs = contradictions ctxt sys
-    ogs = openGoals sys
-    stFinished = finishedSubterms ctxt sys
-
 -- | Use a 'GoalRanking' to generate the ranked, list of possible
 -- 'ProofMethod's and their corresponding results in this 'ProofContext' and
--- for this 'System'.
+-- for this 'System'. If the resulting list is empty, then the constraint
+-- system is solved.
 rankProofMethods :: GoalRanking ProofContext -> [Tactic ProofContext] -> ProofContext -> System
                  -> [(ProofMethod, (M.Map CaseName System, String))]
 rankProofMethods ranking tactics ctxt sys =
-  let Ranking (map solveGoalMethod -> goals) instr = rankGoals ctxt ranking tactics sys (openGoals sys)
-      insertInduction (simplify NE.:| gs) = case L.get pcUseInduction ctxt of
-        AvoidInduction -> simplify : (Induction, "") : gs
-        UseInduction   -> (Induction, "") : simplify : gs
-      proofMethods = bool NE.toList insertInduction (isInitialSystem sys) ((Simplify, "") NE.:| goals)
-      stoppingMethod =    (Finished <$> isFinished ctxt sys)
-                      <|> (Sorry (Just "Oracle ranked no proof methods") <$ instr)
-  in execMethods $ maybe proofMethods ((:[]) . (,"")) stoppingMethod
+  let rankedGoals = rankGoals ctxt ranking tactics sys $ openGoals sys
+      cs = contradictions ctxt sys
+  in case rankedGoals of
+    Ranking gs (Just ApplySorry)
+      | null cs && not (null gs) -> [(Sorry (Just "Oracle ranked no proof methods"), (M.empty, ""))]
+    Ranking gs _ -> do
+      (m, expl) <-
+              (contradiction <$> cs)
+          <|> (case L.get pcUseInduction ctxt of
+                AvoidInduction -> [(Simplify, ""), (Induction, "")]
+                UseInduction   -> [(Induction, ""), (Simplify, "")]
+              )
+          <|> (solveGoalMethod <$> gs)
+      case execProofMethod ctxt m sys of
+        Just cases -> return (m, (cases, expl))
+        Nothing    -> []
   where
-    execMethods = mapMaybe execMethod
-    execMethod (m, expl) = do
-      cases <- execProofMethod ctxt m sys
-      return (m, (cases, expl))
+    contradiction c                    = (Contradiction (Just c), "")
 
     sourceRule goal = case goalRule sys goal of
         Just ru -> " (from rule " ++ getRuleName ru ++ ")"
@@ -553,21 +532,19 @@ rankDiffProofMethods :: GoalRanking ProofContext -> [Tactic ProofContext] -> Dif
                  -> [(DiffProofMethod, (M.Map CaseName DiffSystem, String))]
 rankDiffProofMethods ranking tactics ctxt sys = do
     (m, expl) <-
-            [ (DiffRuleEquivalence, "Prove equivalence using rule equivalence")
-            , (DiffMirrored, "Backward search completed")
-            , (DiffAttack, "Found attack")
-            , (DiffUnfinishable, "Proof cannot be finished")
-            , (DiffBackwardSearch, "Do backward search from rule")]
-        ++  maybe []
-              (map (\x -> (DiffBackwardSearchStep (fst x), "Do backward search step")) . filter (isDiffApplicable . fst))
-              ((rankProofMethods ranking tactics . eitherProofContext ctxt <$> L.get dsSide sys) <*> sys')
-    maybe [] (return . (m,) . (,expl)) (execDiffProofMethod ctxt m sys)
-  where
-    sys' = L.get dsSystem sys
-    isDiffApplicable (Finished (Contradictory _)) = True
-    isDiffApplicable Simplify = True
-    isDiffApplicable (SolveGoal _) = True
-    isDiffApplicable _ = False
+            [(DiffRuleEquivalence, "Prove equivalence using rule equivalence")]
+        <|> [(DiffMirrored, "Backward search completed")]
+        <|> [(DiffAttack, "Found attack")]
+        <|> [(DiffUnfinishable, "Proof cannot be finished")]
+        <|> [(DiffBackwardSearch, "Do backward search from rule")]
+        <|> (case (L.get dsSide sys, L.get dsSystem sys) of
+                  (Just s, Just sys') -> map (\x -> (DiffBackwardSearchStep (fst x), "Do backward search step"))
+                                          $ filter (\x -> not $ fst x == Induction)
+                                          $ rankProofMethods ranking tactics (eitherProofContext ctxt s) sys'
+                  (_     , _        ) -> [])
+    case execDiffProofMethod ctxt m sys of
+      Just cases -> return (m, (cases, expl))
+      Nothing    -> []
 
 -- | Smart constructor for heuristics. Schedules the proof method rankings in a
 -- round-robin fashion dependent on the proof depth.
@@ -1171,14 +1148,15 @@ smartDiffRanking ctxt sys =
 -- | Pretty-print a proof method.
 prettyProofMethod :: HighlightDocument d => ProofMethod -> d
 prettyProofMethod method = case method of
-    Finished Solved -> keyword_ "SOLVED" <-> lineComment_ "trace found"
-    Induction  -> keyword_ "induction"
-    Finished Unfinishable -> keyword_ "UNFINISHABLE" <-> lineComment_ "reducible operator in subterm"
-    Sorry reason ->
+    Solved               -> keyword_ "SOLVED" <-> lineComment_ "trace found"
+    Unfinishable         -> keyword_ "UNFINISHABLE" <-> lineComment_ "reducible operator in subterm"
+    Induction            -> keyword_ "induction"
+    Sorry reason         ->
         fsep [keyword_ "sorry", maybe emptyDoc closedComment_ reason]
-    SolveGoal goal -> keyword_ "solve(" <-> prettyGoal goal <-> keyword_ ")"
-    Simplify -> keyword_ "simplify"
-    Finished (Contradictory reason) ->
+    SolveGoal goal       ->
+        keyword_ "solve(" <-> prettyGoal goal <-> keyword_ ")"
+    Simplify             -> keyword_ "simplify"
+    Contradiction reason ->
         sep [ keyword_ "contradiction"
             , maybe emptyDoc (closedComment . prettyContradiction) reason
             ]

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -125,7 +125,6 @@ module Theory.Constraint.System (
 
   -- ** Construction
   , emptySystem
-  , isInitialSystem
   , emptyDiffSystem
 
   , SystemTraceQuantifier(..)
@@ -823,11 +822,6 @@ emptySystem d isdiff = System
     M.empty S.empty S.empty Nothing emptySubtermStore emptyEqStore
     S.empty S.empty S.empty
     M.empty 0 d isdiff
-
--- TODO: I do not like the second conjunct; this should be done cleaner
-isInitialSystem :: System -> Bool
-isInitialSystem sys = null (L.get sSolvedFormulas sys) && not (S.member bot (L.get sFormulas sys))
-  where bot = GDisj (Disj [])
 
 -- | The empty diff constraint system.
 emptyDiffSystem :: DiffSystem

--- a/lib/theory/src/Theory/Proof.hs
+++ b/lib/theory/src/Theory/Proof.hs
@@ -45,7 +45,6 @@ module Theory.Proof (
   -- ** Unfinished proofs
   , sorry
   , unproven
-  , unprovenLookAhead
   , diffSorry
   , diffUnproven
 
@@ -255,13 +254,6 @@ unproven :: a -> Proof a
 unproven = sorry Nothing
 
 -- | A proof denoting an unproven part of the proof.
-unprovenLookAhead :: ProofContext -> System -> IncrementalProof
-unprovenLookAhead ctxt sys = maybe (sorry Nothing (Just sys)) toNode (isFinished ctxt sys)
-  where
-    toNode :: Result -> IncrementalProof
-    toNode r = LNode (ProofStep (Finished r) (Just sys)) M.empty
-
--- | A proof denoting an unproven part of the proof.
 diffUnproven :: a -> DiffProof a
 diffUnproven = diffSorry Nothing
 
@@ -422,8 +414,8 @@ instance Monoid ProofStatus where
 -- | The status of a 'ProofStep'.
 proofStepStatus :: ProofStep (Maybe a) -> ProofStatus
 proofStepStatus (ProofStep _            Nothing ) = UndeterminedProof
-proofStepStatus (ProofStep (Finished Solved) (Just _)) = TraceFound
-proofStepStatus (ProofStep (Finished Unfinishable) (Just _)) = UnfinishableProof
+proofStepStatus (ProofStep Solved       (Just _)) = TraceFound
+proofStepStatus (ProofStep Unfinishable (Just _)) = UnfinishableProof
 proofStepStatus (ProofStep (Sorry _)    (Just _)) = IncompleteProof
 proofStepStatus (ProofStep _            (Just _)) = CompleteProof
 
@@ -435,6 +427,30 @@ diffProofStepStatus (DiffProofStep (DiffSorry _)    (Just _)) = IncompleteProof
 diffProofStepStatus (DiffProofStep DiffUnfinishable (Just _)) = UnfinishableProof
 diffProofStepStatus (DiffProofStep _                (Just _)) = CompleteProof
 
+
+{- TODO: Test and probably improve
+
+-- | @proveSystem rules se@ tries to construct a proof that @se@ is valid.
+-- This proof may contain 'Sorry' steps, if the prover is stuck. It can also be
+-- of infinite depth, if the proof strategy loops.
+proveSystemIterDeep :: ProofContext -> System -> Proof System
+proveSystemIterDeep rules se0 =
+    fromJust $ asum $ map (prove se0 . round) $ iterate (*1.5) (3::Double)
+  where
+    prove :: System -> Int -> Maybe (Proof System)
+    prove se bound
+      | bound < 0 = Nothing
+      | otherwise =
+          case next of
+            [] -> pure $ sorry "prover stuck => possible attack found" se
+            xs -> asum $ map mkProof xs
+      where
+        next = do m <- possibleProofMethods se
+                  (m,) <$> maybe mzero return (execProofMethod rules m se)
+        mkProof (method, cases) =
+            LNode (ProofStep method se) <$> traverse (`prove` (bound - 1)) cases
+-}
+
 -- | @checkProof rules se prf@ replays the proof @prf@ against the start
 -- sequent @se@. A failure to apply a proof method is denoted by a resulting
 -- proof step without an annotated sequent. An unhandled case is denoted using
@@ -445,21 +461,22 @@ checkProof :: ProofContext
            -> System
            -> Proof a
            -> Proof (Maybe a, Maybe System)
-checkProof ctxt prover =
-    go
+checkProof ctxt prover d sys prf@(LNode (ProofStep method info) cs) =
+    case (method, execProofMethod ctxt method sys) of
+        (Sorry reason, _         ) -> sorryNode reason cs
+        (_           , Just cases) -> node method $ checkChildren cases
+        (_           , Nothing   ) ->
+            sorryNode (Just "invalid proof step encountered")
+                      (M.singleton "" prf)
   where
-    go d sys prf@(LNode (ProofStep method info) cs) = case (method, checkAndExecProofMethod ctxt method sys) of
-      (Sorry reason, _         ) -> sorryNode reason cs
-      (_           , Just cases) -> node method $ checkChildren cases
-      (_           , Nothing   ) -> sorryNode (Just "invalid proof step encountered")
-                                      (M.singleton "" prf)
-      where
-        unhandledCase = mapProofInfo (Nothing,) . prover d
-        checkChildren cases = mergeMapsWith unhandledCase noSystemPrf (go (d + 1)) cases cs
+    node m                 = LNode (ProofStep m (Just info, Just sys))
+    sorryNode reason cases = node (Sorry reason) (M.map noSystemPrf cases)
+    noSystemPrf            = mapProofInfo (\i -> (Just i, Nothing))
 
-        node m                 = LNode (ProofStep m (Just info, Just sys))
-        sorryNode reason cases = node (Sorry reason) (M.map noSystemPrf cases)
-        noSystemPrf            = mapProofInfo (\i -> (Just i, Nothing))
+    checkChildren cases = mergeMapsWith
+        unhandledCase noSystemPrf (checkProof ctxt prover (d + 1)) cases cs
+      where
+        unhandledCase = mapProofInfo ((,) Nothing) . prover d
 
 -- | @checkDiffProof rules se prf@ replays the proof @prf@ against the start
 -- sequent @se@. A failure to apply a proof method is denoted by a resulting
@@ -471,22 +488,65 @@ checkDiffProof :: DiffProofContext
            -> DiffSystem
            -> DiffProof a
            -> DiffProof (Maybe a, Maybe DiffSystem)
-checkDiffProof ctxt prover =
+checkDiffProof ctxt prover d sys prf@(LNode (DiffProofStep method info) cs) =
+    case (method, execDiffProofMethod ctxt method sys) of
+        (DiffSorry reason, _         ) -> sorryNode reason cs
+        (_               , Just cases) -> node method $ checkChildren cases
+        (_               , Nothing   ) ->
+            sorryNode (Just "invalid proof step encountered")
+                      (M.singleton "" prf)
+  where
+    node m                 = LNode (DiffProofStep m (Just info, Just sys))
+    sorryNode reason cases = node (DiffSorry reason) (M.map noSystemPrf cases)
+    noSystemPrf            = mapDiffProofInfo (\i -> (Just i, Nothing))
+
+    checkChildren cases = mergeMapsWith
+        unhandledCase noSystemPrf (checkDiffProof ctxt prover (d + 1)) cases cs
+      where
+        unhandledCase = mapDiffProofInfo ((,) Nothing) . prover d
+
+
+-- | Annotate a proof with the constraint systems of all intermediate steps
+-- under the assumption that all proof steps are valid. If some proof steps
+-- might be invalid, then you must use 'checkProof', which handles them
+-- gracefully.
+annotateWithSystems :: ProofContext -> System -> Proof () -> Proof System
+annotateWithSystems ctxt =
     go
   where
-    go d s prf@(LNode (DiffProofStep method info) cs) = case (method, execDiffProofMethod ctxt method s) of
-      (DiffSorry reason, _         ) -> sorryNode reason cs
-      (_               , Just cases) -> node method $ checkChildren cases
-      (_               , Nothing   ) ->
-          sorryNode (Just "invalid proof step encountered")
-                    (M.singleton "" prf)
+    -- Here we are careful to construct the result such that an inspection of
+    -- the proof does not force the recomputed constraint systems.
+    go sysOrig (LNode (ProofStep method _) csOrig) =
+      LNode (ProofStep method sysOrig) $ M.fromList $ do
+          (name, prf) <- M.toList csOrig
+          let sysAnn = extract ("case '" ++ name ++ "' non-existent") $
+                       M.lookup name csAnn
+          return (name, go sysAnn prf)
       where
-        unhandledCase = mapDiffProofInfo (Nothing,) . prover d
-        checkChildren cases = mergeMapsWith unhandledCase noSystemPrf (go (d + 1)) cases cs
+        extract msg = fromMaybe (error $ "annotateWithSystems: " ++ msg)
+        csAnn       = extract "proof method execution failed" $
+                      execProofMethod ctxt method sysOrig
 
-        node m                 = LNode (DiffProofStep m (Just info, Just s))
-        sorryNode reason cases = node (DiffSorry reason) (M.map noSystemPrf cases)
-        noSystemPrf            = mapDiffProofInfo (\i -> (Just i, Nothing))
+-- | Annotate a proof with the constraint systems of all intermediate steps
+-- under the assumption that all proof steps are valid. If some proof steps
+-- might be invalid, then you must use 'checkProof', which handles them
+-- gracefully.
+annotateWithDiffSystems :: DiffProofContext -> DiffSystem -> DiffProof () -> DiffProof DiffSystem
+annotateWithDiffSystems ctxt =
+    go
+  where
+    -- Here we are careful to construct the result such that an inspection of
+    -- the proof does not force the recomputed constraint systems.
+    go sysOrig (LNode (DiffProofStep method _) csOrig) =
+      LNode (DiffProofStep method sysOrig) $ M.fromList $ do
+          (name, prf) <- M.toList csOrig
+          let sysAnn = extract ("case '" ++ name ++ "' non-existent") $
+                       M.lookup name csAnn
+          return (name, go sysAnn prf)
+      where
+        extract msg = fromMaybe (error $ "annotateWithSystems: " ++ msg)
+        csAnn       = extract "diff proof method execution failed" $
+                      execDiffProofMethod ctxt method sysOrig
 
 ------------------------------------------------------------------------------
 -- Provers: the interface to the outside world.
@@ -577,7 +637,7 @@ tryProver =  (`orelse` mempty)
 oneStepProver :: ProofMethod -> Prover
 oneStepProver method = Prover $ \ctxt _ se _ -> do
     cases <- execProofMethod ctxt method se
-    return $ LNode (ProofStep method (Just se)) (M.map (unprovenLookAhead ctxt) cases)
+    return $ LNode (ProofStep method (Just se)) (M.map (unproven . Just) cases)
 
 -- | Try to execute one proof step using the given proof method.
 oneStepDiffProver :: DiffProofMethod -> DiffProver
@@ -663,8 +723,8 @@ firstProver = foldr orelse failProver
 contradictionProver :: Prover
 contradictionProver = Prover $ \ctxt d sys prf ->
     runProver
-        (firstProver $ map oneStepProver
-            (Finished . Contradictory . Just <$> contradictions ctxt sys))
+        (firstProver $ map oneStepProver $
+            (Contradiction . Just <$> contradictions ctxt sys))
         ctxt d sys prf
 
 -- | Use the first diff prover that works.
@@ -677,7 +737,7 @@ contradictionDiffProver = DiffProver $ \ctxt d sys prf ->
   case (L.get dsCurrentRule sys, L.get dsSide sys, L.get dsSystem sys) of
     (Just _, Just s, Just sys') -> runDiffProver
               (firstDiffProver $ map oneStepDiffProver $
-                  (DiffBackwardSearchStep . Finished . Contradictory . Just <$> contradictions (eitherProofContext ctxt s) sys'))
+                  (DiffBackwardSearchStep . Contradiction . Just <$> contradictions (eitherProofContext ctxt s) sys'))
           ctxt d sys prf
     (_     , _     , _        ) -> Nothing
 
@@ -736,8 +796,10 @@ runAutoProver aut@(AutoProver _ _  bound cut _) =
     -- | The standard automatic prover that ignores the existing proof and
     -- tries to find one by itself.
     autoProver :: Prover
-    autoProver = Prover $ \ctxt depth sysPath _ ->
-        return $ proveSystemDFS (selectHeuristic aut ctxt) (selectTactic aut ctxt) ctxt depth sysPath
+    autoProver = Prover $ \ctxt depth sys _ ->
+        return $ fmap (fmap Just)
+               $ annotateWithSystems ctxt sys
+               $ proveSystemDFS (selectHeuristic aut ctxt) (selectTactic aut ctxt) ctxt depth sys
 
     -- | Bound the depth of proofs generated by the given prover.
     boundProver :: Int -> Prover -> Prover
@@ -758,8 +820,10 @@ runAutoDiffProver aut@(AutoProver _ _ bound cut _) =
     -- | The standard automatic prover that ignores the existing proof and
     -- tries to find one by itself.
     autoProver :: DiffProver
-    autoProver = DiffProver $ \ctxt depth syss _ ->
-        return $ proveDiffSystemDFS (selectDiffHeuristic aut ctxt) (selectDiffTactic aut ctxt) ctxt depth syss
+    autoProver = DiffProver $ \ctxt depth sys _ ->
+        return $ fmap (fmap Just)
+               $ annotateWithDiffSystems ctxt sys
+               $ proveDiffSystemDFS (selectDiffHeuristic aut ctxt) (selectDiffTactic aut ctxt) ctxt depth sys
 
     -- | Bound the depth of proofs generated by the given prover.
     boundProver :: Int -> DiffProver -> DiffProver
@@ -797,7 +861,7 @@ cutOnSolvedSingleThreadDFS prf0 =
         findSolved node = case node of
               -- do not search in nodes that are not annotated
               LNode (ProofStep _      (Nothing, _   )) _  -> NoSolution
-              LNode (ProofStep (Finished Solved) (Just _ , path)) _  -> Solution path
+              LNode (ProofStep Solved (Just _ , path)) _  -> Solution path
               LNode (ProofStep _      (Just _ , _   )) cs ->
                   foldMap findSolved cs
 
@@ -860,7 +924,7 @@ cutOnSolvedDFS prf0 =
           | otherwise = case node of
               -- do not search in nodes that are not annotated
               LNode (ProofStep _      (Nothing, _   )) _  -> NoSolution
-              LNode (ProofStep (Finished Solved) (Just _ , path)) _  -> Solution path
+              LNode (ProofStep Solved (Just _ , path)) _  -> Solution path
               LNode (ProofStep _      (Just _ , _   )) cs ->
                   foldMap (findSolved (succ d))
                       (cs `using` parTraversable nfProofMethod)
@@ -935,7 +999,7 @@ cutOnSolvedBFS =
           (prf', TraceFound)     ->
               trace ("attack found at depth: " ++ show l) prf'
 
-    checkLevel 0 (LNode  step@(ProofStep (Finished Solved) (Just _)) _) =
+    checkLevel 0 (LNode  step@(ProofStep Solved (Just _)) _) =
         S.put TraceFound >> return (LNode step M.empty)
     checkLevel 0 prf@(LNode (ProofStep _ x) cs)
       | M.null cs = return prf
@@ -983,9 +1047,11 @@ cutAfterFirstSorry :: Proof (Maybe a) -> Proof (Maybe a)
 cutAfterFirstSorry = snd . go False
   where
     go :: Bool -> Proof (Maybe a) -> (Bool, Proof (Maybe a))
-    go _      n@(LNode (ProofStep (Sorry _) _) _)     = (True, n)
-    go abort  n@(LNode (ProofStep (Finished _) _) _)  = (abort, n)
-    go True     (LNode (ProofStep _ ann) _)           = (True, LNode (ProofStep (Sorry Nothing) ann) M.empty)
+    go _      n@(LNode (ProofStep (Sorry _) _) _)         = (True, n)
+    go abort  n@(LNode (ProofStep Solved _) _)            = (abort, n)
+    go abort  n@(LNode (ProofStep Unfinishable _) _)      = (abort, n)
+    go abort  n@(LNode (ProofStep (Contradiction _) _) _) = (abort, n)
+    go True     (LNode (ProofStep _ ann) _)               = (True, LNode (ProofStep (Sorry Nothing) ann) M.empty)
     go False    (LNode r cs) =
       let (abort, cs') = M.mapAccum go False cs
       in (abort, LNode r cs')
@@ -1008,26 +1074,33 @@ cutAfterFirstSorryDiff = snd . go False
 -- constraint system using a depth-first-search strategy to resolve the
 -- non-determinism wrt. what goal to solve next.  This proof can be of
 -- infinite depth, if the proof strategy loops.
-proveSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> ProofContext -> Int -> System -> Proof (Maybe System)
-proveSystemDFS heuristic tactics ctxt =
-    prove
+--
+-- Use 'annotateWithSystems' to annotate the proof tree with the constraint
+-- systems.
+proveSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> ProofContext -> Int -> System -> Proof ()
+proveSystemDFS heuristic tactics ctxt d0 sys0 =
+    prove d0 sys0
   where
     prove !depth sys =
         case rankProofMethods (useHeuristic heuristic depth) tactics ctxt sys of
-          [] | finishedSubterms ctxt sys  -> node (Finished Solved) M.empty
-          []                              -> node (Finished Unfinishable) M.empty
-          (method, (cases, _expl)):_      -> node method cases
+          [] | finishedSubterms ctxt sys -> node Solved M.empty
+          []                             -> node Unfinishable M.empty
+          (method, (cases, _expl)):_     -> node method cases
       where
+
         node method cases =
-          LNode (ProofStep method (Just sys)) (M.map (prove (succ depth)) cases)
+          LNode (ProofStep method ()) (M.map (prove (succ depth)) cases)
 
 -- | @proveSystemDFS rules se@ explores all solutions of the initial
 -- constraint system using a depth-first-search strategy to resolve the
 -- non-determinism wrt. what goal to solve next.  This proof can be of
 -- infinite depth, if the proof strategy loops.
-proveDiffSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> DiffProofContext -> Int -> DiffSystem -> DiffProof (Maybe DiffSystem)
-proveDiffSystemDFS heuristic tactics ctxt =
-    prove
+--
+-- Use 'annotateWithSystems' to annotate the proof tree with the constraint
+-- systems.
+proveDiffSystemDFS :: Heuristic ProofContext -> [Tactic ProofContext] -> DiffProofContext -> Int -> DiffSystem -> DiffProof ()
+proveDiffSystemDFS heuristic tactics ctxt d0 sys0 =
+    prove d0 sys0
   where
     prove !depth sys =
         case rankDiffProofMethods (useHeuristic heuristic depth) tactics ctxt sys of
@@ -1035,7 +1108,7 @@ proveDiffSystemDFS heuristic tactics ctxt =
           (method, (cases, _expl)):_ -> node method cases
       where
         node method cases =
-          LNode (DiffProofStep method (Just sys)) (M.map (prove (succ depth)) cases)
+          LNode (DiffProofStep method ()) (M.map (prove (succ depth)) cases)
 
 ------------------------------------------------------------------------------
 -- Pretty printing
@@ -1055,7 +1128,7 @@ prettyProofWith prettyStep prettyCase =
   where
     ppPrf (LNode ps cs) = ppCases ps (M.toList cs)
 
-    ppCases ps@(ProofStep (Finished Solved) _) [] = prettyStep ps
+    ppCases ps@(ProofStep Solved _) [] = prettyStep ps
     ppCases ps []                      = prettyCase ps (kwBy <> text " ")
                                            <> prettyStep ps
     ppCases ps [("", prf)]             = prettyStep ps $-$ ppPrf prf

--- a/lib/theory/src/Theory/Text/Parser/Proof.hs
+++ b/lib/theory/src/Theory/Text/Parser/Proof.hs
@@ -78,9 +78,9 @@ proofMethod = asum
   [ symbol "sorry"         *> pure (Sorry Nothing)
   , symbol "simplify"      *> pure Simplify
   , symbol "solve"         *> (SolveGoal <$> parens goal)
-  , symbol "contradiction" *> pure (Finished (Contradictory Nothing))
+  , symbol "contradiction" *> pure (Contradiction Nothing)
   , symbol "induction"     *> pure Induction
-  , symbol "UNFINISHABLE"  *> pure (Finished Unfinishable)
+  , symbol "UNFINISHABLE"  *> pure Unfinishable
   ]
 
 -- | Start parsing a proof skeleton.
@@ -99,7 +99,7 @@ proofSkeleton =
     solvedProof <|> finalProof <|> interProof
   where
     solvedProof =
-        symbol "SOLVED" *> pure (LNode (ProofStep (Finished Solved) ()) M.empty)
+        symbol "SOLVED" *> pure (LNode (ProofStep Solved ()) M.empty)
 
     finalProof = do
         method <- symbol "by" *> proofMethod

--- a/src/Main/Mode/Batch.hs
+++ b/src/Main/Mode/Batch.hs
@@ -40,7 +40,6 @@ import Theory.Constraint.System.Dot
 import Text.Dot qualified as D
 import Theory.Constraint.System.Graph.Graph
 import Theory.Constraint.System.JSON (sequentsToJSONPretty)
-import Theory.Constraint.Solver (ProofMethod(Finished))
 
 import ClosedTheory (prettyPrecomputation,prettyDiffPrecomputation)
 
@@ -280,9 +279,9 @@ run thisMode as
             -- | Collect all solved (i.e. a trace was found) systems of the theory along with their
             -- path in the proof.
             proofSystems :: IncrementalProof -> [(ProofPath, System)]
-            proofSystems (LNode (ProofStep (Finished Solved) (Just rootSystem)) _) =  [([], rootSystem)]
-            proofSystems (LNode (ProofStep _ _) children) =  
-              [(l : ls, system) | (l, subProof) <- M.toList children 
+            proofSystems (LNode (ProofStep Solved (Just rootSystem)) _) =  [([], rootSystem)]
+            proofSystems (LNode (ProofStep _ _) children) =
+              [(l : ls, system) | (l, subProof) <- M.toList children
                                 , (ls, system) <- proofSystems subProof ]
 
             -- | Make a label for use in the trace output out of all relevant information for a constraint system.

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -99,9 +99,15 @@ applyMethodAtPath thy lemmaName proofPath prover i = do
         heuristic = selectHeuristic prover ctxt
         ranking = useHeuristic heuristic (length proofPath)
         tactic = selectTactic prover ctxt
-    methods <- map fst . rankProofMethods ranking tactic ctxt <$> sys
+    methods <- (map fst . rankProofMethods ranking tactic ctxt) <$> sys
     method <- if length methods >= i then Just (methods !! (i-1)) else Nothing
-    applyProverAtPath thy lemmaName proofPath (oneStepProver method)
+    applyProverAtPath thy lemmaName proofPath
+      (oneStepProver method                            `mappend`
+       replaceSorryProver (oneStepProver Simplify)     `mappend`
+       replaceSorryProver (contradictionProver)        `mappend`
+       replaceSorryProver (oneStepProver Unfinishable) `mappend`
+       replaceSorryProver (oneStepProver Solved)
+      )
 
 applyMethodAtPathDiff :: ClosedDiffTheory -> Side -> String -> ProofPath
                       -> AutoProver             -- ^ How to extract/order the proof methods.
@@ -118,11 +124,11 @@ applyMethodAtPathDiff thy s lemmaName proofPath prover i = do
     methods <- (map fst . rankProofMethods ranking tactic ctxt) <$> sys
     method <- if length methods >= i then Just (methods !! (i-1)) else Nothing
     applyProverAtPathDiff thy s lemmaName proofPath
-      (oneStepProver method                                       `mappend`
-       replaceSorryProver (oneStepProver Simplify)                `mappend`
-       replaceSorryProver (contradictionProver)                   `mappend`
-       replaceSorryProver (oneStepProver (Finished Unfinishable)) `mappend`
-       replaceSorryProver (oneStepProver (Finished Solved))
+      (oneStepProver method                            `mappend`
+       replaceSorryProver (oneStepProver Simplify)     `mappend`
+       replaceSorryProver (contradictionProver)        `mappend`
+       replaceSorryProver (oneStepProver Unfinishable) `mappend`
+       replaceSorryProver (oneStepProver Solved)
       )
 
 applyDiffMethodAtPath :: ClosedDiffTheory -> String -> ProofPath
@@ -1788,10 +1794,10 @@ prevDiffThyPath thy = go
 
 -- | Interesting proof methods that are not skipped by next/prev-smart.
 isInterestingMethod :: ProofMethod -> Bool
-isInterestingMethod (Sorry _) = True
-isInterestingMethod (Finished Solved) = True
-isInterestingMethod (Finished Unfinishable) = True
-isInterestingMethod _ = False
+isInterestingMethod (Sorry _)    = True
+isInterestingMethod Solved       = True
+isInterestingMethod Unfinishable = True
+isInterestingMethod _            = False
 
 -- | Interesting diff proof methods that are not skipped by next/prev-smart.
 isInterestingDiffMethod :: DiffProofMethod -> Bool


### PR DESCRIPTION
Reverts tamarin-prover/tamarin-prover#650

We should wait for fixed regression targets as @jdreier correctly noted.