### PR TITLE
Update workflow function `upload-artifact`

### DIFF
--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Store case studies as artifact
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: case-studies
           path: case-studies


### PR DESCRIPTION
Deployment says:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Looking at https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/, I can just upgrade to v4. Let's see.