### PR TITLE
Fix copy-paste-error in maude signature pretty print

### DIFF
--- a/lib/term/src/Term/Maude/Signature.hs
+++ b/lib/term/src/Term/Maude/Signature.hs
@@ -233,7 +233,7 @@ prettyMaudeSigExcept sig excl = P.vcat
       where
             showAttr (Public,Destructor) = "[destructor]"
             showAttr (Private,Destructor) = "[private,destructor]"
-            showAttr (Private,Constructor) = "[private,destructor]"
+            showAttr (Private,Constructor) = "[private,constructor]"
             showAttr (Public,Constructor) = ""
 
 prettyMaudeSig :: P.HighlightDocument d => MaudeSig -> d


### PR DESCRIPTION
Hi all,

Just a small copy-paste-error in the pretty-printing of a maude signature.