### PR TITLE
Fix bug in pretty printing tactics

### DIFF
--- a/lib/theory/src/TheoryObject.hs
+++ b/lib/theory/src/TheoryObject.hs
@@ -818,25 +818,28 @@ prettyConfigBlock :: HighlightDocument d => ConfigBlock -> d
 prettyConfigBlock cb = text "configuration: " <> doubleQuotes (text cb)
 
 prettyTactic :: HighlightDocument d => Tactic ProofContext -> d
-prettyTactic tactic = kwTactic <> colon <> space <> (text $ _name tactic) 
-    $-$ kwPresort <> colon <> space <> (char $ goalRankingToChar $ _presort tactic) $-$ sep
-        [ ppTabTab  "prio"  (map stringRankingPrio $ _prios tactic) (map stringsPrio $ _prios tactic)
-        , ppTabTab "deprio" (map stringRankingDeprio $ _deprios tactic) (map stringsDeprio $ _deprios tactic)
-        , char '\n'
-        ]
-   where 
+prettyTactic tactic =
+  kwTactic <> colon <> space <> text (_name tactic)
+    $-$ kwPresort <> colon <> space <> char (goalRankingToChar $ _presort tactic)
+    $-$ sep
+      [ ppTabTab "prio" (map stringRankingPrio $ _prios tactic) (map stringsPrio $ _prios tactic)
+      , ppTabTab "deprio" (map stringRankingDeprio $ _deprios tactic) (map stringsDeprio $ _deprios tactic)
+      , char '\n'
+      ]
+  where
+    -- Pretty print for a priority block
 
-        -- pretty print for a prio block
-        ppTab "prio" (rankingName,xs) = kwPrio <> colon <> space <> braces (text rankingName) $-$ (nest 2 $ vcat $ map prettify (map words xs))
-        ppTab "deprio" (rankingName,xs) = kwDeprio <> colon <> space <> braces (text rankingName) $-$ (nest 2 $ vcat $ map prettify (map words xs))
-        ppTab _ _ = emptyDoc
+    ppTab "prio" (rankingName, xs) =
+      kwPrio <> colon <> space <> braces (text rankingName)
+        $-$ nest 2 (vcat $ map text xs)
 
-        ppTabTab _ _ [] = emptyDoc
-        ppTabTab param rankingName listFunctions = vcat (map (ppTab param) (zip rankingName listFunctions))
+    
+    ppTab "deprio" (rankingName, xs) =
+      kwDeprio <> colon <> space <> braces (text rankingName)
+        $-$ nest 2 (vcat $ map text xs)
+    
+    ppTab _ _ = emptyDoc
 
-        prettify :: HighlightDocument d => [String] -> d
-        prettify []    = emptyDoc
-        prettify ("|":t) = (operator_ " | ") <> prettify t-- if (s == "|") || (s == "&") || (s == "not") then (operator_ s) <> prettify t else text s <> prettify t
-        prettify ("&":t) = (operator_ " & ") <> prettify t
-        prettify ("not":t) = (operator_ "not ") <> prettify t
-        prettify (s:t) = text s <> prettify t
+    ppTabTab _ _ [] = emptyDoc
+    ppTabTab param rankingName listFunctions =
+      vcat (zipWith (curry (ppTab param)) rankingName listFunctions)


### PR DESCRIPTION
Hi all,

currently, there is a bug in Tamarin that causes tactics to be pretty printed incorrectly; causing different semantics for the pretty-printed tactic.

In a nutshell, when pretty-printing, the string representation of a prio (or deprio) is split at whitespaces and stripped of them via the `words` function. As a result, the pretty-printed version of regexes no longer contains whitespaces; changing the semantics of the regex.

I've attached a file which serves as a minimal example (.txt to trick the upload)
[minimal_regex_printing_bug.txt](https://github.com/user-attachments/files/19432345/minimal_regex_printing_bug.txt)
and a screenshot of the bug
![regex_printing_bug_tamarin](https://github.com/user-attachments/assets/9b2234dc-3823-449a-be31-f71ae95db903)

As we can see, the original `regex "KU\( ~x"` is pretty-printed as `regex"KU\(~x)`.

To fix the bug, I've resorted to simply printing the function of a prio or deprio as given by the user. This definitely ensures no change in semantics, but also does not ``prettify''.

Actually, correctly pretty-printing a tactic is quite difficult since the datatype only contains the tactics semantics (i.e., the function that ranks the goals) and a string representation of the tactic. I.e., there is no AST that we can pretty-print.
See the previous `prettify :: HighlightDocument d => [String] -> d` function, which poorly tried to parse the string again causing the bug in the first place.
