### PR TITLE
Extend ProVerif export module

### DIFF
--- a/examples/regression/trace/issue708.spthy
+++ b/examples/regression/trace/issue708.spthy
@@ -1,0 +1,40 @@
+theory test_state begin
+
+// TODO this should
+// (a) not give out a warning when exporting to ProVerif
+// (b) very all lemmas
+
+let reader(state) = (
+  lock state;
+  lookup state as x in 
+  event Read(state, x);
+  insert state, 'newstate';
+  unlock state
+)
+
+process:(
+  new state;
+    in(~x);
+  insert state, 'oldstate';
+  (
+    !reader(state)
+  )
+    
+)
+
+lemma ExOld:
+  exists-trace
+  "Ex s #i. Read(s, 'oldstate')@i"
+
+lemma ExNew:
+  exists-trace
+  "Ex s #i. Read(s, 'newstate')@i"
+
+lemma AlwaysOldOrNew:
+  "All s x #i. Read(s, x)@i ==> x = 'oldstate' | x = 'newstate'"
+
+lemma OldThenNew:
+  "All s #i #j.
+   Read(s, 'newstate')@i & Read(s, 'oldstate')@j ==> j < i"
+
+end

--- a/lib/accountability/src/Accountability/Generation.hs
+++ b/lib/accountability/src/Accountability/Generation.hs
@@ -5,16 +5,18 @@
 -- Portability : GHC only
 --
 -- Compute translation-specific restrictions
-module Accountability.Generation
-  ( generateAccountabilityLemmas
-  , checkWellformedness
-  ) where
+module Accountability.Generation (
+        generateAccountabilityLemmas
+      , checkWellformedness
+      , mergeQuantifiers
+) where
 
-import Control.Monad.Catch (MonadThrow)
-import Control.Monad.Fresh (MonadFresh, evalFreshT)
-import Text.PrettyPrint.Class (Document(text, ($-$)), ($--$), vcat, Doc)
-import Theory
-import Theory.Tools.Wellformedness (WfErrorReport)
+import           Control.Monad.Catch         (MonadThrow)
+import           Control.Monad.Fresh         (MonadFresh, evalFreshT)
+import qualified Extension.Data.Label        as L
+import           Text.PrettyPrint.Class      (Document(text, ($-$)), ($--$), vcat, Doc)
+import           Theory
+import           Theory.Tools.Wellformedness (WfErrorReport)
 
 ------------------------------------------------------------------------------
 -- Utilities

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -1,3 +1,8 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use lambda-case" #-}
+
 -- |
 -- Copyright   : (c) 2019 Charlie Jacomme and Robert Künnemann
 -- License     : GPL v3 (see LICENSE)
@@ -6,79 +11,85 @@
 -- Portability : GHC only
 --
 -- Translation from Sapic processes to ProVerif
-
 module Export
-  ( prettyProVerifTheory
-  , prettyProVerifEquivTheory
-  , prettyDeepSecTheory
-  ) where
+  ( prettyProVerifTheory,
+    prettyProVerifEquivTheory,
+    prettyDeepSecTheory,
+  )
+where
 
 import Control.Monad.Fresh
 import Control.Monad.Trans.PreciseFresh qualified as Precise
-
-import Data.Bifunctor
 import Data.ByteString.Char8 qualified as BC
 import Data.Char
 import Data.Data
+import Data.Function (on)
 import Data.Functor.Identity qualified
 import Data.List as List
 import Data.Map qualified as M
 import Data.Maybe
 import Data.Set qualified as S
-
-import System.IO
-import System.IO.Unsafe
-
-import Text.PrettyPrint.Class
-
+import Debug.Trace (trace)
+import ProVerifHeader
 import RuleTranslation
-
 import Sapic.Annotation
 import Sapic.Report
 import Sapic.States
 import Sapic.Typing
-
+import System.IO
+import System.IO.Unsafe
 import Term.Builtin.Rules
 import Term.SubtermRule
-
+import Text.PrettyPrint.Class
 import Theory
 import Theory.Module
 import Theory.Sapic
 import Theory.Text.Pretty
+import Theory.Tools.Wellformedness (formulaFacts)
 
+-- | Types of translation the export module covers (others are covered by sapic module).
 data Translation
   = ProVerif
   | DeepSec
   deriving (Ord, Eq, Typeable, Data)
 
+-- | Types of translations covered here map to other modules, but not vice versa (for instance, Sapic to MSR).
 exportModule :: Translation -> ModuleType
 exportModule ProVerif = ModuleProVerif
 exportModule DeepSec = ModuleDeepSec
 
+-- | Information needed during translation.
 data TranslationContext = TranslationContext
-  { trans :: Translation
-  , attackerChannel :: Maybe LVar
-  , hasBoundStates :: Bool
-  , hasUnboundStates :: Bool
-  , predicates :: [Predicate]
+  { trans :: Translation,
+    attackerChannel :: Maybe LVar,
+    hasBoundStates :: Bool,
+    hasUnboundStates :: Bool,
+    predicates :: [Predicate],
+    replicationBound :: Int,
+    skipReuseOrSrc :: Bool,
+    skipRestrictions :: Bool
   }
   deriving (Eq, Ord)
 
+-- | Default translation context.
 emptyTC :: TranslationContext
 emptyTC =
   TranslationContext
-    { trans = ProVerif
-    , attackerChannel = Nothing
-    , hasBoundStates = False
-    , hasUnboundStates = False
-    , predicates = []
+    { trans = ProVerif,
+      attackerChannel = Nothing,
+      hasBoundStates = False,
+      hasUnboundStates = False,
+      predicates = [],
+      replicationBound = 3, -- TODO: allow modifying this parameter
+      skipReuseOrSrc = False,
+      skipRestrictions = False
     }
 
--- Failure function performing an unsafe IO failure
+-- | Failure function performing an unsafe IO failure
 translationFail :: String -> a
 translationFail s = unsafePerformIO (fail s)
 
-
+-- | Warning function performing an unsafe IO failure
 translationWarning :: String -> a -> a
 translationWarning s cont = unsafePerformIO printWarning
   where
@@ -90,116 +101,122 @@ translationWarning s cont = unsafePerformIO printWarning
 -- Core ProVerif Export
 ------------------------------------------------------------------------------
 
-proverifTemplate :: Document d => [d] -> [d] -> d -> [d] -> [d] -> [d] -> [d] -> d
-proverifTemplate headers queries process macroproc ruleproc lemmas comments =
+proverifTemplate :: (Document d) => [d] -> [d] -> d -> [d] -> [d] -> [d] -> [d] -> [d] -> d
+proverifTemplate headers queries process macroproc ruleproc restrictions lemmas comments =
   vcat headers
     $$ vcat queries
     $$ vcat lemmas
+    $$ vcat restrictions
     $$ vcat macroproc
     $$ vcat ruleproc
     $$ text "process"
     $$ nest 4 process
     $--$ vcat (intersperse (text "") comments)
 
-prettyProVerifTheory
-  :: (ProtoLemma LNFormula ProofSkeleton -> Bool)
-  -> (OpenTheory, TypingEnvironment)
-  -> IO Doc
-prettyProVerifTheory lemSel (thy, typEnv) = do
-  headers <- loadHeaders tc thy typEnv
-  headers2 <- checkDuplicates $
-    (S.toList . filterHeaders $ S.unions [baseHeaders, headers, prochd, macroprochd])
-    ++ S.toList (filterHeaders ruleHeaders)
-  let hd = attribHeaders tc headers2
-  pure $ proverifTemplate hd queries proc' macroproc ruleproc lemmas comments
+prettyProVerifTheory ::
+  ModuleType ->
+  Bool -> -- noReuse
+  Bool -> -- noRestrictions
+  (ProtoLemma LNFormula ProofSkeleton -> Bool) ->
+  (OpenTheory, TypingEnvironment) ->
+  IO Doc
+prettyProVerifTheory m noReuse noRestrictions lemSel (thy, typEnv) = do
+  headersTheory <- loadHeaders tc thy typEnv -- load headers from theory
+  let headersTranslation =
+        [ baseHeaders, -- base headers for translation
+          prochd, -- headers from the process
+          macroprochd, -- headers from the macroprocess
+          ruleHeaders -- headers from the rules
+        ]
+  headers <- checkDuplicates' $ filterHeaders $ S.unions $ headersTheory : headersTranslation
+  let hd = attribHeaders tc headers
+  pure $ proverifTemplate hd queries proc' macroproc ruleproc restrictions lemmas comments
   where
-    tc = emptyTC {predicates = theoryPredicates thy}
+    tc =
+      emptyTC
+        { predicates = theoryPredicates thy,
+          skipReuseOrSrc = noReuse,
+          skipRestrictions = noRestrictions
+        }
     (proc, prochd, hasBoundState, hasUnboundState) = loadProc tc thy
-    (ruleproc, ruleComb, (baseRuleHeaders, destrHeaders, frHeaders, tblHeaders, evHeaders)) = loadRules thy
-    baseRuleHeaderSet = S.fromList $ map (uncurry4 Sym) baseRuleHeaders
-    destrHeaderSet = S.fromList $ map (uncurry4 Eq) destrHeaders
-    frHeaderSet = S.fromList $ map (uncurry4 Sym) frHeaders
-    tblHeaderSet = S.fromList $ map (uncurry Table) tblHeaders
-    evHeaderSet = S.fromList $ map (uncurry HEvent) evHeaders
-    ruleHeaders = S.unions [baseRuleHeaderSet, destrHeaderSet, frHeaderSet, tblHeaderSet, evHeaderSet]
+    (ruleproc, ruleComb, ruleHeaders) = loadRules thy m
     proc'
       | null (theoryProcesses thy) = ruleComb
       | null (theoryRules thy) = proc
       | otherwise = proc <-> text "|" <-> ruleComb
     baseHeaders = if hasUnboundState then stateHeaders else S.empty
+    restrictions =
+      if skipRestrictions tc
+        then []
+        else loadRestrictions tc typEnv thy
     queries = loadQueries thy
     lemmas = loadLemmas lemSel tc typEnv thy
     (macroproc, macroprochd) =
       -- if stateM is not empty, we have inlined the process calls, so we don't reoutput them
       if hasBoundState then ([text ""], S.empty) else loadMacroProc tc thy
-    uncurry4 f (a,b,c,d) = f a b c d
-    comments = [ text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy ]
-
--- ProVerif Headers need to be ordered, and declared only once. We order them by type, and will update a set of headers.
-data ProVerifHeader
-  = Type String -- type declaration
-  | Sym String String String [String] -- symbol declaration, (symkind,name,type,attr)
-  | Fun String String Int String [String] -- symbol declaration, (symkind,name,arity,types,attr)
-  | HEvent String String
-  | Table String String
-  | Eq String String String String -- eqtype, quantif, equation pub/priv
-  deriving (Ord, Show, Eq)
+    comments = [text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy]
 
 stateHeaders :: S.Set ProVerifHeader
 stateHeaders =
   S.fromList
-    [ Table "tbl_states_handle" "(bitstring,channel)" -- the table for linking states identifiers and channels
-    , Table "tbl_locks_handle" "(bitstring,channel)" -- the table for linking locks identifiers and channels
+    [ Table "tbl_states_handle" "(bitstring,channel)", -- the table for linking states identifiers and channels
+      Table "tbl_locks_handle" "(bitstring,channel)" -- the table for linking locks identifiers and channels
     ]
 
--- We provide a dedicated DDH builtin.
-builtins :: [(String, S.Set ProVerifHeader)]
-builtins =
-  map
-    (second S.fromList)
-    [ ( "diffie-hellman"
-      , [ Sym "const" "g" ":bitstring" []
-        , Fun "fun" "exp" 2 "(bitstring,bitstring):bitstring" []
-        , Eq "equation" "forall a:bitstring,b:bitstring;" "exp( exp(g,a),b) = exp(exp(g,b),a)" ""
-        ]
-      )
-    , ( "locations-report"
-      , [ Fun "fun" "rep" 2 "(bitstring,bitstring):bitstring" ["private"]
-        ]
-      )
-    , ( "xor"
-      , [ Fun "fun" "xor" 2 "(bitstring,bitstring):bitstring" []
-        , Fun "fun" "zero" 0 "():bitstring" []
-        ]
-      )
-    , ( "hashing"
-      , [ Fun "fun" "h" 1 "(bitstring):bitstring" []
-        ]
-      )
-    , ( "asymmetric-encryption"
-      , [ Fun "fun" "aenc" 2 "(bitstring,bitstring):bitstring" []
-        , Fun "fun" "pk" 1 "(bitstring):bitstring" []
-        ] --Don't need to define the reduc equations here because they are already read from the theory
-      )
-    , ( "signing"
-      , [ Fun "fun" "sign" 2 "(bitstring,bitstring):bitstring" []
-        , Fun "fun" "pk" 1 "(bitstring):bitstring" []
-        , Fun "fun" "okay" 0 "():bitstring" []
-        ]
-      )
-    , ( "revealing-signing"
-      , [ Fun "fun" "revealSign" 2 "(bitstring,bitstring):bitstring" []
-        , Fun "fun" "revealVerify" 3 "(bitstring,bitstring,bitstring):bitstring" []
-        , Fun "fun" "getMessage" 1 "(bitstring):bitstring" []
-        , Fun "fun" "pk" 1 "(bitstring):bitstring" []
-        , Fun "fun" "okay" 0 "():bitstring" []
-        ]
-      )
-    , ( "symmetric-encryption"
-      , [ Fun "fun" "senc" 2 "(bitstring,bitstring):bitstring" []
-        ]
-      )
+data BuiltinTranslation
+  = NotSupportedBuiltin String
+  | AccurateBuiltin [ProVerifHeader]
+  | BestEffortBuiltin [ProVerifHeader]
+
+builtins :: String -> BuiltinTranslation
+builtins "diffie-hellman" =
+  BestEffortBuiltin
+    [ Sym "const" "g" ":bitstring" [],
+      Fun "fun" "exp" 2 "(bitstring,bitstring):bitstring" [],
+      Eq "equation" "forall a:bitstring,b:bitstring;" "exp( exp(g,a),b) = exp(exp(g,b),a)" ""
     ]
+builtins "locations-report" =
+  AccurateBuiltin
+    [ Fun "fun" "rep" 2 "(bitstring,bitstring):bitstring" ["private"]
+    ]
+builtins "xor" =
+  BestEffortBuiltin
+    [ Fun "fun" "xor" 2 "(bitstring,bitstring):bitstring" [],
+      Fun "fun" "zero" 0 "():bitstring" []
+    ]
+builtins "hashing" =
+  AccurateBuiltin
+    [ Fun "fun" "h" 1 "(bitstring):bitstring" []
+    ]
+builtins "asymmetric-encryption" =
+  AccurateBuiltin
+    [ Fun "fun" "aenc" 2 "(bitstring,bitstring):bitstring" [],
+      Fun "fun" "pk" 1 "(bitstring):bitstring" []
+    ] -- Don't need to define the reduc equations here because they are already read from the theory
+builtins "signing" =
+  AccurateBuiltin
+    [ Fun "fun" "sign" 2 "(bitstring,bitstring):bitstring" [],
+      Fun "fun" "pk" 1 "(bitstring):bitstring" [],
+      Fun "fun" "okay" 0 "():bitstring" []
+    ]
+builtins "revealing-signing" =
+  AccurateBuiltin
+    [ Fun "fun" "revealSign" 2 "(bitstring,bitstring):bitstring" [],
+      Fun "fun" "revealVerify" 3 "(bitstring,bitstring,bitstring):bitstring" [],
+      Fun "fun" "getMessage" 1 "(bitstring):bitstring" [],
+      Fun "fun" "pk" 1 "(bitstring):bitstring" [],
+      Fun "fun" "okay" 0 "():bitstring" []
+    ]
+builtins "symmetric-encryption" =
+  AccurateBuiltin
+    [ Fun "fun" "senc" 2 "(bitstring,bitstring):bitstring" []
+    ]
+builtins "multiset" =
+  NotSupportedBuiltin
+    "Multiset is not supported in ProVerif. If you want to model natural numbers, you can use the dedicated Tamarin builtin."
+builtins "bilinear-pairing" =
+  NotSupportedBuiltin
+    "Bilinear pairings are not supported in ProVerif."
 
 -- We filter out some predefined headers that we don't want to redefine.
 filterHeaders :: S.Set ProVerifHeader -> S.Set ProVerifHeader
@@ -211,31 +228,46 @@ filterHeaders = S.filter (not . isForbidden)
     isForbidden (Type "nat") = True
     isForbidden _ = False
 
--- We cannot define a constant and a function with the same name in proverif
+-- | Extract the “name” of any header that should be unique.
+getProVerifHeaderIdentifier :: ProVerifHeader -> Maybe String
+getProVerifHeaderIdentifier (Fun _ n _ _ _)   = Just n
+getProVerifHeaderIdentifier (Sym _ n _ _)     = Just n
+getProVerifHeaderIdentifier (HEvent n _)      = Just n
+getProVerifHeaderIdentifier (Table n _)       = Just n
+getProVerifHeaderIdentifier _                 = Nothing
+
+-- | Fail if any identifier occurs more than once; otherwise return all headers
 checkDuplicates :: MonadFail m => [ProVerifHeader] -> m [ProVerifHeader]
-checkDuplicates hd = do
-  let names =
-        foldl
-          ( \acc x -> case x of
-              Fun _ n _ _ _ -> n : acc
-              Sym _ n _ _ -> n : acc
-              HEvent n _ -> n : acc
-              Table n _ -> n : acc
-              _ -> acc
-          )
-          []
-          hd
-      conflicts = filter ((> 1) . length) . group $ sort names
-  if null conflicts
-    then pure hd
-    else fail ("The string " <> head (head conflicts) <> " is used for distinct constructs (function name, constant or events). You should rename the constructs.")
+checkDuplicates headers = do
+    let identMap :: M.Map String [ProVerifHeader]
+        identMap = M.fromListWith (<>)
+                  [ (n, [h])
+                  | h <- headers
+                  , Just n <- [getProVerifHeaderIdentifier h]
+                  ]
+        conflicts = filter ((>1) . length) (M.toList identMap)
+
+    -- if there are conflicts, bail; otherwise return the whole input
+    unless (null conflicts) $
+      fail $ unlines
+        ( "ProVerif constructs (functions, constants, events, tables) must be distinct.\
+          \ Please rename these duplicates:"
+        : [ intercalate ", " (map show defs)
+          | (_, defs) <- conflicts
+          ]
+        )
+
+    return headers
+
+checkDuplicates' :: S.Set ProVerifHeader -> IO [ProVerifHeader]
+checkDuplicates' = checkDuplicates . S.toList
 
 ppPubName :: NameId -> Doc
 ppPubName (NameId n) = text $ case n of
   "zero" -> "0"
-  "one"  -> "1"
-  "g"    -> "g"
-  _      -> "s" ++ n
+  "one" -> "1"
+  "g" -> "g"
+  _ -> "s" ++ n
 
 -- Loader of the export functions
 ------------------------------------------------------------------------------
@@ -243,12 +275,11 @@ loadQueries :: Theory sig c b p TranslationElement -> [Doc]
 loadQueries thy =
   map (text . (._eText)) (lookupExportInfo "queries" thy)
 
-
 ------------------------------------------------------------------------------
 -- Core ProVerif Equivalence Export
 ------------------------------------------------------------------------------
 
-proverifEquivTemplate :: Document d => [d] -> [d] -> [d] -> [d] -> [d] -> d
+proverifEquivTemplate :: (Document d) => [d] -> [d] -> [d] -> [d] -> [d] -> d
 proverifEquivTemplate headers queries equivlemmas macroproc comments =
   vcat headers
     $$ vcat queries
@@ -258,10 +289,15 @@ proverifEquivTemplate headers queries equivlemmas macroproc comments =
 
 prettyProVerifEquivTheory :: (OpenTheory, TypingEnvironment) -> IO Doc
 prettyProVerifEquivTheory (thy, typEnv) = do
-  headers <- loadHeaders tc thy typEnv
-  headers2 <- checkDuplicates . S.toList . filterHeaders $
-    S.unions [baseHeaders, headers, equivhd, diffEquivhd, macroprochd]
-  let hd = attribHeaders tc headers2
+  headersTheory <- loadHeaders tc thy typEnv
+  let headersTranslation =
+        [ baseHeaders,
+          equivhd,
+          diffEquivhd,
+          macroprochd
+        ]
+  headers <- checkDuplicates' $ filterHeaders $ S.unions $ headersTheory : headersTranslation
+  let hd = attribHeaders tc headers
   fproc <- finalproc
   pure $ proverifEquivTemplate hd queries fproc macroproc comments
   where
@@ -277,13 +313,13 @@ prettyProVerifEquivTheory (thy, typEnv) = do
     (macroproc, macroprochd) =
       -- if stateM is not empty, we have inlined the process calls, so we don't reoutput them
       if hasBoundState then ([text ""], S.empty) else loadMacroProc tc thy
-    comments = [ text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy ]
+    comments = [text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy]
 
 ------------------------------------------------------------------------------
 -- Core DeepSec Export
 ------------------------------------------------------------------------------
 
-deepsecTemplate :: Document d => [d] -> [d] -> [d] -> [d] -> [d] -> d
+deepsecTemplate :: (Document d) => [d] -> [d] -> [d] -> [d] -> [d] -> d
 deepsecTemplate headers macroproc requests equivlemmas comments =
   vcat headers
     $$ vcat macroproc
@@ -294,17 +330,17 @@ deepsecTemplate headers macroproc requests equivlemmas comments =
 emptyTypeEnv :: TypingEnvironment
 emptyTypeEnv = TypingEnvironment {vars = M.empty, events = M.empty, funs = M.empty}
 
-prettyDeepSecTheory :: OpenTheory -> IO Doc
-prettyDeepSecTheory thy = do
+prettyDeepSecTheory :: Int -> OpenTheory -> IO Doc
+prettyDeepSecTheory repBound thy = do
   headers <- loadHeaders tc thy emptyTypeEnv
   let hd = attribHeaders tc $ S.toList (S.unions [headers, macroprochd, equivhd])
   pure $ deepsecTemplate hd macroproc requests equivlemmas comments
   where
-    tc = emptyTC {trans = DeepSec}
+    tc = emptyTC {trans = DeepSec, replicationBound = repBound}
     requests = loadRequests thy
     (macroproc, macroprochd) = loadMacroProc tc thy
     (equivlemmas, equivhd, _, _) = loadEquivProc tc thy
-    comments = [ text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy ]
+    comments = [text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy]
 
 -- Loader of the export functions
 ------------------------------------------------------------------------------
@@ -336,7 +372,7 @@ ppTypeLit :: (Show c) => TranslationContext -> Lit c SapicLVar -> Doc
 ppTypeLit tc (Var v) = ppTypeVar tc v
 ppTypeLit _ (Con c) = text . sanitizeSymbol 'a' $ show c
 
-auxppTerm :: Show v => (Lit Name v -> Doc) -> VTerm Name v -> (Doc, S.Set ProVerifHeader)
+auxppTerm :: (Show v) => (Lit Name v -> Doc) -> VTerm Name v -> (Doc, S.Set ProVerifHeader)
 auxppTerm ppLit t = (ppTerm t, getHdTerm t)
   where
     ppTerm tm = case viewTerm tm of
@@ -360,28 +396,31 @@ auxppTerm ppLit t = (ppTerm t, getHdTerm t)
     ppXor [] = text "one"
     ppXor [t1, t2] = text "xor(" <> ppTerm t1 <> text ", " <> ppTerm t2 <> text ")"
     ppXor (t1 : ts) = text "xor(" <> ppTerm t1 <> text ", " <> ppXor ts <> text ")"
-    ppTerms sepa n lead finish = fcat
-      . (text lead :)
-          . (++ [text finish])
-              . map (nest n) . punctuate (text sepa) . map ppTerm
+    ppTerms sepa n lead finish =
+      fcat
+        . (text lead :)
+        . (++ [text finish])
+        . map (nest n)
+        . punctuate (text sepa)
+        . map ppTerm
     ppFun f ts =
       text (ppFunSym f ++ "(") <> fsep (punctuate comma (map ppTerm ts)) <> text ")"
     getHdTerm tm = case viewTerm tm of
       Lit (Con (Name PubName n)) ->
         if show n `elem` ["g", "one", "zero"]
           then S.empty
-          -- The 's' is just prepended here instead of using sanitizeSymbol, because that function
+          else -- The 's' is just prepended here instead of using sanitizeSymbol, because that function
           -- only does the prepending for reserved keywords and symbols starting with a digit. For
           -- free bitstrings however, we ALWAYS want the leading 's', to also avoid clashes with
           -- function names, rule names, event names etc. We could also do it like that for variables
           -- and function names (where we use sanitizeSymbol now), but I thought if we did it in all
           -- other places it might not be needed there, and I thought it would be better to leave as
           -- much as possible of the original naming as it is
-          else S.singleton (Sym "free" ("s" ++ show n) ":bitstring" [])
-      Lit  _    -> S.empty
+            S.singleton (Sym "free" ("s" ++ show n) ":bitstring" [])
+      Lit _ -> S.empty
       FApp _ ts -> foldl (\x y -> x `S.union` getHdTerm y) S.empty ts
 
--- pretty print a SapicTerm, collecting the constant that need to be declared
+-- | pretty print a SapicTerm, collecting the constants that need to be declared
 -- matchVars is the set of vars that correspond to pattern matching
 -- isPattern enables the pattern match printing, which adds types to variables, and = to constants.
 auxppSapicTerm :: TranslationContext -> S.Set LVar -> Bool -> SapicTerm -> (Doc, S.Set ProVerifHeader)
@@ -391,22 +430,20 @@ auxppSapicTerm tc mVars isPattern = auxppTerm ppLit
       Con (Name FreshName n) -> text . sanitizeSymbol 'a' $ show n
       Con (Name PubName n) | isPattern -> text "=" <> text ("s" ++ show n)
       Con (Name PubName n) -> ppPubName n
-      Var (SapicLVar lvar@(LVar n LSortPub _) _)
-        | S.member lvar mVars ->
-          translationWarning ("Pattern matching on public variable "++n++" makes Tamarin and ProVerif behaviours diverge.") $
-          text "=" <> ppLVar lvar
-      Var (SapicLVar lvar@(LVar n LSortFresh _) _)
-        | S.member lvar mVars ->
-          translationWarning ("Pattern matching on fresh variable "++n++" makes Tamarin and ProVerif behaviours diverge.") $
-          text "=" <> ppLVar lvar
-      Var (SapicLVar lvar@(LVar n LSortNat _) _)
-        | S.member lvar mVars ->
-          translationWarning ("Pattern matching on natural variable "++n++" makes Tamarin and ProVerif behaviours diverge.") $
-          text "=" <> ppLVar lvar
+      Var (SapicLVar lvar@(LVar n lsort _) _)
+        | lsort `elem` [LSortPub, LSortFresh, LSortNat] ->
+            translationWarning
+              ( "Encountered a variable "
+                  ++ n
+                  ++ " of non-message sort "
+                  ++ show lsort
+                  ++ ". Used in pattern matching, this may produces different behaviour in Tamarin and ProVerif.  Used elsewhere, we simply ignore the sort and translate to to ProVerif's default: bitstring"
+              )
+              $ text "=" <> ppLVar lvar
       Var (SapicLVar lvar _)
         | S.member lvar mVars -> text "=" <> ppLVar lvar
       l | isPattern -> ppTypeLit tc l
-      Var (SapicLVar lvar _)  -> ppLVar lvar
+      Var (SapicLVar lvar _) -> ppLVar lvar
       l -> text . sanitizeSymbol 'a' $ show l
 
 ppSapicTerm :: TranslationContext -> SapicTerm -> (Doc, S.Set ProVerifHeader)
@@ -441,21 +478,27 @@ ppFact tc (Fact tag _ ts)
 
 -- Pretty print an Action, collecting the constant and events that need to be declared.
 -- It also returns a boolean, specifying if the printout can serve as the end of a process or not.
-ppAction
-  :: ProcessAnnotation LVar
-  -> TranslationContext
-  -> LSapicAction
-  -> (Doc, S.Set ProVerifHeader, Bool)
+ppAction ::
+  ProcessAnnotation LVar ->
+  TranslationContext ->
+  LSapicAction ->
+  (Doc, S.Set ProVerifHeader, Bool)
 ppAction ProcessAnnotation {isStateChannel = Nothing} tc (New v) =
   (text "new " <> ppTypeVar tc v, S.empty, True)
 ppAction ProcessAnnotation {pureState = False, isStateChannel = Just t} tc (New v@(SapicLVar lvar _)) =
   ( extras $
-      text "new " <> channel <> text "[assumeCell];"
-        $$ text "new lock_" <> channel <> text "[assumeCell];"
+      text "new "
+        <> channel
+        <> text "[assumeCell];"
+        $$ text "new lock_"
+        <> channel
+        <> text "[assumeCell];"
         -- we also declare the corresponding lock channel, and initialize it
-        $$ text "out(lock_" <> ppLVar lvar <> text ",0) |"
-  , if hasUnboundStates tc then sht else S.empty
-  , False
+        $$ text "out(lock_"
+        <> ppLVar lvar
+        <> text ",0) |",
+    if hasUnboundStates tc then sht else S.empty,
+    False
   )
   where
     channel = ppTypeVar tc v
@@ -464,28 +507,36 @@ ppAction ProcessAnnotation {pureState = False, isStateChannel = Just t} tc (New 
       if hasUnboundStates tc
         then
           x
-            $$ text "insert tbl_states_handle(" <> pt <> text ", " <> ppLVar lvar <> text ");"
-            $$ text "insert tbl_locks_handle(" <> pt <> text ", lock_" <> ppLVar lvar <> text ");"
+            $$ text "insert tbl_states_handle("
+            <> pt
+            <> text ", "
+            <> ppLVar lvar
+            <> text ");"
+            $$ text "insert tbl_locks_handle("
+            <> pt
+            <> text ", lock_"
+            <> ppLVar lvar
+            <> text ");"
         else x
 ppAction ProcessAnnotation {pureState = True, isStateChannel = Just _} tc (New v) =
-  ( text "new " <> ppTypeVar tc v <> text "[assumeCell]"
-  , S.empty
-  , True
+  ( text "new " <> ppTypeVar tc v <> text "[assumeCell]",
+    S.empty,
+    True
   )
-ppAction _ TranslationContext {trans = ProVerif} Rep = (text "!", S.empty, False)
+ppAction _ TranslationContext {trans} Rep | trans == ProVerif = (text "!", S.empty, False)
 ppAction _ TranslationContext {trans = DeepSec} Rep = (text "", S.empty, False)
 ppAction _ tc@TranslationContext {trans = ProVerif} (ChIn t1 t2 mvars) =
-  ( text "in(" <> pt1 <> text "," <> pt2 <> text ")"
-  , sh1 `S.union` sh2
-  , True
+  ( text "in(" <> pt1 <> text "," <> pt2 <> text ")",
+    sh1 `S.union` sh2,
+    True
   )
   where
     (pt1, sh1) = getAttackerChannel tc t1
     (pt2, sh2) = auxppSapicTerm tc (S.map toLVar mvars) True t2
 ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2@(LIT (Var (SapicLVar _ _))) mvars) =
-  ( text "in(" <> pt1 <> text "," <> pt2 <> text ")"
-  , sh1 `S.union` sh2
-  , True
+  ( text "in(" <> pt1 <> text "," <> pt2 <> text ")",
+    sh1 `S.union` sh2,
+    True
   )
   where
     (pt1, sh1) = getAttackerChannel tc t1
@@ -493,10 +544,18 @@ ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2@(LIT (Var (SapicL
 
 -- pattern matching on input for deepsec is not supported
 ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2 mvars) =
-  ( text "in(" <> pt1 <> text "," <> text pt2var <> text ");"
-      $$ text "let (" <> pt2 <> text ")=" <> text pt2var <> text " in"
-  , sh1 `S.union` sh2
-  , False
+  ( text "in("
+      <> pt1
+      <> text ","
+      <> text pt2var
+      <> text ");"
+      $$ text "let ("
+      <> pt2
+      <> text ")="
+      <> text pt2var
+      <> text " in",
+    sh1 `S.union` sh2,
+    False
   )
   where
     (pt1, sh1) = getAttackerChannel tc t1
@@ -506,53 +565,69 @@ ppAction _ tc (ChOut t1 t2) = (text "out(" <> pt1 <> text "," <> pt2 <> text ")"
   where
     (pt1, sh1) = getAttackerChannel tc t1
     (pt2, sh2) = ppSapicTerm tc t2
-ppAction _ tc@TranslationContext {trans = ProVerif} (Event (Fact tag m ts)) = (text "event " <> pa, sh, True) -- event Headers are definde globally inside loadHeaders
+ppAction _ tc@TranslationContext {trans} (Event (Fact tag m ts)) | trans == ProVerif = (text "event " <> pa, sh, True) -- event Headers are definde globally inside loadHeaders
   where
     (pa, sh) = ppFact tc (Fact tag m ts)
 ppAction _ TranslationContext {trans = DeepSec} (Event _) = (text "", S.empty, False)
 -- For pure states, we do not put locks and unlocks
-ppAction ProcessAnnotation {pureState = True} TranslationContext {trans = ProVerif} (Lock _) =
-  (text "", S.empty, False)
+ppAction ProcessAnnotation {pureState = True} TranslationContext {trans} (Lock _)
+  | trans == ProVerif =
+      (text "", S.empty, False)
 -- If there is a state channel, we simply use it
-ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} TranslationContext {trans = ProVerif} (Lock _) =
-  ( text "in(lock_" <> ppLVar lvar <> text "," <> text "counterlock" <> ppLVar lvar <> text ":nat)"
-  , S.empty
-  , True
-  )
+ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} TranslationContext {trans} (Lock _)
+  | trans == ProVerif =
+      ( text "in(lock_" <> ppLVar lvar <> text "," <> text "counterlock" <> ppLVar lvar <> text ":nat)",
+        S.empty,
+        True
+      )
 -- If there is no state channel, we must use the table
-ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans = ProVerif} (Lock t) =
-  ( text "get tbl_locks_handle(" <> pt <> text "," <> text ptvar <> text ") in"
-      $$ text "in(" <> text ptvar <> text " , counter" <> text ptvar <> text ":nat)"
-  , sh
-  , True
-  )
+ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans} (Lock t)
+  | trans == ProVerif =
+      ( text "get tbl_locks_handle("
+          <> pt
+          <> text ","
+          <> text ptvar
+          <> text ") in"
+          $$ text "in("
+          <> text ptvar
+          <> text " , counter"
+          <> text ptvar
+          <> text ":nat)",
+        sh,
+        True
+      )
   where
     freevars = S.fromList $ map (\(SapicLVar lvar _) -> lvar) $ freesSapicTerm t
     (pt, sh) = auxppSapicTerm tc freevars True t
     ptvar = "lock_" ++ stripNonAlphanumerical (render pt)
-ppAction ProcessAnnotation {pureState = True} TranslationContext {trans = ProVerif} (Unlock _) =
-  (text "", S.empty, False)
-ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} TranslationContext {trans = ProVerif} (Unlock _) =
-  ( text "out(lock_" <> ppLVar lvar <> text "," <> text "counterlock" <> ppLVar lvar <> text "+1" <> text ") | "
-  , S.empty
-  , False
-  )
-ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans = ProVerif} (Unlock t) =
-  (text "out(" <> text ptvar <> text " , counter" <> text ptvar <> text "+1) | ", sh, False)
+ppAction ProcessAnnotation {pureState = True} TranslationContext {trans} (Unlock _)
+  | trans == ProVerif =
+      (text "", S.empty, False)
+ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} TranslationContext {trans} (Unlock _)
+  | trans == ProVerif =
+      ( text "out(lock_" <> ppLVar lvar <> text "," <> text "counterlock" <> ppLVar lvar <> text "+1" <> text ") | ",
+        S.empty,
+        False
+      )
+ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans} (Unlock t)
+  | trans == ProVerif =
+      (text "out(" <> text ptvar <> text " , counter" <> text ptvar <> text "+1) | ", sh, False)
   where
     (pt, sh) = ppSapicTerm tc t
     ptvar = "lock_" ++ stripNonAlphanumerical (render pt)
-ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = _} tc@TranslationContext {trans = ProVerif} (Insert _ c) =
-  ( text "out(" <> ppLVar lvar <> text ", " <> pc <> text ") |"
-  , shc
-  , False
-  )
+ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = _} tc@TranslationContext {trans} (Insert _ c)
+  | trans == ProVerif =
+      ( text "out(" <> ppLVar lvar <> text ", " <> pc <> text ") |",
+        shc,
+        False
+      )
   where
     (pc, shc) = ppSapicTerm tc c
 
 -- Should never happen
-ppAction ProcessAnnotation {stateChannel = Nothing, pureState = True} TranslationContext {trans = ProVerif} (Insert _ _) =
-  (text "TRANSLATIONERROR", S.empty, True)
+ppAction ProcessAnnotation {stateChannel = Nothing, pureState = True} TranslationContext {trans} (Insert _ _)
+  | trans == ProVerif =
+      (text "TRANSLATIONERROR", S.empty, True)
 -- ppAction ProcessAnnotation{stateChannel = Just (AnVar lvar), pureState=False} tc@TranslationContext{trans=ProVerif} (Insert _ c) =
 --       (text "in(" <> pt <> text ", " <> pt <> text "_dump:bitstring);"
 --        $$ text "out(" <> pt <> text ", " <> pc <> text ") |"
@@ -562,12 +637,21 @@ ppAction ProcessAnnotation {stateChannel = Nothing, pureState = True} Translatio
 --     (pc, shc) = ppSapicTerm tc c
 
 -- must rely on the table
-ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans = ProVerif} (Insert t t2) =
-  ( text "in(" <> text ptvar <> text ", " <> text dumpvar <> text ":bitstring);"
-      $$ text "out(" <> text ptvar <> text " , " <> pt2 <> text ") | "
-  , S.insert hd $ sh `S.union` sh2
-  , False
-  )
+ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans} (Insert t t2)
+  | trans == ProVerif =
+      ( text "in("
+          <> text ptvar
+          <> text ", "
+          <> text dumpvar
+          <> text ":bitstring);"
+          $$ text "out("
+          <> text ptvar
+          <> text " , "
+          <> pt2
+          <> text ") | ",
+        S.insert hd $ sh `S.union` sh2,
+        False
+      )
   where
     (pt, sh) = ppSapicTerm tc t
     (pt2, sh2) = ppSapicTerm tc t2
@@ -587,18 +671,27 @@ ppSapic tc (ProcessComb NDC _ pl pr) = (nest 4 (parens ppl) $$ text "+" <> nest 
     (ppl, pshl) = ppSapic tc pl
     (ppr, pshr) = ppSapic tc pr
 ppSapic tc (ProcessComb (Let t1 t2 mvars) _ pl (ProcessNull _)) =
-  ( text "let " <> pt1 <> text "=" <> pt2 <> text " in"
-      $$ ppl
-  , S.unions [sh1, sh2, pshl]
+  ( text "let "
+      <> pt1
+      <> text "="
+      <> pt2
+      <> text " in"
+      $$ ppl,
+    S.unions [sh1, sh2, pshl]
   )
   where
     (ppl, pshl) = ppSapic tc pl
     (pt1, sh1) = auxppSapicTerm tc (S.map toLVar mvars) True t1
     (pt2, sh2) = ppSapicTerm tc t2
 ppSapic tc (ProcessComb (Let t1 t2 mvars) _ pl pr) =
-  ( text "let " <> pt1 <> text "=" <> pt2 <> text " in"
+  ( text "let "
+      <> pt1
+      <> text "="
+      <> pt2
+      <> text " in"
       $$ ppl
-      $$ text "else " <> ppr,
+      $$ text "else "
+      <> ppr,
     S.unions [sh1, sh2, pshl, pshr]
   )
   where
@@ -618,8 +711,8 @@ ppSapic tc@TranslationContext {hasBoundStates = True} (ProcessComb (ProcessCall 
   where
     (ppl, pshl) = ppSapic tc pl
 ppSapic tc (ProcessComb (ProcessCall name ts) _ _ _) =
-  ( text name <> parens (fsep (punctuate comma ppts))
-  , S.unions shs
+  ( text name <> parens (fsep (punctuate comma ppts)),
+    S.unions shs
   )
   where
     pts = map (ppSapicTerm tc) ts
@@ -632,7 +725,7 @@ ppSapic tc (ProcessComb (Cond a) _ pl pr) =
     ppFact' (Ato (Syntactic (Pred (Fact (ProtoFact _ "Smaller" _) _ [v1, v2]))))
       | Lit (Var (Free vn1)) <- viewTerm v1,
         Lit (Var (Free vn2)) <- viewTerm v2 =
-        (ppUnTypeVar vn1 <> text "<" <> ppUnTypeVar vn2, S.empty)
+          (ppUnTypeVar vn1 <> text "<" <> ppUnTypeVar vn2, S.empty)
     ppFact' p =
       case expandFormula (predicates tc) (toLFormula p) of
         Left _ -> translationFail "Export does not support tamarin predicates in conditionnals."
@@ -643,16 +736,16 @@ ppSapic tc (ProcessComb (Cond a) _ pl pr) =
         let (ppr, pshr) = ppSapic tc pr
          in (d $$ text "else" $$ nest 4 (parens ppr), s `S.union` pshr)
 ppSapic tc (ProcessComb (CondEq t1 t2) _ pl (ProcessNull _)) =
-  ( text "let (=" <> pt1 <> text ")=" <> pt2 <> text " in " $$ nest 4 (parens ppl)
-  , S.unions [sh1, sh2, pshl]
+  ( text "let (=" <> pt1 <> text ")=" <> pt2 <> text " in " $$ nest 4 (parens ppl),
+    S.unions [sh1, sh2, pshl]
   )
   where
     (ppl, pshl) = ppSapic tc pl
     (pt1, sh1) = ppSapicTerm tc t1
     (pt2, sh2) = ppSapicTerm tc t2
 ppSapic tc (ProcessComb (CondEq t1 t2) _ pl pr) =
-  ( text "let (=" <> pt1 <> text ")=" <> pt2 <> text " in " $$ nest 4 (parens ppl) $$ text "else" <> nest 4 (parens ppr)
-  , S.unions [sh1, sh2, pshl, pshr]
+  ( text "let (=" <> pt1 <> text ")=" <> pt2 <> text " in " $$ nest 4 (parens ppl) $$ text "else" <> nest 4 (parens ppr),
+    S.unions [sh1, sh2, pshl, pshr]
   )
   where
     (ppl, pshl) = ppSapic tc pl
@@ -660,8 +753,8 @@ ppSapic tc (ProcessComb (CondEq t1 t2) _ pl pr) =
     (pt1, sh1) = ppSapicTerm tc t1
     (pt2, sh2) = ppSapicTerm tc t2
 ppSapic tc (ProcessComb (Lookup _ c) ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = True} pl (ProcessNull _)) =
-  ( text "in(" <> pt <> text ", " <> pc <> text ");" $$ ppl
-  , pshl
+  ( text "in(" <> pt <> text ", " <> pc <> text ");" $$ ppl,
+    pshl
   )
   where
     pt = ppLVar lvar
@@ -672,10 +765,18 @@ ppSapic tc (ProcessComb (Lookup _ c) ProcessAnnotation {stateChannel = Just (AnV
 ppSapic _ (ProcessComb (Lookup _ _) ProcessAnnotation {stateChannel = Nothing, pureState = True} _ (ProcessNull _)) =
   translationFail "Unexpected error -> please report with an issue on the github."
 ppSapic tc (ProcessComb (Lookup _ c) ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} pl (ProcessNull _)) =
-  ( text "in(" <> pt <> text ", " <> pc <> text ");"
-      $$ text "out(" <> pt <> text ", " <> pc2 <> text ") |"
-      $$ ppl
-  , pshl
+  ( text "in("
+      <> pt
+      <> text ", "
+      <> pc
+      <> text ");"
+      $$ text "out("
+      <> pt
+      <> text ", "
+      <> pc2
+      <> text ") |"
+      $$ ppl,
+    pshl
   )
   where
     pt = ppLVar lvar
@@ -683,11 +784,23 @@ ppSapic tc (ProcessComb (Lookup _ c) ProcessAnnotation {stateChannel = Just (AnV
     pc2 = ppUnTypeVar c
     (ppl, pshl) = ppSapic tc pl
 ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, pureState = False} pl (ProcessNull _)) =
-  ( text "get tbl_states_handle(" <> pt <> text "," <> text ptvar <> text ") in"
-      $$ text "in(" <> text ptvar <> text " , " <> pc <> text ");"
-      $$ text "out(" <> text ptvar <> text " , " <> pc2 <> text ") |"
-      $$ ppl
-  , sh `S.union` pshl
+  ( text "get tbl_states_handle("
+      <> pt
+      <> text ","
+      <> text ptvar
+      <> text ") in"
+      $$ text "in("
+      <> text ptvar
+      <> text " , "
+      <> pc
+      <> text ");"
+      $$ text "out("
+      <> text ptvar
+      <> text " , "
+      <> pc2
+      <> text ") |"
+      $$ ppl,
+    sh `S.union` pshl
   )
   where
     pc = ppTypeVar tc c
@@ -697,24 +810,46 @@ ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, 
     ptvar = "stateChannel" ++ stripNonAlphanumerical (render pt)
     (ppl, pshl) = ppSapic tc pl
 ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, pureState = False} pl pr) =
-  ( text "get tbl_states_handle(" <> pt <> text "," <> text ptvar <> text ") in"
-      $$ nest 4
-           ( parens
-               ( text "in(" <> text ptvar <> text " , " <> pc <> text ");"
-                   $$ text "out(" <> text ptvar <> text " , " <> pc2 <> text ") | "
-                   $$ ppl
-               )
-           )
+  ( text "get tbl_states_handle("
+      <> pt
+      <> text ","
+      <> text ptvar
+      <> text ") in"
+      $$ nest
+        4
+        ( parens
+            ( text "in("
+                <> text ptvar
+                <> text " , "
+                <> pc
+                <> text ");"
+                $$ text "out("
+                <> text ptvar
+                <> text " , "
+                <> pc2
+                <> text ") | "
+                $$ ppl
+            )
+        )
       $$ text "else"
-      $$ nest 4
-           ( parens
-               ( text "new " <> text ptvar <> text ":channel [assumeCell];" --the cell did not exists, we create it !
-                   $$ text "insert tbl_states_handle(" <> pt' <> text ", " <> text ptvar <> text ");"
-                   $$ text "out(" <> text ptvar <> text ",0) |"
-                   $$ ppr
-               )
-           )
-  , S.unions [sh, pshl, pshr]
+      $$ nest
+        4
+        ( parens
+            ( text "new "
+                <> text ptvar
+                <> text ":channel [assumeCell];" -- the cell did not exists, we create it !
+                $$ text "insert tbl_states_handle("
+                <> pt'
+                <> text ", "
+                <> text ptvar
+                <> text ");"
+                $$ text "out("
+                <> text ptvar
+                <> text ",0) |"
+                $$ ppr
+            )
+        ),
+    S.unions [sh, pshl, pshr]
   )
   where
     pc = ppTypeVar tc c
@@ -727,12 +862,13 @@ ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, 
     (ppr, pshr) = ppSapic tc pr
 ppSapic _ (ProcessComb (Lookup _ _) _ _ _) =
   translationFail "The export does not support a lookup with an else branch."
-ppSapic tc@TranslationContext {trans = ProVerif} (ProcessAction Rep _ p) = (text "!" $$ parens pp, psh)
+ppSapic tc@TranslationContext {trans} (ProcessAction Rep _ p) | trans == ProVerif = (text "!" $$ parens pp, psh)
   where
     (pp, psh) = ppSapic tc p
-
--- TODO: have some parameter in the tc for replication numbers
-ppSapic tc@TranslationContext {trans = DeepSec} (ProcessAction Rep _ p) = (text "!^3" <> parens pp, psh)
+ppSapic tc@TranslationContext {trans = DeepSec} (ProcessAction Rep _ p) =
+  ( text ("!^" ++ show (replicationBound tc)) <> parens pp,
+    psh
+  )
   where
     (pp, psh) = ppSapic tc p
 ppSapic tc (ProcessAction a an (ProcessNull _)) =
@@ -774,7 +910,7 @@ loadProc tc thy = case theoryProcesses thy of
           if isNothing (List.find (== "locations-report") (theoryBuiltins thy))
             then d
             else addAttackerReportProc tc2 thy d
-    in (finald, S.union hd headers, fst hasStates, snd hasStates)
+     in (finald, S.union hd headers, fst hasStates, snd hasStates)
     where
       p = makeAnnotations thy pr
       hasStates = hasBoundUnboundStates p
@@ -788,16 +924,21 @@ loadMacroProcs :: TranslationContext -> OpenTheory -> [ProcessDef] -> ([Doc], S.
 loadMacroProcs _ _ [] = ([text ""], S.empty)
 loadMacroProcs tc thy (p : q) =
   let (docs, heads) = loadMacroProcs tc3 thy q
-  in case p._pVars of
-    -- TODO bugfix, this is probably wrong when the macro does not have any parameter
-    Nothing -> (docs, hd `S.union` heads)
-    Just pvars ->
-      let (newText, newHeads) = ppSapic tc3 mainProc
-          vrs = text "(" <> fsep (punctuate comma (map (ppTypeVar tc3) pvars)) <> text ")"
-          headers = headersOfType $ map extractType pvars
-          macroDef = text "let " <> text p._pName <> vrs <> text "="
-                        $$ nest 4 newText <> text "."
-      in (macroDef : docs, hd `S.union` newHeads `S.union` heads `S.union` headers)
+   in case p._pVars of
+        -- TODO bugfix, this is probably wrong when the macro does not have any parameter
+        Nothing -> (docs, hd `S.union` heads)
+        Just pvars ->
+          let (newText, newHeads) = ppSapic tc3 mainProc
+              vrs = text "(" <> fsep (punctuate comma (map (ppTypeVar tc3) pvars)) <> text ")"
+              headers = headersOfType $ map extractType pvars
+              macroDef =
+                text "let "
+                  <> text p._pName
+                  <> vrs
+                  <> text "="
+                  $$ nest 4 newText
+                  <> text "."
+           in (macroDef : docs, hd `S.union` newHeads `S.union` heads `S.union` headers)
   where
     mainProc = makeAnnotations thy p._pBody
     extractType (SapicLVar _ ty) = ty
@@ -823,11 +964,11 @@ loadDiffProc tc thy = case theoryDiffEquivLemmas thy of
 loadEquivProc :: TranslationContext -> OpenTheory -> ([Doc], S.Set ProVerifHeader, Bool, Bool)
 loadEquivProc tc thy = loadEquivProcs tc thy (theoryEquivLemmas thy)
 
-loadEquivProcs
-  :: TranslationContext
-  -> OpenTheory
-  -> [(PlainProcess, PlainProcess)]
-  -> ([Doc], S.Set ProVerifHeader, Bool, Bool)
+loadEquivProcs ::
+  TranslationContext ->
+  OpenTheory ->
+  [(PlainProcess, PlainProcess)] ->
+  ([Doc], S.Set ProVerifHeader, Bool, Bool)
 loadEquivProcs _ _ [] = ([], S.empty, False, False)
 loadEquivProcs tc thy ((p1, p2) : q) =
   let (docs, heads, hadBoundStates, hadUnboundStates) = loadEquivProcs tc3 thy q
@@ -840,12 +981,15 @@ loadEquivProcs tc thy ((p1, p2) : q) =
             $$ nest 4 newText2
         DeepSec ->
           text "query session_equiv("
-            $$ nest 4 newText1 <> text ","
-            $$ nest 4 newText2 <> text ")."
-  in ( macroDef : docs
-     , S.unions [hd, newHeads1, newHeads2, heads]
-     , hasBoundSt || hadBoundStates, hasUnboundSt || hadUnboundStates
-     )
+            $$ nest 4 newText1
+            <> text ","
+            $$ nest 4 newText2
+            <> text ")."
+   in ( macroDef : docs,
+        S.unions [hd, newHeads1, newHeads2, heads],
+        hasBoundSt || hadBoundStates,
+        hasUnboundSt || hadUnboundStates
+      )
   where
     mainProc1 = makeAnnotations thy p1
     mainProc2 = makeAnnotations thy p2
@@ -864,7 +1008,7 @@ loadEquivProcs tc thy ((p1, p2) : q) =
 ------------------------------------------------------------------------------
 
 -- | Smaller-or-equal / More-or-equally-specific relation on types.
-mergeType :: Eq a => Maybe a -> Maybe a -> Maybe a
+mergeType :: (Eq a) => Maybe a -> Maybe a -> Maybe a
 mergeType t Nothing = t
 mergeType Nothing t = t
 mergeType _ t = t
@@ -872,7 +1016,7 @@ mergeType _ t = t
 mergeEnv :: M.Map LVar SapicType -> M.Map LVar SapicType -> M.Map LVar SapicType
 mergeEnv = M.mergeWithKey (\_ t1 t2 -> Just $ mergeType t1 t2) id id
 
-typeVarsEvent :: Ord k => TypingEnvironment -> FactTag -> [Term (Lit c k)] -> M.Map k SapicType
+typeVarsEvent :: (Ord k) => TypingEnvironment -> FactTag -> [Term (Lit c k)] -> M.Map k SapicType
 typeVarsEvent TypingEnvironment {events = ev} tag ts =
   case M.lookup tag ev of
     Just t ->
@@ -886,22 +1030,23 @@ typeVarsEvent TypingEnvironment {events = ev} tag ts =
         (zip ts t)
     Nothing -> M.empty
 
-ppProtoAtom
-  :: (HighlightDocument d, Ord k, Show k, Show c)
-  => TypingEnvironment
-  -> Bool
-  -> (s (Term (Lit c k)) -> d)
-  -> (Term (Lit c k) -> d)
-  -> ProtoAtom s (Term (Lit c k))
-  -> (d, M.Map k SapicType)
+ppProtoAtom ::
+  (HighlightDocument d, Ord k, Show k, Show c) =>
+  TypingEnvironment ->
+  Bool ->
+  (s (Term (Lit c k)) -> d) ->
+  (Term (Lit c k) -> d) ->
+  ProtoAtom s (Term (Lit c k)) ->
+  (d, M.Map k SapicType)
 ppProtoAtom te _ _ ppT (Action v f@(Fact tag _ ts))
   | factTagArity tag /= length ts = translationFail $ "MALFORMED function" ++ show tag
-  | (tag == KUFact) || isKLogFact f  -- treat KU() and K() facts the same
-      = (ppFactL "attacker" ts <> opAction <> ppT v, M.empty)
+  | (tag == KUFact) || isKLogFact f -- treat KU() and K() facts the same
+    =
+      (ppFactL "attacker" ts <> opAction <> ppT v, M.empty)
   | otherwise =
-    ( text "event(" <> ppFactL ('e' : factTagName tag) ts <> text ")" <> opAction <> ppT v,
-      typeVarsEvent te tag ts
-    )
+      ( text "event(" <> ppFactL ('e' : factTagName tag) ts <> text ")" <> opAction <> ppT v,
+        typeVarsEvent te tag ts
+      )
   where
     ppFactL n t = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ map ppT t
 ppProtoAtom _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
@@ -911,7 +1056,7 @@ ppProtoAtom _ True _ ppT (EqE l r) =
   (sep [ppT l <-> text "<>", ppT r], M.empty)
 -- sep [ppNTerm l <-> text "≈", ppNTerm r]
 ppProtoAtom _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
-ppProtoAtom _ _ _ ppT (Subterm u v) = (ppT u <-> opLess <-> ppT v, M.empty)
+ppProtoAtom _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
 ppProtoAtom _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
 
 ppAtom :: TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
@@ -934,12 +1079,12 @@ extractFree (Bound i) = translationFail $ "prettyFormula: illegal bound variable
 toLAt :: (Ord (f1 b), Ord (f1 (BVar b)), Functor f2, Functor f1) => f2 (Term (f1 (BVar b))) -> f2 (Term (f1 b))
 toLAt = fmap (mapLits (fmap extractFree))
 
-ppLFormula
-  :: (MonadFresh m, Ord c, HighlightDocument b, Functor syn)
-  => TypingEnvironment
-  -> (TypingEnvironment -> Bool -> ProtoAtom syn (Term (Lit c LVar)) -> (b, M.Map LVar SapicType))
-  -> ProtoFormula syn (String, LSort) c LVar
-  -> m ([LVar], (b, M.Map LVar SapicType))
+ppLFormula ::
+  (MonadFresh m, Ord c, HighlightDocument b, Functor syn) =>
+  TypingEnvironment ->
+  (TypingEnvironment -> Bool -> ProtoAtom syn (Term (Lit c LVar)) -> (b, M.Map LVar SapicType)) ->
+  ProtoFormula syn (String, LSort) c LVar ->
+  m ([LVar], (b, M.Map LVar SapicType))
 ppLFormula te ppAt =
   pp
   where
@@ -966,6 +1111,7 @@ ppLFormula te ppAt =
         (vsp, d') <- pp fm'
         pure (vs ++ vsp, d')
 
+-- | Check if a formula is quantifier-free.
 isPropFormula :: LNFormula -> Bool
 isPropFormula (Qua {}) = False
 isPropFormula (Ato _) = True
@@ -974,19 +1120,19 @@ isPropFormula (Not (Ato (EqE _ _))) = True
 isPropFormula (Not _) = True
 isPropFormula (Conn _ p q) = isPropFormula p && isPropFormula q
 
-ppQueryFormula
-  :: (MonadFresh m, Functor s)
-  => TypingEnvironment
-  -> ProtoFormula s (String, LSort) Name LVar
-  -> [LVar]
-  -> m Doc
+ppQueryFormula ::
+  (MonadFresh m, Functor s) =>
+  TypingEnvironment ->
+  ProtoFormula s (String, LSort) Name LVar ->
+  [LVar] ->
+  m Doc
 ppQueryFormula te fm extravs = do
   (vs, (p, typeVars)) <- ppLFormula te ppNAtom fm
   pure $
     sep
-      [ text "query " <> fsep (punctuate comma (map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs))) <> text ";"
-      , nest 1 p
-      , text "."
+      [ text "query " <> fsep (punctuate comma (map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs))) <> text ";",
+        nest 1 p,
+        text "."
       ]
 
 ppTimeTypeVar :: M.Map LVar SapicType -> LVar -> Doc
@@ -1000,12 +1146,15 @@ ppQueryFormulaEx :: TypingEnvironment -> LNFormula -> [LVar] -> Doc
 ppQueryFormulaEx te fm vs =
   Precise.evalFresh (ppQueryFormula te fm vs) (avoidPrecise fm)
 
-ppRestrictFormula
-  :: TypingEnvironment
-  -> ProtoFormula Unit2 (String, LSort) Name LVar
-  -> Precise.FreshT Data.Functor.Identity.Identity Doc
-ppRestrictFormula te =
-  pp
+ppRestrictFormula ::
+  TypingEnvironment ->
+  ProtoFormula Unit2 (String, LSort) Name LVar ->
+  Precise.FreshT Data.Functor.Identity.Identity Doc
+ppRestrictFormula te frm =
+  if any (\(Fact tag _ _) -> factTagName tag == "KU") $ formulaFacts frm
+    then -- todo: Add all translation warnings to the wellformedness report.
+      pure $ translationWarning "formula with KU facts is not supported\n" (ppFail frm)
+    else pp $ frm -- don't allow KU facts, nothing corresponding in PV
   where
     pp (Not fm@(Qua Ex _ _)) = do
       (vs, _, fm') <- openFormulaPrefix fm
@@ -1065,35 +1214,132 @@ ppRestrictFormula te =
       pure $ b && isPropFormula fm'
     disjunct_ex _ = pure False
 
+-- | ppLemma translates ONLY lemmas and only in the "classical way", i.e., with timepoints and so on
+-- | The resulting translations are NOT suitable as ProVerif lemmas, axioms and restrictions (only as queries)
 ppLemma :: TypingEnvironment -> Lemma ProofSkeleton -> Doc
 ppLemma te p =
-  text "(*" <> text p._lName <> text "*)"
-    $$ Precise.evalFresh (ppRestrictFormula te fm) (avoidPrecise fm)
+  trace
+    ( "PROVERIF LEMMA: "
+        ++ render
+          ( vcat
+              ( map
+                  ( \fm -> case fm of
+                      Not fm' ->
+                        if allImplsEx fm' && p._lTraceQuantifier == ExistsTrace
+                          then printFmNameFormula fm' $$ text "(* Existential lemma " <> text p._lName <> text " has a leading negation, interpret ProVerif's answers accordingly!*)\n"
+                          else printFmNameFormula fm
+                      _ -> printFmNameFormula fm
+                  )
+                  fms
+              )
+              $$ if isEmpty comments then comments else text "(* To reconstruct lemma " <> text p._lName <> text ":" $$ comments $$ text "*)"
+          )
+        ++ " END"
+    )
+    $ vcat
+      ( map
+          ( \fm -> case fm of
+              Not fm' ->
+                if allImplsEx fm' && p._lTraceQuantifier == ExistsTrace
+                  then printFmNameFormula fm' $$ text "(* Existential lemma " <> text p._lName <> text " has a leading negation, interpret ProVerif's answers accordingly!*)\n"
+                  else printFmNameFormula fm
+              _ -> printFmNameFormula fm
+          )
+          fms
+      )
+      $$ if isEmpty comments then comments else text "(* To reconstruct lemma " <> text p._lName <> text ":" $$ comments $$ text "*)"
   where
-    fm = p._lFormula
+    fms = map transformFm fms'
 
-loadLemmas
-  :: (ProtoLemma LNFormula ProofSkeleton -> Bool)
-  -> TranslationContext
-  -> TypingEnvironment
-  -> OpenTheory
-  -> [Doc]
+    printFmNameFormula f' = text "(*" <> text p._lName <> text "*)" $$ Precise.evalFresh (ppRestrictFormula te f') (avoidPrecise f') <> text "\n"
+
+    -- assuming all formulas we are concerned with have quantifiers at their top level (after splitTopLvlConns)
+    transformFm fm = transformWithPullNots $ case () of
+      _
+        | allActImplsNotExAct fm -> pnf fm
+        | notExistsOfExists fm -> replNotAOrBWithAImpB $ either id id $ pullnots $ nnf fm
+        -- \| restructToAllImpEx fm /= fm -> restructToAllImpEx fm
+        | existsConjOfNotExists fm && p._lTraceQuantifier == ExistsTrace -> replAAndNotBWithAImpB $ either id id $ pullnots $ rearrangeAnd fm
+        -- \| existsConjOfNotExists fm -> replAAndNotBWithAImpB $ either id id $ pullnots $ changeAssocLeftToRight fm
+        | otherwise -> fm
+
+    {- if existsConjOfNotExists fm
+          then trace (render $ prettyLNFormula $ either id id $ strongPullnots fm) $ either id id $ strongPullnots fm
+          else fm -}
+    -- case allImplsPrenexConc fm of
+    -- fm' -> trace (render $ prettyLNFormula $ pnf $ nnf fm) $ fm'
+    -- fm -> fm
+    -- where
+    -- maybePullAlls = if allAlls maybePrenexConcl then transformWithPullnots $ pnf maybePrenexConcl else maybePrenexConcl
+    -- maybePrenexConcl = if checkAllImpliesEx maybePulledExists == maybePulledExists then maybePulledExists else transformWithPullnots $ checkAllImpliesEx maybePulledExists
+    -- pulledNotsFm = transformWithPullnots fm --convToGuardedStruct fm
+    (fms', comments, _) = trace ("TAMARIN LEMMA: " ++ render (prettyLNFormula p._lFormula) ++ " END") $ splitTopLvlConns p._lTraceQuantifier 1 $ simplifyFormula p._lFormula
+
+transformWithPullNots :: LNFormula -> LNFormula
+transformWithPullNots f = case pullnots f of
+  Left f' -> translationWarning ("Formula " ++ render (prettyLNFormula f) ++ " cannot be rewritten s.t. it either has only 1 ¬ or none, the result is:\n" ++ render (prettyLNFormula f') ++ "!\n\n") f'
+  Right f' -> f'
+
+-- turns out guardedness is potentially not good at all (Tamarin already permits only formulas that adhere to guarded quantification)
+-- use the type structure for its associativity :)
+{-convToGuardedStruct f = case parseString [] "" plainFormula $ render $ prettyGuarded $ formulaToGuarded_ f of
+       Left _ -> f
+       Right fm' -> trace (render $ prettyLNFormula fm') fm'-}
+
+replAAndNotBWithAImpB :: ProtoFormula syn s c v -> ProtoFormula syn s c v
+replAAndNotBWithAImpB (Qua q x p) = Qua q x $ replAAndNotBWithAImpB p
+replAAndNotBWithAImpB (Conn And p (Not q)) = Not $ Conn Imp p q
+replAAndNotBWithAImpB (Conn c p q) = Conn c (replAAndNotBWithAImpB p) (replAAndNotBWithAImpB q)
+replAAndNotBWithAImpB (Not p) = Not (replAAndNotBWithAImpB p)
+replAAndNotBWithAImpB fm = fm
+
+rearrangeAnd :: ProtoFormula syn s c v -> ProtoFormula syn s c v
+rearrangeAnd (Qua q x p) = Qua q x $ rearrangeAnd p
+rearrangeAnd (Conn And (Conn And (Not p) q) f) = Conn And q (Conn And (Not p) f)
+rearrangeAnd (Conn And (Conn And p (Not q)) f) = Conn And p (Conn And (Not q) f)
+rearrangeAnd (Conn c p q) = Conn c (rearrangeAnd p) (rearrangeAnd q)
+rearrangeAnd (Not p) = Not (rearrangeAnd p)
+rearrangeAnd fm = fm
+
+replNotAOrBWithAImpB :: ProtoFormula syn s c v -> ProtoFormula syn s c v
+replNotAOrBWithAImpB (Qua q x p) = Qua q x $ replNotAOrBWithAImpB p
+replNotAOrBWithAImpB (Conn Or (Not p) q) = Conn Imp p q
+replNotAOrBWithAImpB (Conn c p q) = Conn c (replNotAOrBWithAImpB p) (replNotAOrBWithAImpB q)
+replNotAOrBWithAImpB (Not p) = Not (replNotAOrBWithAImpB p)
+replNotAOrBWithAImpB fm = fm
+
+{-reorderQuants :: LNGuarded -> LNGuarded
+reorderQuants (GGuarded qua ss as gf) = GGuarded qua ss (sortNotsFst as) (reorderQuants gf)
+  where
+    sortNotsFst xs = uncurry (++) (partition (\f -> case f of
+                                                          (GGuarded All [] [a] gfalse) -> True
+                                                          _ -> False) xs)
+reorderQuants (GDisj disj)            = gconj $ map reorderQuants (getDisj disj)
+reorderQuants (GConj conj)            = gdisj $ map reorderQuants (getConj conj)
+reorderQuants af                      = af
+-}
+
+loadLemmas ::
+  (ProtoLemma LNFormula ProofSkeleton -> Bool) ->
+  TranslationContext ->
+  TypingEnvironment ->
+  OpenTheory ->
+  [Doc]
 loadLemmas lemSel tc te thy = map (ppLemma te) proverifLemmas
   where
     thyLemmas = theoryLemmas thy
-    transformWithPullnots l = case pullnots l._lFormula of
-      Left fm' ->
-        translationWarning ("Lemma " ++ l._lName ++ "\n" ++ render (prettyLNFormula l._lFormula) ++" cannot be rewritten s.t. it either has only 1 ¬ or none, the result is:\n" ++ render (prettyLNFormula fm') ++ "!\n\n")
-        $ l { _lFormula = fm' }
-      Right fm' -> l { _lFormula = fm' }
-    proverifLemmas = map transformWithPullnots $
-      filter
-        ( \lem ->
-            lemSel lem && case concat [ls | LemmaModule ls <- lem._lAttributes] of
-              [] -> True
-              ls -> exportModule (trans tc) `elem` ls
-        )
-        thyLemmas
+
+    proverifLemmas = filter isApplicableLemma thyLemmas
+
+    isApplicableLemma lem =
+      lemSel lem &&
+      not (skipReuseOrSrc tc &&
+           (ReuseLemma `elem` lem._lAttributes || SourceLemma `elem` lem._lAttributes)) &&
+      moduleCondition lem
+
+    moduleCondition lem =
+      let modules = concat [ ls | LemmaModule ls <- lem._lAttributes ]
+      in null modules || exportModule (trans tc) `elem` modules
 
 ------------------------------------------------------------------------------
 -- Header Generation
@@ -1118,42 +1364,38 @@ headerOfFunSym ((f, (k, pub, Constructor)), inTypes, outType) =
     priv_or_pub Private = ["private"]
 headerOfFunSym _ = S.empty
 
--- Load the proverif headers from the OpenTheory
+-- | Load headers from an OpenTheory into a set of ProVerif Headers
 loadHeaders :: TranslationContext -> OpenTheory -> TypingEnvironment -> IO (S.Set ProVerifHeader)
 loadHeaders tc thy typeEnv = do
-  eqHeaders <- mapM (headersOfRule tc typeEnv) (S.toList sigRules)
-  pure $ typedHeaderOfFunSym `S.union` headerBuiltins' `S.union` foldl (flip S.union) S.empty eqHeaders `S.union` eventHeaders
+  eqHeaders <- foldMap (headersOfRule tc typeEnv) sigRules
+  pure $ typedHeaderOfFunSym
+      `S.union` headerBuiltins'
+      `S.union` eqHeaders
+      `S.union` eventHeaders
   where
     sig = thy._thySignature._sigMaudeInfo
+    builtins' x = case builtins x of
+      AccurateBuiltin y -> y
+      BestEffortBuiltin y -> translationWarning ("Using best-effort translation for " ++ x) y
+      NotSupportedBuiltin s -> translationFail s
     -- all builtins are contained in Sapic Element
-    thyBuiltins = theoryBuiltins thy
-    headerBuiltins =
-      foldl
-        ( \y x -> case List.lookup x builtins of
-            Nothing -> case x of
-              "multiset"         -> translationFail "Multiset is not supported in ProVerif. If you want to model natural numbers, you can use the dedicated Tamarin builtin."
-              "bilinear-pairing" -> translationFail "Bilinear pairings are not supported in ProVerif."
-              _                  -> y
-            Just t -> y `S.union` t
-        )
-        S.empty
-        thyBuiltins
+    headerBuiltins = S.fromList $ foldMap builtins' (theoryBuiltins thy)
+
+    -- builtin headers need to be filtered, to make sure we don't redefine a user-defined function
+    headerBuiltins' = S.filter keep headerBuiltins
+      where
+        funNames = S.fromList [ n | Fun _ n _ _ _ <- S.toList typedHeaderOfFunSym ]
+        keep (Fun _ n _ _ _) = n `S.notMember` funNames
+        keep _               = True
 
     -- all user declared function symbols have typinginfos
     userDeclaredFunctions = theoryFunctionTypingInfos thy
-    typedHeaderOfFunSym = foldl (\y x -> headerOfFunSym x `S.union` y) S.empty userDeclaredFunctions
-
-    -- builtin headers need to be filtered, to make sure we don't redefine a user-defined function
-    headerBuiltins' = S.filter builtinFilter headerBuiltins
-    builtinFilter (Fun _ name _ _ _) = any (equalName name) typedHeaderOfFunSym
-    builtinFilter _ = True
-    equalName name (Fun _ name' _ _ _) = name /= name'
-    equalName _ _ = False
+    typedHeaderOfFunSym = foldMap headerOfFunSym userDeclaredFunctions
 
     -- events headers
     eventHeaders = M.foldrWithKey (\tag types acc -> HEvent ('e' : factTagName tag) ("(" ++ makeArgtypes types ++ ")") `S.insert` acc) S.empty (events typeEnv)
     -- generating headers for equations
-    sigRules = stRules sig
+    sigRules = S.toList (stRules sig)
 
 toSapicLVar :: LVar -> SapicLVar
 toSapicLVar v = SapicLVar v Nothing
@@ -1180,9 +1422,12 @@ headersOfRule tc typeEnv r | (lhs `RRule` rhs) <- ctxtStRuleToRRule r = do
       hrule =
         Eq
           prefix
-          ( "forall "
-              ++ render (fsep (punctuate comma (map ppFreeTyped freesrTyped)))
-              ++ ";"
+          ( case map ppFreeTyped freesrTyped of
+              [] -> ""
+              xs ->
+                "forall "
+                  ++ render (fsep (punctuate comma xs))
+                  ++ ";"
           )
           ( render $
               sep
@@ -1226,14 +1471,18 @@ prettyDeepSecHeader = \case
   -- only keep arity for fun declarations
   Fun "" _ _ _ _ -> text ""
   Fun fkind name arity _ [] ->
-    text fkind <> text " " <> text name
+    text fkind
+      <> text " "
+      <> text name
       <> text "/"
       <> text (show arity)
       <> text "."
   Fun fkind name arity _ attr ->
     if "private" `elem` attr
       then
-        text fkind <> text " " <> text name
+        text fkind
+          <> text " "
+          <> text name
           <> text "/"
           <> text (show arity)
           <> text "[private]"
@@ -1262,16 +1511,16 @@ attribHeaders tc hd =
 attChanName :: String
 attChanName = "att"
 
-mkAttackerChannel
-  :: MonadFresh m
-  => LProcess (ProcessAnnotation LVar)
-  -> m LVar
+mkAttackerChannel ::
+  (MonadFresh m) =>
+  LProcess (ProcessAnnotation LVar) ->
+  m LVar
 mkAttackerChannel _ = freshLVar attChanName LSortMsg
 
-mkAttackerContext
-  :: TranslationContext
-  -> LProcess (ProcessAnnotation LVar)
-  -> (TranslationContext, S.Set ProVerifHeader)
+mkAttackerContext ::
+  TranslationContext ->
+  LProcess (ProcessAnnotation LVar) ->
+  (TranslationContext, S.Set ProVerifHeader)
 mkAttackerContext tc p =
   (tc {attackerChannel = Just attackerVar}, S.singleton hd)
   where
@@ -1281,14 +1530,14 @@ mkAttackerContext tc p =
     hd = Sym "free" n ":channel" []
 
 -- given an optional channel name and a translation context, returns the corresponding printer
-getAttackerChannel
-  :: TranslationContext
-  -> Maybe SapicTerm
-  -> (Doc, S.Set ProVerifHeader)
+getAttackerChannel ::
+  TranslationContext ->
+  Maybe SapicTerm ->
+  (Doc, S.Set ProVerifHeader)
 getAttackerChannel tc t1 = case (t1, attackerChannel tc) of
   (Just tt1, _) -> ppSapicTerm tc tt1
   (Nothing, Just (LVar n _ _)) -> (text n, S.empty)
-  _ ->  translationFail "Unexpected error -> please report with an issue on the github."
+  _ -> translationFail "Unexpected error -> please report with an issue on the github."
 
 ------------------------------------------------------------------------------
 -- Some utility functions
@@ -1316,31 +1565,574 @@ makeAnnotations thy p = res
 -- | Pull out nots in formula
 pullnots :: LNFormula -> Either LNFormula LNFormula
 pullnots fm =
-  let fm_partially_rewritten = fixedpoint pullStep fm in -- nots pulled out by pullStep can enable new pull-out steps, so need to compute fixed point
-  if onlyTopLevelNot fm_partially_rewritten
-    then Right fm_partially_rewritten -- in this case, formula is fully rewritten, i.e. has only 1 top-level not or no nots at all
-    else Left fm_partially_rewritten  -- Error with partially rewritten formula
+  let fm_partially_rewritten = fixedpoint pullStep fm -- nots pulled out by pullStep can enable new pull-out steps, so need to compute fixed point
+   in if onlyTopLevelNot fm_partially_rewritten
+        then Right fm_partially_rewritten -- in this case, formula is fully rewritten, i.e. has only 1 top-level not or no nots at all
+        else Left fm_partially_rewritten -- Error with partially rewritten formula
   where
-    onlyTopLevelNot (Not p) = noNots p -- top-level not expected if rewriting was successful
-    onlyTopLevelNot p       = noNots p -- no top-level not may mean the rewriting has been successful and the formula has no nots at all
-
-    noNots (Not _)      = False -- check that there are no nots below top level
-    noNots (Conn _ p q) = noNots p && noNots q
-    noNots (Qua _ _ p ) = noNots p
-    noNots _            = True
-
     fixedpoint f phi = if phi /= f phi then fixedpoint f (f phi) else phi
 
     pullStep fm' = case fm' of
-      Conn And (Not p) (Not q)  -> Not $ p .||. q
-      Conn Or (Not p) (Not q)   -> Not $ p .&&. q
-      Conn Imp p (Not q)        -> Not $ p .&&. q
-      Conn Iff (Not p) q        -> Not $ p .<=>. q
-      Conn Iff p (Not q)        -> Not $ p .<=>. q
-      Conn c p q                -> Conn c (pullStep p) (pullStep q)
-      Qua All x (Not p)         -> Not $ Qua Ex x p
-      Qua Ex x (Not p)          -> Not $ Qua All x p
-      Qua qua x p               -> Qua qua x $ pullStep p
-      Not (Not p)               -> p
-      Not p                     -> Not $ pullStep p
-      _                         -> fm'
+      Conn And (Not p) (Not q) -> Not $ p .||. q
+      Conn Or (Not p) (Not q) -> Not $ p .&&. q
+      Conn Imp p (Not q) -> if isLessOrEqe q then Conn Imp p (Not q) else Not $ p .&&. q
+      Conn Iff (Not p) q -> Not $ p .<=>. q
+      Conn Iff p (Not q) -> Not $ p .<=>. q
+      Conn c p q -> Conn c (pullStep p) (pullStep q)
+      Qua All x (Not p) -> Not $ Qua Ex x p
+      Qua Ex x (Not p) -> Not $ Qua All x p
+      Qua qua x p -> Qua qua x $ pullStep p
+      Not (Not p) -> p
+      Not (Ato (EqE t1 t2)) -> Not (Ato (EqE t1 t2))
+      Not p -> Not $ pullStep p
+      _ -> fm'
+
+    -- Don't pull nots infront of equality tests/comparisons.
+    isLessOrEqe (Ato (EqE _ _)) = True
+    isLessOrEqe (Ato (Less _ _)) = True
+    isLessOrEqe _ = False
+
+onlyTopLevelNot :: ProtoFormula syn s c v -> Bool
+onlyTopLevelNot (Not p) = noNots p -- top-level not expected if rewriting was successful
+onlyTopLevelNot p = noNots p -- no top-level not may mean the rewriting has been successful and the formula has no nots at all
+
+noNots :: ProtoFormula syn s c v -> Bool
+noNots (Not (Ato (EqE _ _))) = True -- check that there are no nots below top level (except before equality tests/comparisons)
+noNots (Not (Ato (Less _ _))) = True
+noNots (Not _) = False
+noNots (Conn _ p q) = noNots p && noNots q
+noNots (Qua _ _ p) = noNots p
+noNots _ = True
+
+{-
+-- | ProVerif does not allow equalities in the premise/in existential lemmas.
+-- | If possible, we merge the variables/terms and remove the equality.
+mergeEqs :: LNFormula -> LNFormula
+mergeEqs f@(Qua All _ _) = mergeEqsUniv f
+where
+    mergeEqsUniv (Qua All x p) = mergeEqsUniv p
+    mergeEqsUniv (Conn p q) = merge
+mergeEqs f@(Qua Ex _ _) = mergeEqsEx f
+-}
+
+allAlls :: LNFormula -> Bool
+allAlls p =
+  onlyQua All p
+    && ( (1 :: Int)
+           < foldFormula
+             (const 0)
+             (const 0)
+             (const 0)
+             (\c q1 q2 -> case c of Imp -> 1 + q1 + q2; _ -> q1 + q2)
+             (\_ _ q1 -> q1)
+             p
+       )
+
+restructToAllImpEx :: LNFormula -> LNFormula
+restructToAllImpEx (Qua All x p) = Qua All x $ restructToAllImpEx p
+restructToAllImpEx (Conn Imp p q) = Conn Imp p (pnf q)
+restructToAllImpEx fm = fm
+
+-- | Check if the formula has the structure All x1...xn. (f_a => Ex y1...yn. f_b)
+checkAllImpliesEx :: LNFormula -> LNFormula
+checkAllImpliesEx (Qua All x p) = Qua All x $ checkAll p
+  where
+    checkAll (Qua All y f) = Qua All y $ checkAll f
+    checkAll (Conn Imp q1 q2) = Conn Imp q1 (pnf q2)
+    checkAll f = f
+-- \$ checkEx q2
+--      checkAll f = f
+--      checkEx f = if and $
+--                          foldFormula (const [True]) (const [True]) (const [True])
+--                          (\_ _ _-> [True]) (\q _ q1 -> case q of Ex -> q1; All -> [False]) f
+--                  then pnf f else f
+checkAllImpliesEx f = f
+
+-- | Check if a formula has only universal quantifiers and more than one implication.
+-- allAlls :: LNFormula -> Bool
+-- allAlls p = onlyQua All p
+--            && ((1::Int) < foldFormula (const 0) (const 0) (const 0)
+--                          (\c q1 q2 -> case c of Imp -> 1 + q1 + q2; _ -> q1 + q2) (\_ _ q1 -> q1) p)
+
+-- | Check if a formula is of the form All x1 ... xn. (F => (not(Ex y1 ... yn. F')).
+allImplsNotEx :: LNFormula -> Bool
+allImplsNotEx (Qua All _ body) = allImplsNotEx body
+allImplsNotEx (Conn Imp p (Not f'@(Qua Ex _ _))) = isPropFormula p && onlyEx f'
+  where
+    onlyEx (Qua Ex _ body') = isPropFormula body' || onlyEx body'
+    onlyEx _ = False
+allImplsNotEx _ = False
+
+-- | Check if a formula is of the form All x1 ... xn. (F => (Ex y1 ... yn. F') or All x1 ... xn. (F => (Ex y1 ... yn. F') \/ (Ex y1' ... yn'. F'').
+allImplsEx :: LNFormula -> Bool
+allImplsEx (Qua All _ body) = allImplsEx body
+allImplsEx f@(Conn Imp p q) = isPropFormula f || (isPropFormula p && onlyEx q)
+  where
+    onlyEx (Qua Ex _ body') = isPropFormula body' || onlyEx body'
+    onlyEx (Conn Or (Qua Ex _ b1) (Qua Ex _ b2)) = isPropFormula b1 || isPropFormula b2
+    onlyEx _ = False
+allImplsEx _ = False
+
+-- | Check if a formula is of the form All x1 ... xn. (F => F') and F' contains quantifiers.
+-- | If so, return the formula where F' is in PNF else return the input formula.
+allImplsPrenexConc :: LNFormula -> LNFormula
+allImplsPrenexConc (Qua All x body) = Qua All x $ allImplsPrenexConc body
+allImplsPrenexConc f@(Conn Imp p q) = if isPropFormula p && not (isPropFormula q) then Conn Imp p (pnf q) else f
+allImplsPrenexConc f = f
+
+-- | Check if a formula is of the form not(Ex x1 ... xn. F) where F is a conjunction, may contain existential quantifiers and has one negation.
+notExistsOfExists :: LNFormula -> Bool
+notExistsOfExists (Not (Qua Ex _ body)) = existsConjUnderNot body && ((1 :: Int) == (foldFormula (const 0) (const 0) (1 +) (\_ p q -> p + q) (\_ _ p -> p) $ body))
+  where
+    existsConjUnderNot (Qua Ex _ p) = existsConjUnderNot p
+    existsConjUnderNot (Conn And p q) = existsConjUnderNot p && existsConjUnderNot q
+    existsConjUnderNot (Conn {}) = False
+    existsConjUnderNot _ = True
+notExistsOfExists _ = False
+
+-- | -- | Check if a formula is of the form Ex x1 ... xn. F where F contains only negative existential quantifiers and conjunctions.
+existsConjOfNotExists :: LNFormula -> Bool
+existsConjOfNotExists (Qua Ex _ body) = existsConjOfNotExists body
+existsConjOfNotExists (Conn _ p q) = checkNotExists p && checkNotExists q
+  where
+    checkNotExists (Not (Qua Ex _ p)) = checkExistsInNotExists p
+    checkNotExists (Conn And p q) = checkNotExists p && checkNotExists q
+    checkNotExists (Conn {}) = False
+    checkNotExists _ = True
+
+    checkExistsInNotExists (Qua Ex _ p) = checkExistsInNotExists p
+    checkExistsInNotExists (Conn And p q) = checkNotExists p && checkNotExists q
+    checkExistsInNotExists (Conn {}) = False
+    checkExistsInNotExists _ = True
+existsConjOfNotExists _ = False
+
+-- | Check if a formula contains only one type of quantifier.
+onlyQua :: Quantifier -> ProtoFormula syn s c v -> Bool
+onlyQua qua =
+  and
+    . foldFormula
+      (const [True])
+      (const [True])
+      (const [True])
+      (\_ q1 q2 -> q1 ++ q2)
+      (\q _ q1 -> if qua == q then q1 else [False])
+
+-- | Recursively split a formula at its connectives (until we split it into subformulas that start with quantifiers).
+-- | Also add a formal comment so that the user knows how to reconstruct the original formula.
+-- | Trace quantification influences if we distribute AND and OR.
+splitTopLvlConns :: TraceQuantifier -> Int -> LNFormula -> ([LNFormula], Doc, Int)
+splitTopLvlConns AllTraces step (Conn And p q) =
+  ( fstP ++ fstQ,
+    sndP
+      $$ sndQ
+      $$ text (show stepQ ++ ". Combine ")
+      $$ prettyLNFormula p
+      $$ text " and "
+      $$ prettyLNFormula q
+      $$ text " with ∧.",
+    stepQ + 1
+  )
+  where
+    (fstP, sndP, stepP) = splitTopLvlConns AllTraces step p
+    (fstQ, sndQ, stepQ) = splitTopLvlConns AllTraces stepP q
+
+{- splitTopLvlConns AllTraces step (Conn Or p q) =
+    (fstP ++ fstQ,
+     sndP $$ sndQ $$ text ("Distribution of a universal trace quantifier over ∨ yields a stronger statement!\nA positive result is transferable, while a negative result is not!" ++ "\n" ++ show stepQ ++ ". Combine ")
+                     $$ prettyLNFormula p
+                     $$ text " and "
+                     $$ prettyLNFormula q
+                     $$ text " with ∨.",
+     stepQ + 1)
+  where
+    (fstP, sndP, stepP) = splitTopLvlConns AllTraces step p
+    (fstQ, sndQ, stepQ) = splitTopLvlConns AllTraces stepP q -}
+
+splitTopLvlConns ExistsTrace step (Conn Or p q) =
+  ( fstP ++ fstQ,
+    sndP
+      $$ sndQ
+      $$ text (show stepQ ++ ". Combine ")
+      $$ prettyLNFormula p
+      $$ text " and "
+      $$ prettyLNFormula q
+      $$ text " with ∨.",
+    stepQ + 1
+  )
+  where
+    (fstP, sndP, stepP) = splitTopLvlConns ExistsTrace step p
+    (fstQ, sndQ, stepQ) = splitTopLvlConns ExistsTrace stepP q
+
+-- distributing exists over AND yields a weaker statement (implied by the undistributed statement => useless)
+
+{- splitTopLvlConns AllTraces step (Conn Imp p q) =
+    (fstNotP ++ fstQ,
+     sndNotP $$ sndQ $$ text ("Distribution of a universal trace quantifier over ⇒.\nA ⇒ B is being treated as ¬A ∨ B!\nThe distribution yields a stronger statement!" ++ "\n" ++ show stepQ ++ ". Combine ")
+                           $$ prettyLNFormula p
+                           $$ text " and "
+                           $$ prettyLNFormula q
+                           $$ text " with ⇒ (attention: negate the premise).",
+     stepQ + 1)
+  where
+    (fstNotP, sndNotP, stepP) = splitTopLvlConns AllTraces step (Not p)
+    (fstQ, sndQ, stepQ) = splitTopLvlConns AllTraces stepP q -}
+
+-- case is OK, but it does not happen in Tamarin
+{-splitTopLvlConns ExistsTrace step (Conn Imp p q) =
+    (fstNotP ++ fstQ,
+     sndNotP $$ sndQ $$ text (show stepQ ++ ". Combine ")
+                           $$ prettyLNFormula p
+                           $$ text " and "
+                           $$ prettyLNFormula q
+                           $$ text " with ⇒ (attention: negate the premise).",
+     stepQ + 1)
+  where
+    (fstNotP, sndNotP, stepP) = splitTopLvlConns AllTraces step (Not p)
+    (fstQ, sndQ, stepQ) = splitTopLvlConns  ExistsTrace stepP q-}
+
+splitTopLvlConns _ step fm = ([fm], mempty, step)
+
+------------------------------------------------------------------------------
+-- Printers for Restrictions and ProVerif Lemmas
+------------------------------------------------------------------------------
+
+data PVElement = R | RSL
+
+ppAtomR :: TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppAtomR te b = ppProtoAtomR te b (const emptyDoc)
+
+-- only used for ProVerif queries display
+-- the Bool is set to False when we must negate the atom
+ppNAtomR :: TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppNAtomR te b = ppAtomR te b (fst . ppLNTerm emptyTC)
+
+ppProtoAtomR ::
+  (HighlightDocument d, Ord k, Show k, Show c) =>
+  TypingEnvironment ->
+  Bool ->
+  (s (Term (Lit c k)) -> d) ->
+  (Term (Lit c k) -> d) ->
+  ProtoAtom s (Term (Lit c k)) ->
+  (d, M.Map k SapicType)
+ppProtoAtomR te _ _ ppT (Action _ f@(Fact tag _ ts))
+  | factTagArity tag /= length ts = translationFail $ "MALFORMED function" ++ show tag
+  | (tag == KUFact) || isKLogFact f -- treat KU() and K() facts the same
+    =
+      (ppFactL "attacker" ts, M.empty)
+  | otherwise =
+      ( text "event(" <> ppFactL ('e' : factTagName tag) ts <> text ")",
+        typeVarsEvent te tag ts
+      )
+  where
+    ppFactL n t = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ map ppT t
+ppProtoAtomR _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
+ppProtoAtomR _ False _ ppT (EqE l r) =
+  (sep [ppT l <-> opEqual, ppT r], M.empty)
+ppProtoAtomR _ True _ ppT (EqE l r) =
+  (sep [ppT l <-> text "<>", ppT r], M.empty)
+-- sep [ppNTerm l <-> text "≈", ppNTerm r]
+ppProtoAtomR _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
+ppProtoAtomR _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
+ppProtoAtomR _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
+
+ppLFormulaR ::
+  (MonadFresh m, Ord c, HighlightDocument b, Functor syn) =>
+  TypingEnvironment ->
+  (TypingEnvironment -> Bool -> ProtoAtom syn (Term (Lit c LVar)) -> (b, M.Map LVar SapicType)) ->
+  ProtoFormula syn (String, LSort) c LVar ->
+  m ([LVar], (b, M.Map LVar SapicType))
+ppLFormulaR te ppAt =
+  pp
+  where
+    pp (Ato a) = pure ([], ppAt te False (toLAt a))
+    pp (TF True) = pure ([], (operator_ "true", M.empty)) -- "T"
+    pp (TF False) = pure ([], (operator_ "false", M.empty)) -- "F"
+    pp (Not (Ato a@(EqE _ _))) = pure ([], ppAt te True (toLAt a))
+    pp (Not p) = do
+      (vs, (p', envp)) <- pp p
+      pure (vs, (operator_ "not" <> opParens p', envp)) -- text "¬" <> parens (pp a)
+      -- pure $ operator_ "not" <> opParens p' -- text "¬" <> parens (pp a)
+    pp (Conn op p q) = do
+      (vsp, (p', envp)) <- pp p
+      (vsq, (q', envq)) <- pp q
+      pure (vsp ++ vsq, (sep [opParens p' <-> ppOp op, opParens q'], mergeEnv envp envq))
+      where
+        ppOp And = text "&&"
+        ppOp Or = text "||"
+        ppOp Imp = text "==>"
+        ppOp Iff = opIff
+    pp fm@(Qua {}) =
+      scopeFreshness $ do
+        (vs, _, fm') <- openFormulaPrefix fm
+        (vsp, d') <- pp fm'
+        pure (filter (\v -> lvarSort v /= LSortNode) (vs ++ vsp), d')
+
+ppQueryFormulaR ::
+  (MonadFresh m, Functor s) =>
+  PVElement ->
+  TypingEnvironment ->
+  ProtoFormula s (String, LSort) Name LVar ->
+  [LVar] ->
+  m Doc
+ppQueryFormulaR pe te fm extravs = do
+  (vs, (p, typeVars)) <- ppLFormulaR te ppNAtomR fm
+  pure $
+    sep
+      [ text word <> fsep (punctuate comma (map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs))) <> text ";",
+        nest 1 p,
+        text "."
+      ]
+  where
+    word = case pe of
+      R -> "restriction "
+      RSL -> "axiom "
+
+ppQueryFormulaExR :: PVElement -> TypingEnvironment -> LNFormula -> [LVar] -> Doc
+ppQueryFormulaExR pe te fm vs =
+  Precise.evalFresh (ppQueryFormulaR pe te fm vs) (avoidPrecise fm)
+
+ppRestrictFormulaR ::
+  PVElement ->
+  TypingEnvironment ->
+  ProtoFormula Unit2 (String, LSort) Name LVar ->
+  Precise.FreshT Data.Functor.Identity.Identity Doc
+ppRestrictFormulaR pe te frm =
+  if any (\(Fact tag _ _) -> factTagName tag == "KU") (formulaFacts frm) -- don't allow KU facts, nothing corresponding in PV
+    || hasLessOrTmpEq frm -- by this point we have stripped the less if that was possible in the 1st place
+    || allActImplsExAct frm
+    then pure $ ppFail frm
+    else pp $ allImplExLessWoTmps frm
+  where
+    pp (Not fm@(Qua Ex _ _)) = do
+      (vs, _, fm') <- openFormulaPrefix fm
+      pure
+        ( if isPropFormula fm'
+            then ppOk fm' vs
+            else ppFail fm
+        )
+    pp fm@(Qua All _ _) = do
+      (_, _, fm') <- openFormulaPrefix fm
+      pp2 fm fm'
+    pp fm = pure $ ppFail fm
+    ppOk = ppQueryFormulaExR pe te
+    ppFail fm = text "(*" <> prettyLNFormula fm <> text "*)"
+
+    pp2 fm_original fm | isPropFormula fm = do
+      pure $ ppOk fm_original []
+    pp2 fm_original (Conn Imp p fm) | isPropFormula p = do
+      isExDisj <- disjunct_ex fm
+      pure $
+        if isExDisj
+          then ppOk fm_original []
+          else ppFail fm_original
+    pp2 fm_original _ = pure $ ppFail fm_original
+
+    disjunct_ex fm@(Qua Ex _ _) = do
+      (_, _, fm') <- openFormulaPrefix fm
+      pure $ isPropFormula fm'
+    disjunct_ex (Conn Or fm@(Qua Ex _ _) fm2) = do
+      (_, _, fm') <- openFormulaPrefix fm
+      b <- disjunct_ex fm2
+      pure $ b && isPropFormula fm'
+    disjunct_ex (Conn Or fm2 fm@(Qua Ex _ _)) = do
+      (_, _, fm') <- openFormulaPrefix fm
+      b <- disjunct_ex fm2
+      pure $ b && isPropFormula fm'
+    disjunct_ex _ = pure False
+
+    -- pp2 fm_original (Conn Imp p fm@(Qua Ex _ _)) | isPropFormula p  = do
+    --             (_,_,fm') <- openFormulaPrefix fm
+    --             pure $ (if isPropFormula fm' then
+    --                         ppOk fm_original []
+    --                       else
+    --                         ppFail fm_original)
+    -- pp2 fm_original (Conn Imp p (Conn Or fm@(Qua Ex _ _)  fm2@(Qua Ex _ _))) | isPropFormula p  = do
+    --             (_,_,fm') <- openFormulaPrefix fm
+    --             (_,_,fm2') <- openFormulaPrefix fm2
+    --             pure $ (if isPropFormula fm' && isPropFormula fm2' then
+    --                         ppOk fm_original []
+    --                       else
+    --                         ppFail fm_original)
+
+    -- check if a formula has no timepoint comparisons/eqs; should've been removed at that point
+    hasLessOrTmpEq fm =
+      foldFormula
+        ( \a -> case a of
+            Less _ _ -> True
+            EqE t1 _ -> t1 `elem` formulaActsTmps
+            _ -> False
+        )
+        (const False)
+        (const False)
+        (\_ p q -> p || q)
+        (\_ _ p -> p)
+        fm
+      where
+        -- gather the of the actions to check of we have some eq/ineq with them
+        formulaActsTmps = foldFormula fAto (const []) id (\_ p q -> p ++ q) (\_ _ p -> p) fm
+          where
+            fAto a = case a of
+              Action tf _ -> [tf]
+              _ -> []
+
+-- | Only works for restrictions (due to them being different types than lemmas)
+ppRestr :: TypingEnvironment -> Restriction -> Doc
+ppRestr te rstr =
+  trace
+    ( "PROVERIF RESTR: "
+        ++ render
+          ( text "(*"
+              <> text rstr._rstrName
+              <> text "*)"
+              $$ Precise.evalFresh (ppRestrictFormulaR R te fm) (avoidPrecise fm)
+          )
+        ++ " END"
+    )
+    $ text "(*"
+      <> text rstr._rstrName
+      <> text "*)"
+      $$ Precise.evalFresh (ppRestrictFormulaR R te fm) (avoidPrecise fm)
+  where
+    fm = transformWithPullNots $ transformWithStamps $ trace ("TAMARIN RESTR: " ++ render (prettyLNFormula rstr._rstrFormula) ++ " END") $ rstr._rstrFormula
+
+{-fm = case parseString [] "" plainFormula $ render $ prettyGuarded gf of
+       Left e -> error (show e ++ render (prettyGuarded gf))
+       Right fm' -> fm' --- trace (show $ render $ prettyGuarded $ formulaToGuarded_ rstr._rstrFormula) $ fm'
+transformWithPullnots f = case pullnots f of
+    Left _ -> f
+    Right f' -> f'
+gf = formulaToGuarded_ $ transformWithPullnots $ transformWithStamps rstr._rstrFormula-}
+
+-- | Printer for reuse/src lemmas.
+-- | Different than ppLemma in that it ignores timepoints and does transformations custom to these lemmas.
+ppReuseSrcLemma :: TypingEnvironment -> Lemma ProofSkeleton -> Doc
+ppReuseSrcLemma te l =
+  text "(*"
+    <> text l._lName
+    <> text "*)"
+    $$ Precise.evalFresh (ppRestrictFormulaR RSL te fm) (avoidPrecise fm)
+  where
+    fm = allImplExLessWoTmps $ transformWithPullNots $ transformWithStamps l._lFormula
+
+{-fm = transformWithPullnots $ case parseString [] "" plainFormula $ render $ prettyGuarded gf of
+       Left _ -> error "should not happen"
+       Right fm' -> fm' --- trace (show $ render $ prettyGuarded $ formulaToGuarded_ rstr._rstrFormula) $ fm'
+transformWithPullnots f = case pullnots f of
+    Left _ -> f
+    Right f' -> f'
+gf = formulaToGuarded_ $ transformWithStamps l._lFormula-}
+
+-- Check if a formula is of the form "All x1 .. xn tA. A(x1 ... xn)@tA ==> not (Ex y1 ... yn tB. B(y1 ... yn)@tB)"
+allActImplsNotExAct :: LNFormula -> Bool
+allActImplsNotExAct (Qua All _ body) = allActImplsNotExAct body
+allActImplsNotExAct f@(Conn Imp p@(Ato at) (Not q)) = isActionAtom at && onlyEx q
+  where
+    onlyEx (Qua Ex _ body') = onlyEx body'
+    onlyEx (Ato a) = isActionAtom a
+    onlyEx _ = False
+allActImplsNotExAct _ = False
+
+-- Check if a formula is of the form "All x1 .. xn tA. A(x1 ... xn)@tA ==> Ex y1 ... yn tB. B(y1 ... yn)@tB"
+-- We reject such formulas as lemmas/axioms/restrictions.
+allActImplsExAct :: LNFormula -> Bool
+allActImplsExAct (Qua All _ body) = allActImplsExAct body
+allActImplsExAct f@(Conn Imp p@(Ato at) q) = isActionAtom at && onlyEx q
+  where
+    onlyEx (Qua Ex _ body') = onlyEx body'
+    onlyEx (Ato a) = isActionAtom a
+    onlyEx _ = False
+allActImplsExAct _ = False
+
+-- Check if a formula is of the form "All x1 .. xn tA. A(x1 ... xn)@tA ==> Ex y1 ... yn tB. B(y1 ... yn)@tB & tB < tA"
+-- If so, remove the less (it's implicit as we translate to a basic correspondence).
+allImplExLessWoTmps :: LNFormula -> LNFormula
+allImplExLessWoTmps (Qua All x p) = Qua All x $ allImplExLessWoTmps p
+allImplExLessWoTmps (Conn Imp (Ato (Action tA fA)) q) = Conn Imp (Ato (Action tA fA)) $ case q of
+  (Qua Ex x p) -> Qua Ex x $ onlyEx p
+  f -> f
+  where
+    onlyEx (Qua Ex x p) = Qua Ex x $ onlyEx p
+    onlyEx f@(Conn And (Ato (Action tB fB)) (Ato (Less tB' tA'))) = if tA == tA' && tB == tB' then Ato (Action tB fB) else f
+    onlyEx f = f
+allImplExLessWoTmps f = f
+
+transformWithStamps :: LNFormula -> LNFormula
+transformWithStamps f = if snd $ go False f then forAll ("st0", LSortFresh) (LVar "st0" LSortFresh 0) $ forAll ("st1", LSortFresh) (LVar "st1" LSortFresh 1) $ fst $ go False f else fst $ go False f
+  where
+    go False (Qua All s fm) = (Qua All s $ fst $ go False fm, snd recCall)
+      where
+        recCall = go False fm
+    go False fm@(Conn Imp (Conn And l r) tmpEq) = case (l, r, tmpEq) of
+      (Ato (Action i1 (Fact (ProtoFact m1 name1 arr1) ann1 ts1)), Ato (Action i2 (Fact (ProtoFact m2 name2 arr2) ann2 ts2)), Ato (EqE t1 t2)) ->
+        -- matches both OnlyOnce and Unique restriction types
+        if ((i2 == t1 && i1 == t2) || (i1 == t1 && i2 == t2)) && name1 == name2
+          then (Conn Imp (Conn And l' r') tmpEq', True)
+          else (fm, False)
+        where
+          l' = Ato (Action i1 (Fact (ProtoFact m1 (newName name1) (arr1 + 1)) ann1 (varTerm (Free $ LVar "st0" LSortFresh 0) : ts1)))
+          r' = Ato (Action i2 (Fact (ProtoFact m2 (newName name2) (arr2 + 1)) ann2 (varTerm (Free $ LVar "st1" LSortFresh 1) : ts2)))
+          tmpEq' = Ato (EqE (varTerm (Free $ LVar "st0" LSortFresh 0)) (varTerm (Free $ LVar "st1" LSortFresh 1)))
+          newName "OnlyOnce" = "OnlyOnce"
+          newName name = "U" ++ name
+      (Conn And (Ato (Action i1 (Fact (ProtoFact m1 name1 arr1) ann1 ts1))) (Ato (Action i2 (Fact (ProtoFact m2 name2 arr2) ann2 _))), Ato (EqE tA tB), Ato (EqE t1 t2)) ->
+        -- handle the OnlyOnce variant with A=B in addition to the OnlyOnces
+        if ((i2 == t1 && i1 == t2) || (i1 == t1 && i2 == t2)) && name1 == name2 -- hacky, but ProVerif does not have a problem with the dangling B
+          then (Conn Imp (Conn And l' r') tmpEq', True)
+          else (fm, False)
+        where
+          l' = Ato (Action i1 (Fact (ProtoFact m1 "OnlyOnce" (arr1 + 1)) ann1 (varTerm (Free $ LVar "st0" LSortFresh 0) : ts1)))
+          r' = Ato (Action i2 (Fact (ProtoFact m2 "OnlyOnce" (arr2 + 1)) ann2 (varTerm (Free $ LVar "st1" LSortFresh 1) : ts1)))
+          tmpEq' = Ato (EqE (varTerm (Free $ LVar "st0" LSortFresh 0)) (varTerm (Free $ LVar "st1" LSortFresh 1)))
+      _ -> (fm, False)
+    go _ fm = (fm, False)
+
+loadRestrictions ::
+  TranslationContext ->
+  TypingEnvironment ->
+  OpenTheory ->
+  [Doc]
+loadRestrictions _ te thy = map (ppRestr te) thyRestrs
+  where
+    thyRestrs = theoryRestrictions thy
+
+findActsByTmp :: (Eq t) => [GAtom t] -> t -> [GAtom t]
+findActsByTmp (a : as) tmp = case a of
+  GEqE _ _ -> findActsByTmp as tmp
+  GAction t _ -> if t == tmp then a : findActsByTmp as tmp else findActsByTmp as tmp
+findActsByTmp [] _ = []
+
+{-modifyAtoms :: ((Integer, Atom (VTerm Name (BVar LVar))) -> (Integer, Atom (VTerm Name (BVar LVar)))) -> (Integer, LNGuarded) -> (Integer, LNGuarded)
+modifyAtoms f (i, GDisj d) = (i, GDisj $ Disj $ map (\a -> snd $ modifyAtoms f (i,a)) $ getDisj d)
+modifyAtoms f (i, GConj c) = (i, GConj $ Conj $ map (\a -> snd $ modifyAtoms f (i,a)) $ getConj c)
+modifyAtoms f (i, GGuarded q vs gas gf) = case q of
+                                            All -> (i, GGuarded q vs (modifiedAtoms i gas) (snd $ modifyAtoms f (i, gf)))
+                                            Ex -> (i, GGuarded q vs gas gf)
+    where
+        modifiedAtoms ind = snd . foldl (\(i, acc) a -> (fst (f (i, a)), acc ++ [snd (f (i, a))])) (ind, [])
+        -- modifiedFormulas ind = snd . foldl (\(i, acc) a -> (fst (modifyAtoms i a), acc ++ [snd (modifyAtoms i a)])) (ind, [])
+modifyAtoms f (i, GAto a) = (i, GAto $ snd $ f (i, a))
+
+modifyOnlyOnceAtom :: Integer -> Atom (VTerm Name (BVar LVar)) -> Atom (VTerm Name (BVar LVar))
+modifyOnlyOnceAtom i a = case a of
+                            Action t f -> case f of
+                                              Fact (ProtoFact m "OnlyOnce" arr) ann ts -> Action t (Fact (ProtoFact m "OnlyOnce" (arr+1)) ann (varTerm (Bound i):ts))
+                                              _ -> a
+                            _ -> a
+
+modifyOnlyOnceEqe :: Integer -> Atom (VTerm Name (BVar LVar)) -> Atom (VTerm Name (BVar LVar))
+modifyOnlyOnceEqe i a = case a of
+                            EqE t1 t2 -> if True then EqE (varTerm (Bound (i-1))) (varTerm (Bound i)) else a
+                            _ -> a
+
+varVecLen :: LNGuarded -> Integer
+varVecLen (GGuarded _ vs _ _) = genericLength vs
+varVecLen _ = 0-}
+
+{-modifyAtoms :: LNFormula -> LNFormula
+modifyAtoms = mapAtoms (\_ a -> case a of
+                                       Action _ f -> case f of
+                                                         Fact tag an terms -> case tag of
+                                                             ProtoFact _ "OnlyOnce" _ -> ProtoFact _ "OnlyOnce" _
+                                                             _ -> a
+                                                         _ -> a
+                                       _ -> a)-}

--- a/lib/export/src/ProVerifHeader.hs
+++ b/lib/export/src/ProVerifHeader.hs
@@ -1,0 +1,11 @@
+module ProVerifHeader where
+
+-- ProVerif Headers need to be ordered, and declared only once. We order them by type, and will update a set of headers.
+data ProVerifHeader
+  = Type String -- type declaration
+  | Sym String String String [String] -- symbol declaration, (symkind,name,type,attr)
+  | Fun String String Int String [String] -- symbol declaration, (symkind,name,arity,types,attr)
+  | HEvent String String
+  | Table String String
+  | Eq String String String String -- eqtype, quantif, equation pub/priv
+  deriving (Ord, Show, Eq)

--- a/lib/export/tamarin-prover-export.cabal
+++ b/lib/export/tamarin-prover-export.cabal
@@ -52,6 +52,7 @@ library
 
   other-modules:
     RuleTranslation
+    ProVerifHeader
 
   default-extensions:
     DuplicateRecordFields

--- a/lib/sapic/src/Sapic/Facts.hs
+++ b/lib/sapic/src/Sapic/Facts.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+
 -- Copyright   : (c) 2019 Robert Künnemann
 -- License     : GPL v3 (see LICENSE)
 --
@@ -7,128 +8,142 @@
 --
 -- Translation specific fact types that are translated into LNFacts
 module Sapic.Facts
-  ( TransAction(..)
-  , TransFact(..)
-  , SpecialPosition(..)
-  , AnnotatedRule(..)
-  , FactType(..)
-  , mapAct
-  , StateKind(..)
-  , isSemiState
-  , isState
-  , isFrFact
-  , isOutFact
-  , isStateFact
-  , isLetFact
-  , isLockFact
-  , isNonSemiState
-  , addVarToState
-  , factToFact
-  , actionToFact
-  , actionToFactFormula
-  , pureStateFactTag
-  , pureStateLockFactTag
-  , toRule
-  , varMID
-  , varProgress
-  , msgVarProgress
-  , patternInsFilter
-  , nonPatternInsFilter
-  , isPattern
-  , hasPattern
-  , propagateNames
-  ) where
+  ( TransAction (..),
+    TransFact (..),
+    SpecialPosition (..),
+    AnnotatedRule (..),
+    FactType (..),
+    mapAct,
+    StateKind (..),
+    isSemiState,
+    isState,
+    isFrFact,
+    isOutFact,
+    isStateFact,
+    isLetFact,
+    isLockFact,
+    isNonSemiState,
+    addVarToState,
+    factToFact,
+    actionToFact,
+    actionToFactFormula,
+    pureStateFactTag,
+    pureStateLockFactTag,
+    toRule,
+    varMID,
+    varProgress,
+    msgVarProgress,
+    patternInsFilter,
+    nonPatternInsFilter,
+    isPattern,
+    hasPattern,
+    propagateNames,
+  )
+where
 
+import Data.Bits
+import Data.Char
+import Data.Color
+import Data.List qualified as List
+import Data.Set qualified as S
+import Sapic.Annotation
 import Theory
 import Theory.Sapic
 import Theory.Sapic.Print
-import Sapic.Annotation
-import Data.Char
-import Data.Color
-import Data.Bits
-import Data.List qualified as List
-import Data.Set qualified as S
 
 -- | Facts that are used as actions
 data TransAction
-  -- base translation
-  = InitEmpty
-  -- storage
-  | IsIn LNTerm LVar
+  = -- base translation
+    InitEmpty
+  | -- storage
+    IsIn LNTerm LVar
   | IsNotSet LNTerm
   | InsertA LNTerm LNTerm
   | DeleteA LNTerm
-  -- locks
-  | LockUnnamed LNTerm LVar
+  | -- locks
+    LockUnnamed LNTerm LVar
   | LockNamed LNTerm LVar
   | UnlockUnnamed LNTerm LVar
   | UnlockNamed LNTerm LVar
-  -- in_event restriction
-  | ChannelIn LNTerm
+  | -- in_event restriction
+    ChannelIn LNTerm
   | EventEmpty
-  -- support for msrs
-  | TamarinAct LNFact
-  -- predicate support
-  | PredicateA LNFact
+  | -- support for msrs
+    TamarinAct LNFact
+  | -- predicate support
+    PredicateA LNFact
   | NegPredicateA LNFact
-  -- progress translation
-  | ProgressFrom ProcessPosition
+  | -- progress translation
+    ProgressFrom ProcessPosition
   | ProgressTo ProcessPosition ProcessPosition
-  -- reliable channels
-  | Send ProcessPosition LNTerm
+  | -- reliable channels
+    Send ProcessPosition LNTerm
   | Receive ProcessPosition LNTerm
-  -- to implement with accountability extension
-  --- | InitId
-  --- | StopId
-  --- | EventId
+
+-- to implement with accountability extension
+--- | InitId
+--- | StopId
+--- | EventId
 
 -- | Facts that are used as premises and conclusions.
 -- Most important one is the state, containing the variables currently
 -- bound. Persistant variant for replication, and linear for all other
 -- actions. Semistates are used in rules where a SAPIC step might take more
 -- than one MSR step, i.e., messages over private channels.
-data StateKind  = LState | PState | LSemiState | PSemiState
-  deriving Eq
-data TransFact =  Fr LVar | In LNTerm
-            | Out LNTerm
-            | FLet ProcessPosition LNTerm (S.Set LVar)
-            | Message LNTerm LNTerm
-            | Ack LNTerm LNTerm
-            | State StateKind ProcessPosition (S.Set LVar)
-            | MessageIDSender ProcessPosition
-            | MessageIDReceiver ProcessPosition
-            | TamarinFact LNFact
-            -- pure storage
-            | PureCell LNTerm LNTerm
-            | CellLocked LNTerm LNTerm
+data StateKind = LState | PState | LSemiState | PSemiState
+  deriving (Eq)
 
-data SpecialPosition = InitPosition -- initial position, is logically the predecessor of []
-                     | NoPosition -- no real position, e.g., message id rule
+data TransFact
+  = Fr LVar
+  | In LNTerm
+  | Out LNTerm
+  | FLet ProcessPosition LNTerm (S.Set LVar)
+  | Message LNTerm LNTerm
+  | Ack LNTerm LNTerm
+  | State StateKind ProcessPosition (S.Set LVar)
+  | MessageIDSender ProcessPosition
+  | MessageIDReceiver ProcessPosition
+  | TamarinFact LNFact
+  | -- pure storage
+    PureCell LNTerm LNTerm
+  | CellLocked LNTerm LNTerm
+
+data SpecialPosition
+  = InitPosition -- initial position, is logically the predecessor of []
+  | NoPosition -- no real position, e.g., message id rule
 
 -- | annotated rules know:
 data AnnotatedRule ann = AnnotatedRule
-  { processName :: Maybe String    -- optional name for rules that are not bound to a process, e.g., Init
-  , process     :: LProcess ann   -- process this rules was generated for
-  , position    :: Either ProcessPosition SpecialPosition -- position of this process in top-level process
-  , prems       :: [TransFact]     -- Facts/actions to be translated
-  , acts        :: [TransAction]
-  , concs       :: [TransFact]
-  , restr       :: [SyntacticLNFormula]
-  , index       :: Int             -- Index to distinguish multiple rules originating from the same process
+  { processName :: Maybe String, -- optional name for rules that are not bound to a process, e.g., Init
+    process :: LProcess ann, -- process this rules was generated for
+    position :: Either ProcessPosition SpecialPosition, -- position of this process in top-level process
+    prems :: [TransFact], -- Facts/actions to be translated
+    acts :: [TransAction],
+    concs :: [TransFact],
+    restr :: [SyntacticLNFormula],
+    index :: Int -- Index to distinguish multiple rules originating from the same process
   }
 
 -- | Fact types used by the MSR to ProverIf translation.
 data FactType = GET | IN | NEW | EVENT | INSERT | OUT
-  deriving Eq
+  deriving (Eq)
 
 -- | applies function acting on rule taple on annotated rule.
-mapAct :: (([TransFact], [TransAction], [TransFact],[SyntacticLNFormula])
-           -> ([TransFact], [TransAction], [TransFact],[SyntacticLNFormula]))
-          -> AnnotatedRule ann -> AnnotatedRule ann
-mapAct f anrule = let (l',a',r',res') = f (prems anrule, acts anrule,
-                                           concs anrule, restr anrule)
-                  in
-                  anrule { prems = l', acts = a', concs = r', restr = res' }
+mapAct ::
+  ( ([TransFact], [TransAction], [TransFact], [SyntacticLNFormula]) ->
+    ([TransFact], [TransAction], [TransFact], [SyntacticLNFormula])
+  ) ->
+  AnnotatedRule ann ->
+  AnnotatedRule ann
+mapAct f anrule =
+  let (l', a', r', res') =
+        f
+          ( prems anrule,
+            acts anrule,
+            concs anrule,
+            restr anrule
+          )
+   in anrule {prems = l', acts = a', concs = r', restr = res'}
 
 isSemiState :: StateKind -> Bool
 isSemiState LState = False
@@ -145,7 +160,7 @@ isState (State {}) = True
 isState _ = False
 
 addVarToState :: LVar -> TransFact -> TransFact
-addVarToState v' (State kind pos vs)  = State kind pos (v' `S.insert` vs)
+addVarToState v' (State kind pos vs) = State kind pos (v' `S.insert` vs)
 addVarToState _ x = x
 
 multiplicity :: StateKind -> Multiplicity
@@ -156,13 +171,14 @@ multiplicity PSemiState = Persistent
 
 -- | map f to the name of a fact
 mapFactName :: (String -> String) -> Fact t -> Fact t
-mapFactName f fact =  fact { factTag = f' (factTag fact) }
-    where f' (ProtoFact m s i) = ProtoFact m (f s) i
-          f' ft = ft
+mapFactName f fact = fact {factTag = f' (factTag fact)}
+  where
+    f' (ProtoFact m s i) = ProtoFact m (f s) i
+    f' ft = ft
 
 -- Optimisation: have a diffent fact name for every (unique) locking variable
 lockFactName :: LVar -> String
-lockFactName v = "Lock_"++ show (lvarIdx v)
+lockFactName v = "Lock_" ++ show (lvarIdx v)
 
 unlockFactName :: LVar -> String
 unlockFactName v = "Unlock_" ++ show (lvarIdx v)
@@ -175,43 +191,46 @@ varNameProgress p = "prog_" ++ prettyPosition p
 
 varProgress :: ProcessPosition -> LVar
 varProgress p = LVar n s i
-    where n = varNameProgress p
-          s = LSortFresh
-          i = 0
+  where
+    n = varNameProgress p
+    s = LSortFresh
+    i = 0
 
 msgVarProgress :: ProcessPosition -> LVar
 msgVarProgress p = LVar n s i
-    where n = varNameProgress p
-          s = LSortMsg
-          i = 0
+  where
+    n = varNameProgress p
+    s = LSortMsg
+    i = 0
 
 varMsgId :: ProcessPosition -> LVar
 varMsgId p = LVar n s i
-    where n = "mid_" ++ prettyPosition p
-          s = LSortFresh
-          i = 0
+  where
+    n = "mid_" ++ prettyPosition p
+    s = LSortFresh
+    i = 0
 
 actionToFact :: TransAction -> Fact LNTerm
 actionToFact InitEmpty = protoFact Linear "Init" []
-  --  | StopId
-  --  | EventEmpty
-  --  | EventId
+--  | StopId
+--  | EventEmpty
+--  | EventId
 actionToFact (Send p t) = protoFact Linear "Send" [varTerm $ varMsgId p, t]
-actionToFact (Receive p t) = protoFact Linear "Receive" [varTerm $ varMsgId p ,t]
-actionToFact (IsIn t v)   =  protoFact Linear "IsIn" [t,varTerm v]
-actionToFact (IsNotSet t )   =  protoFact Linear "IsNotSet" [t]
-actionToFact (InsertA t1 t2)   =  protoFact Linear "Insert" [t1,t2]
-actionToFact (DeleteA t )   =  protoFact Linear "Delete" [t]
-actionToFact (ChannelIn t)   =  protoFact Linear "ChannelIn" [t]
-actionToFact EventEmpty   =   protoFact Linear "Event" []
-actionToFact (PredicateA f)   =  mapFactName ("Pred_" ++) f
-actionToFact (NegPredicateA f)   =  mapFactName ("Pred_Not_" ++) f
-actionToFact (LockNamed t v)   = protoFact Linear (lockFactName v) [lockPubTerm v,varTerm v, t ]
-actionToFact (LockUnnamed t v)   = protoFact Linear "Lock" [lockPubTerm v, varTerm v, t ]
-actionToFact (UnlockNamed t v) = protoFact Linear (unlockFactName v) [lockPubTerm v,varTerm v,t]
-actionToFact (UnlockUnnamed t v) = protoFact Linear "Unlock" [lockPubTerm v,varTerm v,t]
-actionToFact (ProgressFrom p) = protoFact Linear ("ProgressFrom_"++prettyPosition p) [varTerm $ varProgress p]
-actionToFact (ProgressTo p pf) = protoFact Linear ("ProgressTo_"++prettyPosition p) [varTerm $ varProgress pf]
+actionToFact (Receive p t) = protoFact Linear "Receive" [varTerm $ varMsgId p, t]
+actionToFact (IsIn t v) = protoFact Linear "IsIn" [t, varTerm v]
+actionToFact (IsNotSet t) = protoFact Linear "IsNotSet" [t]
+actionToFact (InsertA t1 t2) = protoFact Linear "Insert" [t1, t2]
+actionToFact (DeleteA t) = protoFact Linear "Delete" [t]
+actionToFact (ChannelIn t) = protoFact Linear "ChannelIn" [t]
+actionToFact EventEmpty = protoFact Linear "Event" []
+actionToFact (PredicateA f) = mapFactName ("Pred_" ++) f
+actionToFact (NegPredicateA f) = mapFactName ("Pred_Not_" ++) f
+actionToFact (LockNamed t v) = protoFact Linear (lockFactName v) [lockPubTerm v, varTerm v, t]
+actionToFact (LockUnnamed t v) = protoFact Linear "Lock" [lockPubTerm v, varTerm v, t]
+actionToFact (UnlockNamed t v) = protoFact Linear (unlockFactName v) [lockPubTerm v, varTerm v, t]
+actionToFact (UnlockUnnamed t v) = protoFact Linear "Unlock" [lockPubTerm v, varTerm v, t]
+actionToFact (ProgressFrom p) = protoFact Linear ("ProgressFrom_" ++ prettyPosition p) [varTerm $ varProgress p]
+actionToFact (ProgressTo p pf) = protoFact Linear ("ProgressTo_" ++ prettyPosition p) [varTerm $ varProgress pf]
 actionToFact (TamarinAct f) = f
 
 toFreeMsgVariable :: LVar -> BVar LVar
@@ -224,59 +243,55 @@ actionToFactFormula = fmap (fmap $ fmap toFreeMsgVariable) . actionToFact
 -- | Term with variable for message id. Uniqueness ensured by process position.
 varMID :: ProcessPosition -> LVar
 varMID p = LVar n s i
-    where n = "mid_" ++ prettyPosition p
-          s = LSortFresh
-          i = 0 -- This is the message index.
-                -- We could also compute it from the position as before,
-                -- but I don't see an advantage (yet)
+  where
+    n = "mid_" ++ prettyPosition p
+    s = LSortFresh
+    i = 0 -- This is the message index.
+    -- We could also compute it from the position as before,
+    -- but I don't see an advantage (yet)
 
 factToFact :: TransFact -> Fact LNTerm
 factToFact (Fr v) = freshFact $ varTerm v
 factToFact (In t) = inFact t
 factToFact (Out t) = outFact t
-factToFact (FLet p t vars) = protoFact Linear ("Let"++ "_" ++ prettyPosition p) (t:ts)
-      where
-        ts = map varTerm (S.toList vars)
+factToFact (FLet p t vars) = protoFact Linear ("Let" ++ "_" ++ prettyPosition p) (t : ts)
+  where
+    ts = map varTerm (S.toList vars)
 factToFact (Message t t') = protoFact Linear "Message" [t, t']
 factToFact (Ack t t') = protoFact Linear "Ack" [t, t']
-factToFact (MessageIDSender p) = protoFact Linear "MID_Sender" [ varTerm $ varMID p ]
-factToFact (MessageIDReceiver p) = protoFact Linear "MID_Receiver" [ varTerm$ varMID p ]
+factToFact (MessageIDSender p) = protoFact Linear "MID_Sender" [varTerm $ varMID p]
+factToFact (MessageIDReceiver p) = protoFact Linear "MID_Receiver" [varTerm $ varMID p]
 factToFact (State kind p vars) = protoFact (multiplicity kind) (name kind ++ "_" ++ prettyPosition p) ts
-    where
-        name k = if isSemiState k then "Semistate" else "State"
-        ts = map varTerm (S.toList vars)
+  where
+    name k = if isSemiState k then "Semistate" else "State"
+    ts = map varTerm (S.toList vars)
 factToFact (TamarinFact f) = f
 factToFact (PureCell t1 t2) = protoFact Linear "L_PureState" [t1, t2]
 factToFact (CellLocked t1 t2) = protoFact Linear "L_CellLocked" [t1, t2]
 
-
 pureStateFactTag :: FactTag
-pureStateFactTag =  ProtoFact Linear "L_PureState" 2
+pureStateFactTag = ProtoFact Linear "L_PureState" 2
 
 pureStateLockFactTag :: FactTag
-pureStateLockFactTag =  ProtoFact Linear "L_CellLocked" 2
-
+pureStateLockFactTag = ProtoFact Linear "L_CellLocked" 2
 
 isOutFact :: Fact t -> Bool
 isOutFact (Fact OutFact _ _) = True
-isOutFact _                 = False
+isOutFact _ = False
 
 isFrFact :: Fact t -> Bool
 isFrFact (Fact FreshFact _ _) = True
-isFrFact _                 = False
-
+isFrFact _ = False
 
 isLetFact :: Fact LNTerm -> Bool
 isLetFact (Fact (ProtoFact _ name _) _ _) =
   "Let" `List.isPrefixOf` name
 isLetFact _ = False
 
-
 isStateFact :: Fact LNTerm -> Bool
 isStateFact (Fact (ProtoFact _ name _) _ _) =
   "State" `List.isPrefixOf` name
-  ||
-  "Semistate" `List.isPrefixOf` name
+    || "Semistate" `List.isPrefixOf` name
 isStateFact _ = False
 
 isLockFact :: Fact LNTerm -> Bool
@@ -292,13 +307,13 @@ nonPatternInsFilter f = isInFact f && not (hasPattern f)
 
 isPattern :: Term l -> Bool
 isPattern t = case viewTerm t of
-    Lit _ -> False
-    _     -> True
+  Lit _ -> False
+  _ -> True
 
 hasPattern :: LNFact -> Bool
 hasPattern (Fact _ _ ts) = any isPattern ts
 
-prettyEitherPositionOrSpecial:: Either ProcessPosition SpecialPosition -> String
+prettyEitherPositionOrSpecial :: Either ProcessPosition SpecialPosition -> String
 prettyEitherPositionOrSpecial (Left pos) = prettyPosition pos
 prettyEitherPositionOrSpecial (Right InitPosition) = "Init"
 prettyEitherPositionOrSpecial (Right NoPosition) = ""
@@ -308,36 +323,40 @@ getTopLevelName (ProcessNull ann) = getProcessNames ann
 getTopLevelName (ProcessComb _ ann _ _) = getProcessNames ann
 getTopLevelName (ProcessAction _ ann _) = getProcessNames ann
 
-propagateNames :: (GoodAnnotation an) => Process an v-> Process an v
+propagateNames :: (GoodAnnotation an) => Process an v -> Process an v
 propagateNames = propagate' []
-    where
-      propagate' n (ProcessComb c an pl pr) = ProcessComb c
-                                                (setProcessNames (n ++ getProcessNames an) an)
-                                                (propagate' (n ++ getProcessNames an) pl)
-                                                (propagate' (n ++ getProcessNames an) pr)
-      propagate' n (ProcessAction a an p) = ProcessAction a
-                                                (setProcessNames (n ++ getProcessNames an) an)
-                                                (propagate' (n ++ getProcessNames an) p)
-      propagate' n (ProcessNull an) = ProcessNull (setProcessNames (n ++ getProcessNames an) an)
+  where
+    propagate' n (ProcessComb c an pl pr) =
+      ProcessComb
+        c
+        (setProcessNames (n ++ getProcessNames an) an)
+        (propagate' (n ++ getProcessNames an) pl)
+        (propagate' (n ++ getProcessNames an) pr)
+    propagate' n (ProcessAction a an p) =
+      ProcessAction
+        a
+        (setProcessNames (n ++ getProcessNames an) an)
+        (propagate' (n ++ getProcessNames an) p)
+    propagate' n (ProcessNull an) = ProcessNull (setProcessNames (n ++ getProcessNames an) an)
 
 crc32 :: String -> Int
 crc32 s = foldl iter 0xffffffff (map ord s)
-    where
-        inner c = (c `shiftR` 1) `xor` (0xedb88329 .&. (-(c .&. 1)))
-        iter c m = iterate inner (c `xor` m) !! 8
+  where
+    inner c = (c `shiftR` 1) `xor` (0xedb88329 .&. (-(c .&. 1)))
+    iter c m = iterate inner (c `xor` m) !! 8
 
 interpolate :: (Fractional t, Ord t) => HSV t -> HSV t -> t -> HSV t
 interpolate (HSV h1 s1 v1) (HSV h2 s2 v2) a = HSV h' s' v'
-      where
-        h' = (h2 - h1) * a + h1
-        s' = (s2 - s1) * a + s1
-        v' = (v2 - v1) * a + v1
+  where
+    h' = (h2 - h1) * a + h1
+    s' = (s2 - s1) * a + s1
+    v' = (v2 - v1) * a + v1
 
 colorHash :: (Fractional t, Ord t) => String -> RGB t
 colorHash s = RGB r g b
-      where
-        nthByte x n = (x `shiftR` (8*n)) .&. 0xff
-        (r,g,b) = fmap ((/255) . fromIntegral . nthByte (crc32 s)) (0,1,2)
+  where
+    nthByte x n = (x `shiftR` (8 * n)) .&. 0xff
+    (r, g, b) = fmap ((/ 255) . fromIntegral . nthByte (crc32 s)) (0, 1, 2)
 
 -- Computes a color for a list of strings by first computing
 -- the CRC32 checksum of each string and then interpolating the
@@ -347,31 +366,35 @@ colorHash s = RGB r g b
 -- and luminance of the final color is normalized to to 0.5.
 colorForProcessName :: [String] -> RGB Rational
 colorForProcessName [] = RGB 255 255 255
-colorForProcessName names = hsvToRGB $ normalize $ fst $ foldl f (head palette, 0::Int) (tail palette)
-      where
-        palette = map (rgbToHSV . colorHash) names
-        normalize (HSV h _ _) = HSV h 0.5 0.5
-        f (acc, i) v = (interpolate acc v (2^^(-i)), i+1)
+colorForProcessName names = hsvToRGB $ normalize $ fst $ foldl f (head palette, 0 :: Int) (tail palette)
+  where
+    palette = map (rgbToHSV . colorHash) names
+    normalize (HSV h _ _) = HSV h 0.5 0.5
+    f (acc, i) v = (interpolate acc v (2 ^^ (-i)), i + 1)
 
-toRule :: GoodAnnotation ann => AnnotatedRule ann -> Rule ProtoRuleEInfo
-toRule AnnotatedRule{..} = -- this is a Record Wildcard
-          Rule (ProtoRuleEInfo (StandRule name) attr restr) l r a (newVariables l r)
-          where
-            name = case processName of
-                Just s -> s
-                Nothing ->
-                         unNull (stripNonAlphanumerical (prettySapicTopLevel process))
-                         ++ "_" ++ show index ++ "_"
-                         ++ prettyEitherPositionOrSpecial position
-            attr = [ RuleColor $ colorForProcessName $ getTopLevelName process
-                   , Process $ toProcess process
-                   , IsSAPiCRule
-                   ] 
-                   ++ if isLookup process then [ IgnoreDerivChecks] else [] 
-            l = map factToFact prems
-            a = map actionToFact acts
-            r = map factToFact concs
-            stripNonAlphanumerical = filter isAlpha
-            unNull s = if null s then "p" else s
-            isLookup (ProcessComb (Lookup _ _) _ _ _)= True 
-            isLookup _ = False 
+toRule :: (GoodAnnotation ann) => AnnotatedRule ann -> Rule ProtoRuleEInfo
+toRule AnnotatedRule {..} =
+  -- this is a Record Wildcard
+  Rule (ProtoRuleEInfo (StandRule name) attr restr) l r a (newVariables l r)
+  where
+    name = case processName of
+      Just s -> s
+      Nothing ->
+        unNull (stripNonAlphanumerical (prettySapicTopLevel process))
+          ++ "_"
+          ++ show index
+          ++ "_"
+          ++ prettyEitherPositionOrSpecial position
+    attr =
+      [ RuleColor $ colorForProcessName $ getTopLevelName process,
+        Process $ toProcess process,
+        IsSAPiCRule
+      ]
+        ++ ([IgnoreDerivChecks | isLookup process])
+    l = map factToFact prems
+    a = map actionToFact acts
+    r = map factToFact concs
+    stripNonAlphanumerical = filter isAlpha
+    unNull s = if null s then "p" else s
+    isLookup (ProcessComb (Lookup _ _) _ _ _) = True
+    isLookup _ = False

--- a/lib/theory/src/OpenTheory.hs
+++ b/lib/theory/src/OpenTheory.hs
@@ -32,29 +32,23 @@ import Theory.Text.Pretty
 import Control.Parallel.Strategies
 
 
--- remove Sapic items and convert other items to identical item but with unit type for sapic elements
+-- | map TranslationItems to () and keep other items as is
+removeTranslationElement :: TheoryItem r p TranslationElement -> TheoryItem r p ()
+removeTranslationElement (TranslationItem _) = TranslationItem ()
+removeTranslationElement (RuleItem r) = RuleItem r
+removeTranslationElement (LemmaItem l) = LemmaItem l
+removeTranslationElement (RestrictionItem rl) = RestrictionItem rl
+removeTranslationElement (TextItem t) = TextItem t
+removeTranslationElement (ConfigBlockItem b) = ConfigBlockItem b
+removeTranslationElement (PredicateItem predi) = PredicateItem predi
+removeTranslationElement (MacroItem macro) = MacroItem macro
+
+-- | remove TranslationItems from Theory and convert other items to identical item but with unit type for sapic elements
 removeTranslationItems :: OpenTheory -> OpenTranslatedTheory
 removeTranslationItems thy =
-  Theory {_thyName=(L.get thyName thy)
-          ,_thyInFile=(L.get thyInFile thy)
-          ,_thyHeuristic=(L.get thyHeuristic thy)
-          ,_thyTactic=(L.get thyTactic thy)
-          ,_thySignature=(L.get thySignature thy)
-          ,_thyCache=(L.get thyCache thy)
-          ,_thyItems = newThyItems
-          ,_thyOptions =(L.get thyOptions thy)
-          ,_thyIsSapic = (L.get thyIsSapic thy)}
-    where
-      newThyItems = map removeTranslationElement (L.get thyItems thy)
-      removeTranslationElement :: TheoryItem r p TranslationElement -> TheoryItem r p ()
-      removeTranslationElement (TranslationItem _) = TranslationItem ()
-      removeTranslationElement (RuleItem r) = RuleItem r
-      removeTranslationElement (LemmaItem l) = LemmaItem l
-      removeTranslationElement (RestrictionItem rl) = RestrictionItem rl
-      removeTranslationElement (TextItem t) = TextItem t
-      removeTranslationElement (ConfigBlockItem b) = ConfigBlockItem b
-      removeTranslationElement (PredicateItem predi) = PredicateItem predi
-      removeTranslationElement (MacroItem macro) = MacroItem macro
+  thy {_thyItems = newThyItems}
+  where
+    newThyItems = map removeTranslationElement (L.get thyItems thy)
 
 --open translated theory again
 openTranslatedTheory :: OpenTranslatedTheory -> OpenTheory

--- a/lib/theory/src/Theory/Module.hs
+++ b/lib/theory/src/Theory/Module.hs
@@ -1,39 +1,41 @@
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DeriveDataTypeable        #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-module Theory.Module (
-      ModuleType (..)
-    , description
-)
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Theory.Module
+  ( ModuleType (..),
+    description,
+  )
 where
 
+import Control.DeepSeq (NFData)
+import Data.Binary (Binary)
+import Data.Data (Data)
 import GHC.Generics (Generic)
-import Control.DeepSeq ( NFData )
-import Data.Binary ( Binary )
-import Data.Data ( Data )
 
-data ModuleType =
-   -- Too generate a parser from the show() values, these need to be ordered
-   -- such that no preceding show value is a prefix of another one that comes
-  ModuleSpthyTyped
+data ModuleType
+  = -- Too generate a parser from the show() values, these need to be ordered
+    -- such that no preceding show value is a prefix of another one that comes
+    ModuleSpthyTyped
   | ModuleSpthy
   | ModuleMsr
   | ModuleProVerifEquivalence
   | ModuleProVerif
   | ModuleDeepSec
   deriving (Eq, Ord, Enum, Bounded, Generic, Data, NFData, Binary)
+
 instance Show ModuleType where
-    show ModuleSpthyTyped ="spthytyped"
-    show ModuleSpthy = "spthy"
-    show ModuleMsr ="msr"
-    show ModuleProVerifEquivalence ="proverifequiv"
-    show ModuleProVerif ="proverif"
-    show ModuleDeepSec ="deepsec"
+  show ModuleSpthyTyped = "spthytyped"
+  show ModuleSpthy = "spthy"
+  show ModuleMsr = "msr"
+  show ModuleProVerifEquivalence = "proverifequiv"
+  show ModuleProVerif = "proverif"
+  show ModuleDeepSec = "deepsec"
 
 description :: ModuleType -> String
 description ModuleSpthy = "spthy (including Sapic Processes)"
-description ModuleSpthyTyped ="spthy with explicit types inferred"
-description ModuleMsr ="pure msrs (with Sapic translation)"
-description ModuleProVerifEquivalence ="ProVerif export for the equivalence lemmas"
-description ModuleProVerif ="ProVerif export for the reachability lemmas"
-description ModuleDeepSec ="DeepSec export for the equivalences lemmas"
+description ModuleSpthyTyped = "spthy with explicit types inferred"
+description ModuleMsr = "pure msrs (with Sapic translation)"
+description ModuleProVerifEquivalence = "ProVerif export for the equivalence lemmas"
+description ModuleProVerif = "ProVerif export for the reachability lemmas"
+description ModuleDeepSec = "DeepSec export for the equivalences lemmas"

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -8,76 +8,71 @@
 --
 -- Theory loading infrastructure.
 module Main.TheoryLoader
-  -- * Static theory loading settings
-  ( theoryLoadFlags
-  , lemmaSelector
+  ( -- * Static theory loading settings
+    theoryLoadFlags,
+    lemmaSelector,
+    TheoryLoadOptions (..),
+    defaultTheoryLoadOptions,
+    ArgumentError (..),
+    mkTheoryLoadOptions,
+    TheoryLoadError (..),
+    loadTheory,
+    translateAndCheckTheory,
+    prettyOpenTheoryByModule,
+    closeTheory,
 
-  , TheoryLoadOptions(..)
-  , defaultTheoryLoadOptions
-  , ArgumentError(..)
-  , mkTheoryLoadOptions
+    -- ** Constructing automatic prover
+    constructAutoProver,
 
-  , TheoryLoadError(..)
-  , loadTheory
-  , translateAndCheckTheory
-  , prettyOpenTheoryByModule
-  , closeTheory
+    -- ** Cached Message Deduction Rule Variants
+    dhIntruderVariantsFile,
+    bpIntruderVariantsFile,
+    addMessageDeductionRuleVariants,
+  )
+where
 
-  -- ** Constructing automatic prover
-  , constructAutoProver
-
-  -- ** Cached Message Deduction Rule Variants
-  , dhIntruderVariantsFile
-  , bpIntruderVariantsFile
-  , addMessageDeductionRuleVariants
-
-  ) where
-
-import Data.Bifunctor (Bifunctor(bimap), first)
-import Data.Bitraversable (Bitraversable(bitraverse))
-import Data.Char (toLower)
-import Data.FileEmbed (embedFile)
-import Data.List (isPrefixOf, intercalate, find)
-import Data.Map (keys)
-import Data.Maybe (fromMaybe, isNothing)
-import Data.Set qualified
-import Debug.Trace
-
+import Accountability qualified as Acc
+import Accountability.Generation qualified as Acc
 import Control.DeepSeq (force)
 import Control.Exception (evaluate)
 import Control.Monad
 import Control.Monad.Catch (MonadCatch)
 import Control.Monad.Except
-import Control.Monad.IO.Class (MonadIO(liftIO))
-
-import Safe
-import System.Console.CmdArgs.Explicit
-import System.Timeout (timeout)
-
-import Text.Parsec (ParseError)
-import Text.Read (readEither)
-
-import Accountability qualified as Acc
-import Accountability.Generation qualified as Acc
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Bifunctor (Bifunctor (bimap), first)
+import Data.Bitraversable (Bitraversable (bitraverse))
+import Data.Char (toLower)
+import Data.FileEmbed (embedFile)
+import Data.List (find, intercalate, isPrefixOf)
+import Data.Map (keys)
+import Data.Maybe (fromMaybe, isNothing)
+import Data.Set qualified
+import Debug.Trace
 import Export qualified
-import Items.LemmaItem (HasLemmaName, HasLemmaAttributes)
+import Items.LemmaItem (HasLemmaAttributes, HasLemmaName)
 import Items.OptionItem (Option (..))
 import Main.Console
+import Safe
 import Sapic qualified
-
-import Theory hiding (transReport, closeTheory)
+import System.Console.CmdArgs.Explicit
+import System.Timeout (timeout)
+import Text.Parsec (ParseError)
+import Text.Read (readEither)
+import Theory hiding (closeTheory, transReport)
 import Theory.Module
-import Theory.Text.Parser (parseIntruderRules, theory, diffTheory)
+import Theory.Text.Parser (diffTheory, parseIntruderRules, theory)
 import Theory.Text.Parser.Token
 import Theory.Text.Pretty qualified as Pretty
-import Theory.Tools.AbstractInterpretation (EvaluationStyle(..))
+import Theory.Tools.AbstractInterpretation (EvaluationStyle (..))
 import Theory.Tools.IntruderRules
-  ( specialIntruderRules, subtermIntruderRules
-  , multisetIntruderRules, xorIntruderRules
-  , natIntruderRules )
+  ( multisetIntruderRules,
+    natIntruderRules,
+    specialIntruderRules,
+    subtermIntruderRules,
+    xorIntruderRules,
+  )
 import Theory.Tools.MessageDerivationChecks
 import Theory.Tools.Wellformedness
-
 import TheoryObject (diffTheoryConfigBlock, theoryConfigBlock)
 
 ------------------------------------------------------------------------------
@@ -91,59 +86,108 @@ import TheoryObject (diffTheoryConfigBlock, theoryConfigBlock)
 -- | Flags for loading a theory.
 theoryLoadFlags :: [Flag Arguments]
 theoryLoadFlags =
-  [ flagOpt "" ["prove"] (updateArg "prove") "LEMMAPREFIX*|LEMMANAME"
-      "Attempt to prove all lemmas that start with LEMMAPREFIX or the lemma which name is LEMMANAME (can be repeated)."
-
-  , flagOpt "" ["lemma"] (updateArg "lemma") "LEMMAPREFIX*|LEMMANAME"
-      "Select lemma(s) by name or prefx (can be repeated)"
-
-  , flagOpt "dfs" ["stop-on-trace"] (updateArg "stop-on-trace") "DFS|BFS|SEQDFS|NONE"
-      "How to search for traces (default DFS)"
-
-  , flagOpt "5" ["bound", "b"] (updateArg "bound") "INT"
-      "Bound the depth of the proofs"
-
-  ,  flagOpt (prettyGoalRanking $ head $ defaultRankings False)
-      ["heuristic"] (updateArg "heuristic") ("(" ++ intercalate "|" (keys goalRankingIdentifiers) ++ ")+")
-      ("Sequence of proof method rankings to use (default '" ++ prettyGoalRanking (head $ defaultRankings False) ++ "')")
-
-  , flagOpt "summary" ["partial-evaluation"] (updateArg "partial-evaluation")
+  [ flagOpt
+      ""
+      ["prove"]
+      (updateArg "prove")
+      "LEMMAPREFIX*|LEMMANAME"
+      "Attempt to prove all lemmas that start with LEMMAPREFIX or the lemma which name is LEMMANAME (can be repeated).",
+    flagOpt
+      ""
+      ["lemma"]
+      (updateArg "lemma")
+      "LEMMAPREFIX*|LEMMANAME"
+      "Select lemma(s) by name or prefx (can be repeated)",
+    flagOpt
+      "dfs"
+      ["stop-on-trace"]
+      (updateArg "stop-on-trace")
+      "DFS|BFS|SEQDFS|NONE"
+      "How to search for traces (default DFS)",
+    flagOpt
+      "5"
+      ["bound", "b"]
+      (updateArg "bound")
+      "INT"
+      "Bound the depth of the proofs",
+    flagOpt
+      (prettyGoalRanking $ head $ defaultRankings False)
+      ["heuristic"]
+      (updateArg "heuristic")
+      ("(" ++ intercalate "|" (keys goalRankingIdentifiers) ++ ")+")
+      ("Sequence of proof method rankings to use (default '" ++ prettyGoalRanking (head $ defaultRankings False) ++ "')"),
+    flagOpt
+      "summary"
+      ["partial-evaluation"]
+      (updateArg "partial-evaluation")
       "SUMMARY|VERBOSE"
-      "Partially evaluate multiset rewriting system"
-
-  , flagOpt "" ["defines","D"] (updateArg "defines") "STRING"
-      "Define flags for pseudo-preprocessor."
-
-  , flagNone ["diff"] (addEmptyArg "diff")
-      "Turn on observational equivalence mode using diff terms."
-
-  , flagNone ["quit-on-warning"] (addEmptyArg "quit-on-warning")
-      "Strict mode that quits on any warning that is emitted."
-
-  , flagNone ["auto-sources"] (addEmptyArg "auto-sources")
-      "Try to auto-generate sources lemmas"
-
-  , flagOpt "" ["oraclename"] (updateArg "oraclename") "FILE"
-      ("Path to the oracle heuristic (default '" ++ "./theory_filename.oracle" ++ "', fallback '" ++ "./oracle" ++ "')")
-
-  , flagNone ["quiet"] (addEmptyArg "quiet")
-      "Do not display computation steps of oracle or tactic."
-
-  , flagNone ["verbose", "v"] (addEmptyArg "verbose")
-      "Display full information when calculating proof."
-
-  , flagOpt "10" ["open-chains","c"] (updateArg "OpenChainsLimit" ) "PositiveInteger"
-      "Limits the number of open chains to be resoled during precomputations (default 10)"
-
-  , flagOpt "5" ["saturation","s"] (updateArg "SaturationLimit" ) "PositiveInteger"
-      "Limits the number of saturations during precomputations (default 5)"
-
-  , flagOpt "5" ["derivcheck-timeout","d"] (updateArg "derivcheck-timeout" ) "INT"
-      "Set timeout for message derivation checks in sec (default 5). 0 deactivates check."
-
-
---  , flagOpt "" ["diff"] (updateArg "diff") "OFF|ON"
---      "Turn on observational equivalence (default OFF)."
+      "Partially evaluate multiset rewriting system",
+    flagOpt
+      ""
+      ["defines", "D"]
+      (updateArg "defines")
+      "STRING"
+      "Define flags for pseudo-preprocessor.",
+    flagNone
+      ["diff"]
+      (addEmptyArg "diff")
+      "Turn on observational equivalence mode using diff terms.",
+    flagNone
+      ["quit-on-warning"]
+      (addEmptyArg "quit-on-warning")
+      "Strict mode that quits on any warning that is emitted.",
+    flagNone
+      ["auto-sources"]
+      (addEmptyArg "auto-sources")
+      "Try to auto-generate sources lemmas",
+    flagOpt
+      ""
+      ["oraclename"]
+      (updateArg "oraclename")
+      "FILE"
+      ("Path to the oracle heuristic (default '" ++ "./theory_filename.oracle" ++ "', fallback '" ++ "./oracle" ++ "')"),
+    flagNone
+      ["quiet"]
+      (addEmptyArg "quiet")
+      "Do not display computation steps of oracle or tactic.",
+    flagNone
+      ["verbose", "v"]
+      (addEmptyArg "verbose")
+      "Display full information when calculating proof.",
+    flagOpt
+      "10"
+      ["open-chains", "c"]
+      (updateArg "OpenChainsLimit")
+      "PositiveInteger"
+      "Limits the number of open chains to be resoled during precomputations (default 10)",
+    flagOpt
+      "5"
+      ["saturation", "s"]
+      (updateArg "SaturationLimit")
+      "PositiveInteger"
+      "Limits the number of saturations during precomputations (default 5)",
+    flagOpt
+      "5"
+      ["derivcheck-timeout", "d"]
+      (updateArg "derivcheck-timeout")
+      "INT"
+      "Set timeout for message derivation checks in sec (default 5). 0 deactivates check.",
+      --  , flagOpt "" ["diff"] (updateArg "diff") "OFF|ON"
+      --      "Turn on observational equivalence (default OFF).",
+    flagNone
+      ["no-reuse"]
+      (addEmptyArg "no-reuse")
+      "Do not export reuse or source lemmas",
+    flagNone
+      ["no-restrictions"]
+      (addEmptyArg "no-restrictions")
+      "Do not export restrictions",
+    flagOpt
+      "3"
+      ["replication-bound"]
+      (updateArg "replication-bound")
+      "INT"
+      "Replication bound for DeepSec export"
   ]
 
 -----------------------------------------------
@@ -151,57 +195,67 @@ theoryLoadFlags =
 -----------------------------------------------
 
 data TheoryLoadOptions = TheoryLoadOptions
-  { proveMode         :: Bool
-  , lemmaNames        :: [String]
-  , stopOnTrace       :: Maybe SolutionExtractor
-  , proofBound        :: Maybe Int
-  , heuristic         :: Maybe (Heuristic ProofContext)
-  , partialEvaluation :: Maybe EvaluationStyle
-  , defines           :: [String]
-  , diffMode          :: Bool
-  , quitOnWarning     :: Bool
-  , autoSources       :: Bool
-  , verboseMode       :: Bool
-  , outputModule      :: Maybe ModuleType -- Note: This flag is only used for batch mode.
-  , maudePath         :: FilePath -- FIXME: Other functions defined in Environment.hs
-  , parseOnlyMode     :: Bool
-  , precomputeOnlyMode:: Bool
-  , openChain         :: Integer
-  , saturation        :: Integer
-  , derivationChecks  :: Int
-  } deriving Show
+  { proveMode :: Bool,
+    lemmaNames :: [String],
+    stopOnTrace :: Maybe SolutionExtractor,
+    proofBound :: Maybe Int,
+    heuristic :: Maybe (Heuristic ProofContext),
+    partialEvaluation :: Maybe EvaluationStyle,
+    defines :: [String],
+    diffMode :: Bool,
+    quitOnWarning :: Bool,
+    autoSources :: Bool,
+    verboseMode :: Bool,
+    outputModule :: Maybe ModuleType, -- Note: This flag is only used for batch mode.
+    maudePath :: FilePath, -- FIXME: Other functions defined in Environment.hs
+    parseOnlyMode :: Bool,
+    precomputeOnlyMode :: Bool,
+    openChain :: Integer,
+    saturation :: Integer,
+    derivationChecks :: Int,
+    noReuse :: Bool,
+    noRestrictions :: Bool,
+    replicationBound :: Int
+  }
+  deriving (Show)
 
 defaultTheoryLoadOptions :: TheoryLoadOptions
-defaultTheoryLoadOptions = TheoryLoadOptions
-  { proveMode         = False
-  , lemmaNames        = []
-  , stopOnTrace       = Nothing
-  , proofBound        = Nothing
-  , heuristic         = Nothing
-  , partialEvaluation = Nothing
-  , defines           = []
-  , diffMode          = False
-  , quitOnWarning     = False
-  , autoSources       = False
-  , verboseMode       = False
-  , outputModule      = Nothing
-  , maudePath         = "maude"
-  , parseOnlyMode     = False
-  , precomputeOnlyMode= False
-  , openChain         = 10
-  , saturation        = 5
-  , derivationChecks  = 5
-  }
+defaultTheoryLoadOptions =
+  TheoryLoadOptions
+    { proveMode = False,
+      lemmaNames = [],
+      stopOnTrace = Nothing,
+      proofBound = Nothing,
+      heuristic = Nothing,
+      partialEvaluation = Nothing,
+      defines = [],
+      diffMode = False,
+      quitOnWarning = False,
+      autoSources = False,
+      verboseMode = False,
+      outputModule = Nothing,
+      maudePath = "maude",
+      parseOnlyMode = False,
+      precomputeOnlyMode = False,
+      openChain = 10,
+      saturation = 5,
+      derivationChecks = 5,
+      noReuse = False,
+      noRestrictions = False,
+      replicationBound = 3
+    }
 
 toParserFlags :: TheoryLoadOptions -> [String]
-toParserFlags thyOpts = concat
-  [ [ "diff" |  thyOpts.diffMode ]
-  , thyOpts.defines
-  , [ "quit-on-warning" | thyOpts.quitOnWarning ] ]
+toParserFlags thyOpts =
+  concat
+    [ ["diff" | thyOpts.diffMode],
+      thyOpts.defines,
+      ["quit-on-warning" | thyOpts.quitOnWarning]
+    ]
 
 newtype ArgumentError = ArgumentError String
 
-mkTheoryLoadOptions :: MonadError ArgumentError m => Arguments -> m TheoryLoadOptions
+mkTheoryLoadOptions :: (MonadError ArgumentError m) => Arguments -> m TheoryLoadOptions
 mkTheoryLoadOptions as =
   TheoryLoadOptions
     <$> proveMode
@@ -222,49 +276,57 @@ mkTheoryLoadOptions as =
     <*> openchain
     <*> saturation
     <*> deriv
+    <*> noReuse
+    <*> noRestrictions
+    <*> replicationBound
   where
-    proveMode  = pure $ argExists "prove" as
+    proveMode = pure $ argExists "prove" as
     lemmaNames = pure $ findArg "prove" as ++ findArg "lemma" as
 
     parseIntArg args defaultValue conv errMsg = case args of
-      []    -> pure defaultValue
-      (x:_) -> case (readEither x :: Either String Int) of
-        Left  _ -> throwError $ ArgumentError errMsg
+      [] -> pure defaultValue
+      (x : _) -> case (readEither x :: Either String Int) of
+        Left _ -> throwError $ ArgumentError errMsg
         Right i -> pure $ conv i
-      -- FIXME : provide option to handle potential error without crash (ie, take default value and raise error but continue)
+    -- FIXME : provide option to handle potential error without crash (ie, take default value and raise error but continue)
 
     proofBound = parseIntArg (findArg "bound" as) Nothing Just "bound: invalid bound given"
 
     heuristic = case findArg "heuristic" as of
-      Just rawRankings@(_:_) -> pure $ Just $
-        roundRobinHeuristic $
-          map (mapOracleRanking (maybeSetOracleRelPath oraclename))
-              (filterHeuristic (argExists "diff" as) rawRankings)
+      Just rawRankings@(_ : _) ->
+        pure $
+          Just $
+            roundRobinHeuristic $
+              map
+                (mapOracleRanking (maybeSetOracleRelPath oraclename))
+                (filterHeuristic (argExists "diff" as) rawRankings)
       Just [] -> throwError $ ArgumentError "heuristic: at least one ranking must be given"
       _ -> pure Nothing
     oraclename = case findArg "oraclename" as of
       Just "" -> Nothing
-      name    -> name
-    --toGoalRanking | argExists "diff" as = stringToGoalRankingDiff
+      name -> name
+    -- toGoalRanking | argExists "diff" as = stringToGoalRankingDiff
     --              | otherwise           = stringToGoalRanking
 
     partialEvaluation = case map toLower <$> findArg "partial-evaluation" as of
       Just "summary" -> pure $ Just Summary
       Just "verbose" -> pure $ Just Tracing
-      Just _         -> throwError $ ArgumentError "partial-evaluation: unknown option"
-      Nothing        -> pure Nothing
+      Just _ -> throwError $ ArgumentError "partial-evaluation: unknown option"
+      Nothing -> pure Nothing
 
-    defines       = pure $ findArg "defines" as
-    diffMode      = pure $ argExists "diff" as
-    verboseMode   = pure $ argExists "verbose" as
+    defines = pure $ findArg "defines" as
+    diffMode = pure $ argExists "diff" as
+    verboseMode = pure $ argExists "verbose" as
     quitOnWarning = pure $ argExists "quit-on-warning" as
-    autoSources   = pure $ argExists "auto-sources" as
+    autoSources = pure $ argExists "auto-sources" as
+    noReuse = pure $ argExists "no-reuse" as
+    noRestrictions = pure $ argExists "no-restrictions" as
 
     outputModule = case findArg "outModule" as of
-      Just str -> case find ((str ==) . show) [minBound..] of
+      Just str -> case find ((str ==) . show) [minBound ..] of
         Just m -> pure $ Just m
-        _      -> throwError $ ArgumentError "output mode not supported."
-      Nothing  -> pure defaultTheoryLoadOptions.outputModule
+        _ -> throwError $ ArgumentError "output mode not supported."
+      Nothing -> pure defaultTheoryLoadOptions.outputModule
 
     parseOnlyMode = pure $ argExists "parseOnly" as
 
@@ -282,32 +344,34 @@ mkTheoryLoadOptions as =
     derivDefault = defaultTheoryLoadOptions.derivationChecks
     deriv = parseIntArg derivchecks derivDefault id "derivcheck-timeout: invalid bound given"
 
-stopOnTrace :: MonadError ArgumentError m => Arguments -> m (Maybe SolutionExtractor)
-stopOnTrace as = case map toLower <$> findArg "stop-on-trace" as of
-  Just "dfs"    -> pure $ Just CutDFS
-  Just "none"   -> pure $ Just CutNothing
-  Just "bfs"    -> pure $ Just CutBFS
-  Just "seqdfs" -> pure $ Just CutSingleThreadDFS
-  Just unknown  -> throwError $ ArgumentError ("unknown stop-on-trace method: " ++ unknown)
-  Nothing       -> pure Nothing
+    replicationBound = parseIntArg (findArg "replication-bound" as) defaultTheoryLoadOptions.replicationBound id "replication-bound: invalid bound given"
 
-lemmaSelectorByModule :: HasLemmaAttributes l => TheoryLoadOptions -> l -> Bool
+stopOnTrace :: (MonadError ArgumentError m) => Arguments -> m (Maybe SolutionExtractor)
+stopOnTrace as = case map toLower <$> findArg "stop-on-trace" as of
+  Just "dfs" -> pure $ Just CutDFS
+  Just "none" -> pure $ Just CutNothing
+  Just "bfs" -> pure $ Just CutBFS
+  Just "seqdfs" -> pure $ Just CutSingleThreadDFS
+  Just unknown -> throwError $ ArgumentError ("unknown stop-on-trace method: " ++ unknown)
+  Nothing -> pure Nothing
+
+lemmaSelectorByModule :: (HasLemmaAttributes l) => TheoryLoadOptions -> l -> Bool
 lemmaSelectorByModule thyOpt lem = case lemmaModules of
   [] -> True -- default to true if no modules (or only empty ones) are set
-  _  -> maybe True (`elem` lemmaModules) thyOpt.outputModule
+  _ -> maybe True (`elem` lemmaModules) thyOpt.outputModule
   where
-    lemmaModules = concat [ m | LemmaModule m <- lem.lAttributes ]
+    lemmaModules = concat [m | LemmaModule m <- lem.lAttributes]
 
 -- | quiet flag in the argument
---quiet :: Arguments -> [String]
---quiet as = if (argExists "quiet" as) then ["quiet"] else []
+-- quiet :: Arguments -> [String]
+-- quiet as = if (argExists "quiet" as) then ["quiet"] else []
 
 -- | Select lemmas for proving
-lemmaSelector :: HasLemmaName l => TheoryLoadOptions -> l -> Bool
+lemmaSelector :: (HasLemmaName l) => TheoryLoadOptions -> l -> Bool
 lemmaSelector thyOpts lem
   | null lemmaNames = True
   | lemmaNames == [""] = True
-  | lemmaNames == ["",""] = True
+  | lemmaNames == ["", ""] = True
   | otherwise = any lemmaMatches lemmaNames
   where
     lemmaNames :: [String]
@@ -327,19 +391,20 @@ instance Show TheoryLoadError where
   show (WarningError e) = Pretty.render (prettyWfErrorReport e)
 
 -- | Load an open theory from a string with the given options.
-loadTheory
-  :: Monad m
-  => TheoryLoadOptions
-  -> String
-  -> FilePath
-  -> ExceptT TheoryLoadError m (Either OpenTheory OpenDiffTheory)
+loadTheory ::
+  (Monad m) =>
+  TheoryLoadOptions ->
+  String ->
+  FilePath ->
+  ExceptT TheoryLoadError m (Either OpenTheory OpenDiffTheory)
 loadTheory thyOpts input inFile = do
   thy <- withExceptT ParserError $ liftEither $ unwrapError $ bimap parse parse thyParser
   traceM ("[Theory " ++ theoryName thy ++ "] Theory loaded")
   pure $ addParamsOptions thyOpts thy
   where
-    thyParser | isDiffMode = Right $ diffTheory $ Just inFile
-              | otherwise  = Left  $ theory     $ Just inFile
+    thyParser
+      | isDiffMode = Right $ diffTheory $ Just inFile
+      | otherwise = Left $ theory $ Just inFile
 
     parse p = parseString (toParserFlags thyOpts) inFile p input
 
@@ -351,30 +416,33 @@ loadTheory thyOpts input inFile = do
     unwrapError (Right (Right v)) = Right $ Right v
     theoryName = either (._thyName) (._diffThyName)
 
--- | Process an open theory based on the specified output module.
-processOpenTheory :: MonadCatch m => TheoryLoadOptions -> OpenTheory -> m OpenTheory
-processOpenTheory thyOpts = case modType of
-  Nothing                        -> Sapic.typeTheory >=> Sapic.translate >=> Acc.translate
-  Just ModuleSpthy               -> pure
-  Just ModuleSpthyTyped          -> Sapic.typeTheory
+-- | Preprocess an open theory based on the specified output module so that
+-- well-formedness can be checked (but do not translate yet)
+processOpenTheory :: (MonadCatch m) => TheoryLoadOptions -> OpenTheory -> m OpenTheory
+processOpenTheory thyOpts = case thyOpts.outputModule of
+  Nothing -> Sapic.typeTheory >=> Sapic.translate >=> Acc.translate
+  Just ModuleSpthy -> pure
+  Just ModuleSpthyTyped -> Sapic.typeTheory
   -- If the output module is set to MSR, we only keep the specified lemmas in the theory.
-  Just ModuleMsr                 -> Sapic.typeTheory
-                                    >=> Sapic.translate
-                                    >=> Acc.translate
-                                    >=> (pure . filterLemma lemmas)
+  Just ModuleMsr ->
+    Sapic.typeTheory
+      >=> Sapic.translate
+      >=> Acc.translate
+      >=> (pure . filterLemma lemmas)
   Just ModuleProVerifEquivalence -> Sapic.typeTheory -- Type theory here to catch errors.
-  Just ModuleProVerif            -> Sapic.typeTheory -- Type theory here to catch errors.
-  Just ModuleDeepSec             -> Sapic.typeTheory
+  Just ModuleProVerif -> Sapic.typeTheory -- Type theory here to catch errors.
+  Just ModuleDeepSec -> Sapic.typeTheory
   where
-    modType = thyOpts.outputModule
     lemmas = lemmaSelector thyOpts
 
--- | Translate an open theory.
-translateTheory
-  :: (MonadCatch m, MonadError TheoryLoadError m)
-  => TheoryLoadOptions
-  -> Either OpenTheory OpenDiffTheory
-  -> m (WfErrorReport, Either OpenTheory OpenDiffTheory)
+-- | Translate an open theory: `translateTheory opts thy` with options `opts`
+-- and Open(Diff)Theory `thy` translates it according to the output module and
+-- performs a well-formedness check.
+translateTheory ::
+  (MonadCatch m, MonadError TheoryLoadError m) =>
+  TheoryLoadOptions ->
+  Either OpenTheory OpenDiffTheory ->
+  m (WfErrorReport, Either OpenTheory OpenDiffTheory)
 translateTheory thyOpts thy = do
   traceM ("[Theory " ++ theoryName thy ++ "] Theory translated")
   let report = either (\t -> Sapic.checkWellformedness t ++ Acc.checkWellformedness t) (const []) thy
@@ -385,75 +453,98 @@ translateTheory thyOpts thy = do
     theoryName = either (._thyName) (._diffThyName)
 
 -- | Perform wellformedness and deducability checks on a theory.
-checkTranslatedTheory
-  :: (MonadIO m, MonadError TheoryLoadError m)
-  => TheoryLoadOptions
-  -> SignatureWithMaude
-  -> Either OpenTranslatedTheory OpenDiffTheory
-  -> m (WfErrorReport, Either OpenTranslatedTheory OpenDiffTheory)
+checkTranslatedTheory ::
+  (MonadIO m, MonadError TheoryLoadError m) =>
+  TheoryLoadOptions ->
+  SignatureWithMaude ->
+  Either OpenTranslatedTheory OpenDiffTheory ->
+  m (WfErrorReport, Either OpenTranslatedTheory OpenDiffTheory)
 checkTranslatedTheory thyOpts sign thy = do
-  let transReport = either (`checkWellformedness` sign)
-                           (`checkWellformednessDiff` sign) thy
+  let transReport =
+        either
+          (\thy -> checkWellformedness incompleteMSRs thy sign)
+          (`checkWellformednessDiff` sign)
+          thy
 
-  let deducThy = bimap addMessageDeductionRuleVariants
-                       addMessageDeductionRuleVariantsDiff
-                       thy
+  let deducThy =
+        bimap
+          addMessageDeductionRuleVariants
+          addMessageDeductionRuleVariantsDiff
+          thy
 
   variableReport <- case compare derivChecks 0 of
     EQ -> pure $ Just []
     _ -> do
       traceM ("[Theory " ++ theoryName thy ++ "] Derivation checks started")
-      derivCheckSignature <- liftIO $
-        toSignatureWithMaude thyOpts.maudePath $ maudePublicSig (toSignaturePure sign)
-      rep <- liftIO $ timeout (1000000 * derivChecks) $ evaluate . force $ either
-        (\t -> checkVariableDeducability t derivCheckSignature autoSources defaultProver)
-        (\t -> diffCheckVariableDeducability t derivCheckSignature autoSources defaultProver defaultDiffProver) deducThy
+      derivCheckSignature <-
+        liftIO $
+          toSignatureWithMaude thyOpts.maudePath $
+            maudePublicSig (toSignaturePure sign)
+      rep <-
+        liftIO $
+          timeout (1000000 * derivChecks) $
+            evaluate . force $
+              either
+                (\t -> checkVariableDeducability t derivCheckSignature autoSources defaultProver)
+                (\t -> diffCheckVariableDeducability t derivCheckSignature autoSources defaultProver defaultDiffProver)
+                deducThy
       traceM ("[Theory " ++ theoryName thy ++ "] Derivation checks ended")
       pure rep
 
-  let report = transReport ++ fromMaybe derivTimeoutMsg  variableReport
+  let report = transReport ++ fromMaybe derivTimeoutMsg variableReport
 
   pure (report, deducThy)
   where
+    incompleteMSRs = False -- TODO how do we know if we do not have all MSRs due to translation?
     autoSources = thyOpts.autoSources
     derivChecks = thyOpts.derivationChecks
-    derivTimeoutMsg = [(underlineTopic "Derivation Checks"
-                      , Pretty.vcat [
-                          Pretty.text "Derivation checks timed out."
-                        , Pretty.text "Use --derivcheck-timeout=INT to configure timeout."
-                        , Pretty.text "Set to 0 to deactivate for no timeout." ])]
+    derivTimeoutMsg =
+      [ ( underlineTopic "Derivation Checks",
+          Pretty.vcat
+            [ Pretty.text "Derivation checks timed out.",
+              Pretty.text "Use --derivcheck-timeout=INT to configure timeout.",
+              Pretty.text "Set to 0 to deactivate for no timeout."
+            ]
+        )
+      ]
 
     defaultProver = replaceSorryProver $ runAutoProver $ constructAutoProver defaultTheoryLoadOptions
     defaultDiffProver = replaceDiffSorryProver $ runAutoDiffProver $ constructAutoProver defaultTheoryLoadOptions
-    maudePublicSig s = Signature $ s._sigMaudeInfo
-      { stFunSyms = makepublic (stFunSyms s._sigMaudeInfo)
-      , funSyms = makepublicsym (funSyms s._sigMaudeInfo)
-      , irreducibleFunSyms = makepublicsym (irreducibleFunSyms s._sigMaudeInfo)
-      , reducibleFunSyms = makepublicsym (reducibleFunSyms s._sigMaudeInfo)
-      }
-    makepublic = Data.Set.map (\(name, (int, _, construct)) -> (name,(int, Public, construct)))
-    makepublicsym  = Data.Set.map $ \case
-      NoEq (name, (int, _, constr)) -> NoEq (name,(int, Public, constr))
+    maudePublicSig s =
+      Signature $
+        s._sigMaudeInfo
+          { stFunSyms = makepublic (stFunSyms s._sigMaudeInfo),
+            funSyms = makepublicsym (funSyms s._sigMaudeInfo),
+            irreducibleFunSyms = makepublicsym (irreducibleFunSyms s._sigMaudeInfo),
+            reducibleFunSyms = makepublicsym (reducibleFunSyms s._sigMaudeInfo)
+          }
+    makepublic = Data.Set.map (\(name, (int, _, construct)) -> (name, (int, Public, construct)))
+    makepublicsym = Data.Set.map $ \case
+      NoEq (name, (int, _, constr)) -> NoEq (name, (int, Public, constr))
       x -> x
 
     theoryName = either (._thyName) (._diffThyName)
 
 -- | Add report and version information to a theory.
-withVersionAndReport
-  :: MonadError TheoryLoadError m
-  => String
-  -> TheoryLoadOptions
-  -> WfErrorReport
-  -> Either (Theory sig1 c1 r1 p1 s) (DiffTheory sig2 c2 r2 r3 p2 p3)
-  -> m (Either (Theory sig1 c1 r1 p1 s) (DiffTheory sig2 c2 r2 r3 p2 p3))
+withVersionAndReport ::
+  (MonadError TheoryLoadError m) =>
+  String ->
+  TheoryLoadOptions ->
+  WfErrorReport ->
+  Either (Theory sig1 c1 r1 p1 s) (DiffTheory sig2 c2 r2 r3 p2 p3) ->
+  m (Either (Theory sig1 c1 r1 p1 s) (DiffTheory sig2 c2 r2 r3 p2 p3))
 withVersionAndReport version thyOpts report thy = do
-  let reportThy = bimap (addComment     (reportToDoc report))
-                        (addDiffComment (reportToDoc report))
-                        thy
+  let reportThy =
+        bimap
+          (addComment (reportToDoc report))
+          (addDiffComment (reportToDoc report))
+          thy
 
-  let versionThy = bimap (addComment (Pretty.text version))
-                         (addDiffComment (Pretty.text version))
-                         reportThy
+  let versionThy =
+        bimap
+          (addComment (Pretty.text version))
+          (addDiffComment (Pretty.text version))
+          reportThy
 
   when (thyOpts.quitOnWarning && not (null report)) (throwError $ WarningError report)
 
@@ -461,28 +552,34 @@ withVersionAndReport version thyOpts report thy = do
   where
     reportToDoc rep
       | null rep = Pretty.text "All wellformedness checks were successful."
-      | otherwise = Pretty.vsep
-                      [ Pretty.text "WARNING: the following wellformedness checks failed!"
-                      , prettyWfErrorReport rep ]
+      | otherwise =
+          Pretty.vsep
+            [ Pretty.text "WARNING: the following wellformedness checks failed!",
+              prettyWfErrorReport rep
+            ]
 
 -- | Close a translated theory.
-closeTranslatedTheory :: MonadError TheoryLoadError m => TheoryLoadOptions -> SignatureWithMaude -> Either OpenTranslatedTheory OpenDiffTheory -> m (Either ClosedTheory ClosedDiffTheory)
+closeTranslatedTheory :: (MonadError TheoryLoadError m) => TheoryLoadOptions -> SignatureWithMaude -> Either OpenTranslatedTheory OpenDiffTheory -> m (Either ClosedTheory ClosedDiffTheory)
 closeTranslatedTheory thyOpts sign srcThy = do
   diffLemThy <- withDiffTheory (pure . addDefaultDiffLemma) srcThy
-  let
-    closedThy = bimap (\t -> closeTheoryWithMaude     sign t autoSources True)
-                      (\t -> closeDiffTheoryWithMaude sign t autoSources)
-                      diffLemThy
-    partialThy =
-      case thyOpts.partialEvaluation of
-        Just style ->
-          bimap (applyPartialEvaluation style autoSources)
-                (applyPartialEvaluationDiff style autoSources)
-                closedThy
-        Nothing -> closedThy
-    provedThy = bimap (proveTheory     selector prover)
-                      (proveDiffTheory selector prover diffProver)
-                      partialThy
+  let closedThy =
+        bimap
+          (\t -> closeTheoryWithMaude sign t autoSources True)
+          (\t -> closeDiffTheoryWithMaude sign t autoSources)
+          diffLemThy
+      partialThy =
+        case thyOpts.partialEvaluation of
+          Just style ->
+            bimap
+              (applyPartialEvaluation style autoSources)
+              (applyPartialEvaluationDiff style autoSources)
+              closedThy
+          Nothing -> closedThy
+      provedThy =
+        bimap
+          (proveTheory selector prover)
+          (proveDiffTheory selector prover diffProver)
+          partialThy
 
   traceM ("[Theory " ++ theoryName srcThy ++ "] Theory closed")
 
@@ -493,36 +590,38 @@ closeTranslatedTheory thyOpts sign srcThy = do
     selector :: (HasLemmaName l, HasLemmaAttributes l) => l -> Bool
     selector l = lemmaSelectorByModule thyOpts l && lemmaSelector thyOpts l
 
-    prover | thyOpts.proveMode = replaceSorryProver $ runAutoProver $ constructAutoProver thyOpts
-           | otherwise         = mempty
+    prover
+      | thyOpts.proveMode = replaceSorryProver $ runAutoProver $ constructAutoProver thyOpts
+      | otherwise = mempty
 
-    diffProver | thyOpts.proveMode = replaceDiffSorryProver $ runAutoDiffProver $ constructAutoProver thyOpts
-               | otherwise         = mempty
+    diffProver
+      | thyOpts.proveMode = replaceDiffSorryProver $ runAutoDiffProver $ constructAutoProver thyOpts
+      | otherwise = mempty
 
     withDiffTheory = bitraverse pure
 
     theoryName = either (._thyName) (._diffThyName)
 
 -- | Translate an open theory, perform checks on the translated theory and finally close it.
-closeTheory
-  :: (MonadCatch m, MonadIO m, MonadError TheoryLoadError m)
-  => String
-  -> TheoryLoadOptions
-  -> SignatureWithMaude
-  -> Either OpenTheory OpenDiffTheory
-  -> m (WfErrorReport, Either ClosedTheory ClosedDiffTheory)
+closeTheory ::
+  (MonadCatch m, MonadIO m, MonadError TheoryLoadError m) =>
+  String ->
+  TheoryLoadOptions ->
+  SignatureWithMaude ->
+  Either OpenTheory OpenDiffTheory ->
+  m (WfErrorReport, Either ClosedTheory ClosedDiffTheory)
 closeTheory version loadedThyOpts sign srcThy = do
-  (preReport, transThy)    <- translateTheory thyOpts srcThy
-  let removedThy           = first removeTranslationItems transThy
+  (preReport, transThy) <- translateTheory thyOpts srcThy
+  let removedThy = first removeTranslationItems transThy
   (postReport, checkedThy) <- checkTranslatedTheory thyOpts sign removedThy
-  closedThy                <- closeTranslatedTheory thyOpts sign checkedThy
-  finalThy                 <- withVersionAndReport version thyOpts (preReport ++ postReport) closedThy
+  closedThy <- closeTranslatedTheory thyOpts sign checkedThy
+  finalThy <- withVersionAndReport version thyOpts (preReport ++ postReport) closedThy
 
   pure (preReport ++ postReport, finalThy)
   where
     loadedAutoSources = loadedThyOpts.autoSources
     loadedStopOnTrace = loadedThyOpts.stopOnTrace
-    loadedHeuristic   = loadedThyOpts.heuristic
+    loadedHeuristic = loadedThyOpts.heuristic
 
     srcThyInFileName = either (._thyInFile) (._diffThyInFile) srcThy
 
@@ -532,7 +631,7 @@ closeTheory version loadedThyOpts sign srcThy = do
 
     -- Set the oraclename to theory_filename.oracle (if none was supplied).
     thyHeurDefOracle opts =
-      opts { heuristic = (\(Heuristic grl) -> Just $ Heuristic $ defaultOracleNames srcThyInFileName grl) =<< loadedHeuristic }
+      opts {heuristic = (\(Heuristic grl) -> Just $ Heuristic $ defaultOracleNames srcThyInFileName grl) =<< loadedHeuristic}
 
     -- Read and process the arguments from the theory's config block.
     srcThyConfigBlockArgs = argsConfigString $ either theoryConfigBlock diffTheoryConfigBlock srcThy
@@ -541,87 +640,90 @@ closeTheory version loadedThyOpts sign srcThy = do
       processValue (mode "configuration block arguments" [] "" (flagArg (updateArg "") "") theoryConfFlags) <$> splitArgs
 
     theoryConfFlags =
-      [ flagOpt "dfs" ["stop-on-trace"] (updateArg "stop-on-trace") "" ""
-      , flagNone ["auto-sources"] (addEmptyArg "auto-sources") ""
+      [ flagOpt "dfs" ["stop-on-trace"] (updateArg "stop-on-trace") "" "",
+        flagNone ["auto-sources"] (addEmptyArg "auto-sources") ""
       ]
 
     configStopOnTrace opts =
       if isNothing loadedStopOnTrace
-        then opts { stopOnTrace = either (\(ArgumentError e) -> error e) id $ stopOnTrace srcThyConfigBlockArgs }
+        then opts {stopOnTrace = either (\(ArgumentError e) -> error e) id $ stopOnTrace srcThyConfigBlockArgs}
         else opts
 
     configAutoSources opts =
-      opts { autoSources = argExists "auto-sources" srcThyConfigBlockArgs || loadedAutoSources }
+      opts {autoSources = argExists "auto-sources" srcThyConfigBlockArgs || loadedAutoSources}
 
 -- | Translate an open theory and perform checks on the translated theory.
-translateAndCheckTheory
-  :: (MonadCatch m, MonadIO m, MonadError TheoryLoadError m)
-  => String
-  -> TheoryLoadOptions
-  -> SignatureWithMaude
-  -> Either OpenTheory OpenDiffTheory
-  -> m (WfErrorReport, Either OpenTheory OpenDiffTheory)
+translateAndCheckTheory ::
+  (MonadCatch m, MonadIO m, MonadError TheoryLoadError m) =>
+  String ->
+  TheoryLoadOptions ->
+  SignatureWithMaude ->
+  Either OpenTheory OpenDiffTheory ->
+  m (WfErrorReport, Either OpenTheory OpenDiffTheory)
 translateAndCheckTheory version thyOpts sign srcThy = do
   (preReport, transThy) <- translateTheory thyOpts srcThy
-  let removedThy        = first removeTranslationItems transThy
-  (postReport, _)       <- checkTranslatedTheory thyOpts sign removedThy
-  finalThy              <- withVersionAndReport version thyOpts (preReport ++ postReport) transThy
+  let removedThy = first removeTranslationItems transThy
+  (postReport, _) <- checkTranslatedTheory thyOpts sign removedThy
+  finalThy <- withVersionAndReport version thyOpts (preReport ++ postReport) transThy
   pure (preReport ++ postReport, finalThy)
 
 -- | Pretty print an open theory based on the specified output module.
 prettyOpenTheoryByModule :: TheoryLoadOptions -> OpenTheory -> IO Pretty.Doc
-prettyOpenTheoryByModule thyOpts = case modType of
+prettyOpenTheoryByModule thyOpts = case  thyOpts.outputModule of
   Nothing {- Same as ModuleMsr -} -> pure . prettyOpenTranslatedTheory . removeTranslationItems
-  Just ModuleSpthy                -> pure . prettyOpenTheory
-  Just ModuleSpthyTyped           -> pure . prettyOpenTheory
-  Just ModuleMsr                  -> pure . prettyOpenTranslatedTheory . removeTranslationItems
-  Just ModuleProVerifEquivalence  -> Export.prettyProVerifEquivTheory   <=< Sapic.typeTheoryEnv
-  Just ModuleProVerif             -> Export.prettyProVerifTheory lemmas <=< Sapic.typeTheoryEnv
-  Just ModuleDeepSec              -> Export.prettyDeepSecTheory
+  Just ModuleSpthy -> pure . prettyOpenTheory
+  Just ModuleSpthyTyped -> pure . prettyOpenTheory
+  Just ModuleMsr -> pure . prettyOpenTranslatedTheory . removeTranslationItems
+  Just ModuleProVerifEquivalence -> Export.prettyProVerifEquivTheory <=< Sapic.typeTheoryEnv
+  Just ModuleProVerif -> Export.prettyProVerifTheory ModuleProVerif noReuse noRestrictions lemmas <=< Sapic.typeTheoryEnv
+  Just ModuleDeepSec -> Export.prettyDeepSecTheory replicationBound
   where
-    modType = thyOpts.outputModule
     lemmas = lemmaSelector thyOpts
+    noReuse = thyOpts.noReuse
+    noRestrictions = thyOpts.noRestrictions
+    replicationBound = thyOpts.replicationBound
 
 -- | Construct an 'AutoProver' from the given arguments (--bound, --stop-on-trace).
 constructAutoProver :: TheoryLoadOptions -> AutoProver
 constructAutoProver thyOpts =
-  AutoProver thyOpts.heuristic
-             Nothing
-             thyOpts.proofBound
-             (fromMaybe CutDFS thyOpts.stopOnTrace)
-             False
+  AutoProver
+    thyOpts.heuristic
+    Nothing
+    thyOpts.proofBound
+    (fromMaybe CutDFS thyOpts.stopOnTrace)
+    False
 
 -----------------------------------------------
 -- Add Options parameters in an OpenTheory
 -----------------------------------------------
 
 -- | Add parameters in the OpenTheory, here openchain and saturation in the options
-addParamsOptions
-  :: TheoryLoadOptions
-  -> Either OpenTheory OpenDiffTheory
-  -> Either OpenTheory OpenDiffTheory
+addParamsOptions ::
+  TheoryLoadOptions ->
+  Either OpenTheory OpenDiffTheory ->
+  Either OpenTheory OpenDiffTheory
 addParamsOptions opt = addVerboseOptions . addPrecomputationOnlyOptions . addSatArg . addChainsArg . addLemmaToProve
   where
     -- Add Open Chain Limit parameters in the Options
     _openChainsLimit = opt.openChain
-    addChainsArg (Left thy) = Left thy { _thyOptions = thy._thyOptions { _openChainsLimit }}
-    addChainsArg (Right diffThy) = Right diffThy { _diffThyOptions = diffThy._diffThyOptions { _openChainsLimit }}
+    addChainsArg (Left thy) = Left thy {_thyOptions = thy._thyOptions {_openChainsLimit}}
+    addChainsArg (Right diffThy) = Right diffThy {_diffThyOptions = diffThy._diffThyOptions {_openChainsLimit}}
     -- Add Saturation Limit parameters in the Options
     _saturationLimit = opt.saturation
-    addSatArg (Left thy) = Left thy { _thyOptions = thy._thyOptions { _saturationLimit }}
-    addSatArg (Right diffThy) = Right diffThy { _diffThyOptions = diffThy._diffThyOptions { _saturationLimit }}
+    addSatArg (Left thy) = Left thy {_thyOptions = thy._thyOptions {_saturationLimit}}
+    addSatArg (Right diffThy) = Right diffThy {_diffThyOptions = diffThy._diffThyOptions {_saturationLimit}}
     -- Add lemmas to Prove in the Options
     _lemmasToProve = opt.lemmaNames
-    addLemmaToProve (Left thy) = Left thy { _thyOptions = thy._thyOptions { _lemmasToProve }}
-    addLemmaToProve (Right diffThy) = Right diffThy { _diffThyOptions = diffThy._diffThyOptions { _lemmasToProve }}
+    addLemmaToProve (Left thy) = Left thy {_thyOptions = thy._thyOptions {_lemmasToProve}}
+    addLemmaToProve (Right diffThy) = Right diffThy {_diffThyOptions = diffThy._diffThyOptions {_lemmasToProve}}
     -- Add Verbose parameter in the Options
     _verboseOption = opt.verboseMode
-    addVerboseOptions (Left thy) = Left thy { _thyOptions = thy._thyOptions { _verboseOption }}
-    addVerboseOptions (Right diffThy) = Right diffThy { _diffThyOptions = diffThy._diffThyOptions { _verboseOption }}
+    addVerboseOptions (Left thy) = Left thy {_thyOptions = thy._thyOptions {_verboseOption}}
+    addVerboseOptions (Right diffThy) = Right diffThy {_diffThyOptions = diffThy._diffThyOptions {_verboseOption}}
     -- Add PrecomputationOnly parameter in the Options
     _precomputationOnlyOption = opt.precomputeOnlyMode
-    addPrecomputationOnlyOptions (Left thy) = Left thy { _thyOptions = thy._thyOptions { _precomputationOnlyOption }}
-    addPrecomputationOnlyOptions (Right diffThy) = Right diffThy { _diffThyOptions = diffThy._diffThyOptions { _precomputationOnlyOption }}
+    addPrecomputationOnlyOptions (Left thy) = Left thy {_thyOptions = thy._thyOptions {_precomputationOnlyOption}}
+    addPrecomputationOnlyOptions (Right diffThy) = Right diffThy {_diffThyOptions = diffThy._diffThyOptions {_precomputationOnlyOption}}
 
 ------------------------------------------------------------------------------
 -- Message deduction variants cached in files
@@ -639,14 +741,18 @@ bpIntruderVariantsFile = "data/intruder_variants_bp.spthy"
 mkDhIntruderVariants :: MaudeSig -> [IntrRuleAC]
 mkDhIntruderVariants msig =
   either (error . show) id $ -- report errors lazily through 'error'
-    parseIntruderRules msig dhIntruderVariantsFile
+    parseIntruderRules
+      msig
+      dhIntruderVariantsFile
       $(embedFile "data/intruder_variants_dh.spthy")
 
 -- | Construct the BP intruder variants for the given maude signature.
 mkBpIntruderVariants :: MaudeSig -> [IntrRuleAC]
 mkBpIntruderVariants msig =
   either (error . show) id $ -- report errors lazily through 'error'
-    parseIntruderRules msig bpIntruderVariantsFile
+    parseIntruderRules
+      msig
+      bpIntruderVariantsFile
       $(embedFile "data/intruder_variants_bp.spthy")
 
 -- | Add the variants of the message deduction rule. Uses built-in cached
@@ -654,17 +760,22 @@ mkBpIntruderVariants msig =
 -- exponentiation and Bilinear-Pairing.
 addMessageDeductionRuleVariants :: OpenTranslatedTheory -> OpenTranslatedTheory
 addMessageDeductionRuleVariants thy0
-  | enableBP msig = addIntruderVariants [ mkDhIntruderVariants
-                                        , mkBpIntruderVariants ]
-  | enableDH msig = addIntruderVariants [ mkDhIntruderVariants ]
-  | otherwise     = thy
+  | enableBP msig =
+      addIntruderVariants
+        [ mkDhIntruderVariants,
+          mkBpIntruderVariants
+        ]
+  | enableDH msig = addIntruderVariants [mkDhIntruderVariants]
+  | otherwise = thy
   where
-    msig  = thy0._thySignature._sigMaudeInfo
-    rules = subtermIntruderRules False msig ++ specialIntruderRules False
-              ++ (if enableNat msig then natIntruderRules else [])
-              ++ (if enableMSet msig then multisetIntruderRules else [])
-              ++ (if enableXor msig then xorIntruderRules else [])
-    thy   = addIntrRuleACsAfterTranslate rules thy0
+    msig = thy0._thySignature._sigMaudeInfo
+    rules =
+      subtermIntruderRules False msig
+        ++ specialIntruderRules False
+        ++ (if enableNat msig then natIntruderRules else [])
+        ++ (if enableMSet msig then multisetIntruderRules else [])
+        ++ (if enableXor msig then xorIntruderRules else [])
+    thy = addIntrRuleACsAfterTranslate rules thy0
     addIntruderVariants mkRuless = addIntrRuleACsAfterTranslate (concatMap ($ msig) mkRuless) thy
 
 -- | Add the variants of the message deduction rule. Uses the cached version
@@ -672,18 +783,24 @@ addMessageDeductionRuleVariants thy0
 -- deduction rules for Diffie-Hellman exponentiation.
 addMessageDeductionRuleVariantsDiff :: OpenDiffTheory -> OpenDiffTheory
 addMessageDeductionRuleVariantsDiff thy0
-  | enableBP msig = addIntruderVariantsDiff [ mkDhIntruderVariants
-                                            , mkBpIntruderVariants ]
-  | enableDH msig = addIntruderVariantsDiff [ mkDhIntruderVariants ]
-  | otherwise     = addIntrRuleLabels thy
+  | enableBP msig =
+      addIntruderVariantsDiff
+        [ mkDhIntruderVariants,
+          mkBpIntruderVariants
+        ]
+  | enableDH msig = addIntruderVariantsDiff [mkDhIntruderVariants]
+  | otherwise = addIntrRuleLabels thy
   where
-    msig        = thy0._diffThySignature._sigMaudeInfo
-    rules diff' = subtermIntruderRules diff' msig ++ specialIntruderRules diff'
-                   ++ (if enableNat msig then natIntruderRules else [])
-                   ++ (if enableMSet msig then multisetIntruderRules else [])
-                   ++ (if enableXor msig then xorIntruderRules else [])
-    thy         = addIntrRuleACsDiffBoth (rules False) $ addIntrRuleACsDiffBothDiff (rules True) thy0
-    addIntruderVariantsDiff mkRuless = addIntrRuleLabels $
-      addIntrRuleACsDiffBothDiff
-        (concatMap ($ msig) mkRuless)
-        (addIntrRuleACsDiffBoth (concatMap ($ msig) mkRuless) thy)
+    msig = thy0._diffThySignature._sigMaudeInfo
+    rules diff' =
+      subtermIntruderRules diff' msig
+        ++ specialIntruderRules diff'
+        ++ (if enableNat msig then natIntruderRules else [])
+        ++ (if enableMSet msig then multisetIntruderRules else [])
+        ++ (if enableXor msig then xorIntruderRules else [])
+    thy = addIntrRuleACsDiffBoth (rules False) $ addIntrRuleACsDiffBothDiff (rules True) thy0
+    addIntruderVariantsDiff mkRuless =
+      addIntrRuleLabels $
+        addIntrRuleACsDiffBothDiff
+          (concatMap ($ msig) mkRuless)
+          (addIntrRuleACsDiffBoth (concatMap ($ msig) mkRuless) thy)


### PR DESCRIPTION
This PR enhances the ProVerif export module with support for:
 - exporting restrictions
 - exporting reuse and source lemmas
 - exporting builtins
 - improved formula rewriting

Lemmas can now be negated or split to comply with ProVerif's logical fragment.

New command-line options added:
 - `--no-reuse`: disables export of reuse and source lemmas
 - `--no-restrictions`: disables export of restrictions
 - `--replication-bound=[INT]`: sets a bound for the DeepSec export

Additionally, the export module now supports the `--output/--Output` options to write results to a file or directory.

Fixes #709