### PR TITLE
Print typed function symbols in Maude Signature (again).

### DIFF
--- a/lib/theory/src/OpenTheory.hs
+++ b/lib/theory/src/OpenTheory.hs
@@ -1,36 +1,36 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ViewPatterns #-}
 
+module OpenTheory
+  ( module OpenTheory,
+    module Theory.ProofSkeleton,
+    module Rule,
+    module Items.OpenTheoryItem,
+  )
+where
 
-module OpenTheory (
-    module OpenTheory
-    , module Theory.ProofSkeleton
-    , module Rule
-    , module Items.OpenTheoryItem
-    ) where
 import Control.Basics
 import Control.Category
 import Control.Monad.Reader
+import Control.Parallel.Strategies
 import Data.Either
 import Data.List
 import Data.Maybe
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Extension.Data.Label hiding (get)
-import qualified Extension.Data.Label as L
+import Extension.Data.Label qualified as L
 import Items.OpenTheoryItem
-import Theory.ProofSkeleton
+import Pretty
 import Rule
 import Safe
 import Term.Positions
 import Theory.Model
 import Theory.Proof
+import Theory.ProofSkeleton
+import Theory.Text.Pretty
 import TheoryObject
 import Utils.Misc
 import Prelude hiding (id, (.))
-
-import Pretty
-import Theory.Text.Pretty
-import Control.Parallel.Strategies
-
 
 -- | map TranslationItems to () and keep other items as is
 removeTranslationElement :: TheoryItem r p TranslationElement -> TheoryItem r p ()
@@ -50,98 +50,108 @@ removeTranslationItems thy =
   where
     newThyItems = map removeTranslationElement (L.get thyItems thy)
 
---open translated theory again
+-- open translated theory again
 openTranslatedTheory :: OpenTranslatedTheory -> OpenTheory
 openTranslatedTheory thy =
-  Theory {_thyName=(L.get thyName thy)
-          ,_thyInFile=(L.get thyInFile thy)
-          ,_thyHeuristic=(L.get thyHeuristic thy)
-          ,_thyTactic=(L.get thyTactic thy)
-          ,_thySignature=(L.get thySignature thy)
-          ,_thyCache=(L.get thyCache thy)
-          ,_thyItems = newThyItems
-          ,_thyOptions =(L.get thyOptions thy)
-          ,_thyIsSapic =(L.get thyIsSapic thy)}
-    where
-      newThyItems = mapMaybe addTranslationElement (L.get thyItems thy)
-      addTranslationElement :: TheoryItem r p () -> Maybe (TheoryItem r p s)
-      addTranslationElement (RuleItem r) = Just $ RuleItem r
-      addTranslationElement (LemmaItem l) = Just $ LemmaItem l
-      addTranslationElement (RestrictionItem rl) = Just $ RestrictionItem rl
-      addTranslationElement (TextItem t) = Just $ TextItem t
-      addTranslationElement (ConfigBlockItem b) = Just $ ConfigBlockItem b
-      addTranslationElement (PredicateItem predi) = Just $ PredicateItem predi
-      addTranslationElement (MacroItem macro) = Just $ MacroItem macro
-      addTranslationElement (TranslationItem _) = Nothing
+  Theory
+    { _thyName = (L.get thyName thy),
+      _thyInFile = (L.get thyInFile thy),
+      _thyHeuristic = (L.get thyHeuristic thy),
+      _thyTactic = (L.get thyTactic thy),
+      _thySignature = (L.get thySignature thy),
+      _thyCache = (L.get thyCache thy),
+      _thyItems = newThyItems,
+      _thyOptions = (L.get thyOptions thy),
+      _thyIsSapic = (L.get thyIsSapic thy)
+    }
+  where
+    newThyItems = mapMaybe addTranslationElement (L.get thyItems thy)
+    addTranslationElement :: TheoryItem r p () -> Maybe (TheoryItem r p s)
+    addTranslationElement (RuleItem r) = Just $ RuleItem r
+    addTranslationElement (LemmaItem l) = Just $ LemmaItem l
+    addTranslationElement (RestrictionItem rl) = Just $ RestrictionItem rl
+    addTranslationElement (TextItem t) = Just $ TextItem t
+    addTranslationElement (ConfigBlockItem b) = Just $ ConfigBlockItem b
+    addTranslationElement (PredicateItem predi) = Just $ PredicateItem predi
+    addTranslationElement (MacroItem macro) = Just $ MacroItem macro
+    addTranslationElement (TranslationItem _) = Nothing
 
 -- | Add an auto-generated sources lemma if possible
-addAutoSourcesLemmaDiff :: MaudeHandle
-                        -> String
-                        -> ClosedRuleCache
-                        -> ClosedRuleCache
-                        -> [DiffTheoryItem DiffProtoRule ClosedProtoRule IncrementalDiffProof IncrementalProof]
-                        -> [DiffTheoryItem DiffProtoRule ClosedProtoRule IncrementalDiffProof IncrementalProof]
+addAutoSourcesLemmaDiff ::
+  MaudeHandle ->
+  String ->
+  ClosedRuleCache ->
+  ClosedRuleCache ->
+  [DiffTheoryItem DiffProtoRule ClosedProtoRule IncrementalDiffProof IncrementalProof] ->
+  [DiffTheoryItem DiffProtoRule ClosedProtoRule IncrementalDiffProof IncrementalProof]
 addAutoSourcesLemmaDiff hnd lemmaName crcLeft crcRight items =
-    diffPart ++ lhsPart ++ rhsPart
+  diffPart ++ lhsPart ++ rhsPart
   where
     -- We split items into three. DiffRules, DiffLemmas, and DiffTextItems are
     -- kept as is. We apply addAutoSourcesLemma on each side (rules, lemmas and
     -- restrictions), and recompose everything.
     diffPart = mapMaybe f items
       where
-        f (DiffRuleItem r)               = Just (DiffRuleItem r)
-        f (DiffLemmaItem l)              = Just (DiffLemmaItem l)
-        f (DiffTextItem t)               = Just (DiffTextItem t)
-        f (DiffConfigBlockItem b)        = Just (DiffConfigBlockItem b)
-        f _                              = Nothing
+        f (DiffRuleItem r) = Just (DiffRuleItem r)
+        f (DiffLemmaItem l) = Just (DiffLemmaItem l)
+        f (DiffTextItem t) = Just (DiffTextItem t)
+        f (DiffConfigBlockItem b) = Just (DiffConfigBlockItem b)
+        f _ = Nothing
 
-    lhsPart = if containsPartialDeconstructions crcLeft
-        then mapMaybe (toSide LHS) $
-                addAutoSourcesLemma hnd (lemmaName ++ "_LHS") crcLeft $
-                  mapMaybe (filterItemSide LHS) items
-        else mapMaybe (toSide LHS) $
-                  mapMaybe (filterItemSide LHS) items
-    rhsPart = if containsPartialDeconstructions crcRight
-        then mapMaybe (toSide RHS) $
-                addAutoSourcesLemma hnd (lemmaName ++ "_RHS") crcRight $
-                  mapMaybe (filterItemSide RHS) items
-        else mapMaybe (toSide RHS) $
-                  mapMaybe (filterItemSide RHS) items
+    lhsPart =
+      if containsPartialDeconstructions crcLeft
+        then
+          mapMaybe (toSide LHS) $
+            addAutoSourcesLemma hnd (lemmaName ++ "_LHS") crcLeft $
+              mapMaybe (filterItemSide LHS) items
+        else
+          mapMaybe (toSide LHS) $
+            mapMaybe (filterItemSide LHS) items
+    rhsPart =
+      if containsPartialDeconstructions crcRight
+        then
+          mapMaybe (toSide RHS) $
+            addAutoSourcesLemma hnd (lemmaName ++ "_RHS") crcRight $
+              mapMaybe (filterItemSide RHS) items
+        else
+          mapMaybe (toSide RHS) $
+            mapMaybe (filterItemSide RHS) items
 
-    filterItemSide s (EitherRuleItem (s', r))        | s == s' = Just (RuleItem r)
-    filterItemSide s (EitherLemmaItem (s', l))       | s == s' = Just (LemmaItem l)
+    filterItemSide s (EitherRuleItem (s', r)) | s == s' = Just (RuleItem r)
+    filterItemSide s (EitherLemmaItem (s', l)) | s == s' = Just (LemmaItem l)
     filterItemSide s (EitherRestrictionItem (s', r)) | s == s' = Just (RestrictionItem r)
-    filterItemSide _ _                                         = Nothing
+    filterItemSide _ _ = Nothing
 
-    toSide s (RuleItem r)               = Just $ EitherRuleItem (s, r)
-    toSide LHS (LemmaItem l)            = Just $ EitherLemmaItem (LHS, addLeftLemma  l)
-    toSide RHS (LemmaItem l)            = Just $ EitherLemmaItem (RHS, addRightLemma l)
-    toSide s (RestrictionItem r)        = Just $ EitherRestrictionItem (s, r)
-    toSide _ (TextItem t)               = Just $ DiffTextItem t
-    toSide _ (MacroItem m)              = Just $ DiffMacroItem m
-    toSide _ (ConfigBlockItem b)        = Just $ DiffConfigBlockItem b
+    toSide s (RuleItem r) = Just $ EitherRuleItem (s, r)
+    toSide LHS (LemmaItem l) = Just $ EitherLemmaItem (LHS, addLeftLemma l)
+    toSide RHS (LemmaItem l) = Just $ EitherLemmaItem (RHS, addRightLemma l)
+    toSide s (RestrictionItem r) = Just $ EitherRestrictionItem (s, r)
+    toSide _ (TextItem t) = Just $ DiffTextItem t
+    toSide _ (MacroItem m) = Just $ DiffMacroItem m
+    toSide _ (ConfigBlockItem b) = Just $ DiffConfigBlockItem b
     -- FIXME: We currently ignore predicates and sapic stuff as they should not
     --        be generated by addAutoSourcesLemma
-    toSide _ (PredicateItem _)   = Nothing
-    toSide _ (TranslationItem _)       = Nothing
+    toSide _ (PredicateItem _) = Nothing
+    toSide _ (TranslationItem _) = Nothing
 
 -- | Add an auto-generated sources lemma if possible
-addAutoSourcesLemma :: MaudeHandle
-                    -> String
-                    -> ClosedRuleCache
-                    -> [TheoryItem ClosedProtoRule IncrementalProof s]
-                    -> [TheoryItem ClosedProtoRule IncrementalProof s]
+addAutoSourcesLemma ::
+  MaudeHandle ->
+  String ->
+  ClosedRuleCache ->
+  [TheoryItem ClosedProtoRule IncrementalProof s] ->
+  [TheoryItem ClosedProtoRule IncrementalProof s]
 addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
   -- We only add the lemma if there is no lemma of the same name
   case find lemma items of
-    Nothing  -> items'++[LemmaItem l]
+    Nothing -> items' ++ [LemmaItem l]
     (Just _) -> items'
   where
-    runMaude   = (`runReader` hnd)
+    runMaude = (`runReader` hnd)
 
     -- searching for the lemma
     lemma (LemmaItem (Lemma name _ _ _ _ _ _)) | name == lemmaName = True
-    lemma _                                                    = False
+    lemma _ = False
 
     -- build the lemma
     l = fmap skeletonToIncrementalProof $ unprovenLemma lemmaName [SourceLemma] AllTraces formula
@@ -152,43 +162,45 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
     -- compute all encrypted subterms that are output by protocol rules
     allOutConcs :: [(ClosedProtoRule, LNTerm)]
     allOutConcs = do
-        ru                                <- rules
-        (_, protoOrOutFactView -> Just t) <- enumConcs $ L.get cprRuleAC ru
-        unifyProtC                        <- concatMap allProtSubterms t
-        return (ru, unifyProtC)
+      ru <- rules
+      (_, protoOrOutFactView -> Just t) <- enumConcs $ L.get cprRuleAC ru
+      unifyProtC <- concatMap allProtSubterms t
+      return (ru, unifyProtC)
 
     -- compute all fact that are conclusions in protocol rules (not OutFact)
     allOutConcsNotProt :: [(ClosedProtoRule, LNFact)]
     allOutConcsNotProt = do
-        ru              <- rules
-        (_, unifyFactC) <- enumConcs $ L.get cprRuleAC ru
-        -- we ignore cases where the fact is OutFact
-        guard (getFactTag unifyFactC /= OutFact)
-        return (ru, unifyFactC)
+      ru <- rules
+      (_, unifyFactC) <- enumConcs $ L.get cprRuleAC ru
+      -- we ignore cases where the fact is OutFact
+      guard (getFactTag unifyFactC /= OutFact)
+      return (ru, unifyFactC)
 
     -- We use the raw sources here to generate one lemma to rule them all...
     (items', formula, _) = foldl computeFormula (items, ltrue, []) chains
 
     -- Generate a list of all cases that contain open chains
-    chains = concatMap (multiply unsolvedChains . duplicate) $
-                   concatMap (map snd . getDisj . L.get cdCases) raw
+    chains =
+      concatMap (multiply unsolvedChains . duplicate) $
+        concatMap (map snd . getDisj . L.get cdCases) raw
 
     -- Given a list of theory items, a formula, a source with an open chain,
     -- return an updated list of theory items and an update formula for the sources lemma.
-    computeFormula :: ([TheoryItem ClosedProtoRule IncrementalProof s], LNFormula, [(RuleInfo ProtoRuleName IntrRuleACInfo, ExtendedPosition)])
-                   -> ((NodeConc, NodePrem), System)
-                   -> ([TheoryItem ClosedProtoRule IncrementalProof s], LNFormula, [(RuleInfo ProtoRuleName IntrRuleACInfo, ExtendedPosition)])
-    computeFormula (its, form, done) ((conc,_), source) = (its', form', done')
+    computeFormula ::
+      ([TheoryItem ClosedProtoRule IncrementalProof s], LNFormula, [(RuleInfo ProtoRuleName IntrRuleACInfo, ExtendedPosition)]) ->
+      ((NodeConc, NodePrem), System) ->
+      ([TheoryItem ClosedProtoRule IncrementalProof s], LNFormula, [(RuleInfo ProtoRuleName IntrRuleACInfo, ExtendedPosition)])
+    computeFormula (its, form, done) ((conc, _), source) = (its', form', done')
       where
         -- The new items are the old ones but with added labels
-        its'  = addLabels inputsAndOutputs its
+        its' = addLabels inputsAndOutputs its
         -- The new formula is the old one AND the new formula
         form' = addFormula inputsAndOutputs form
         -- The new list of treated cases
         done' = addCases inputsAndOutputs done
 
         -- Variable causing the open chain
-        v     = head $ getFactTerms $ nodeConcFact conc source
+        v = head $ getFactTerms $ nodeConcFact conc source
 
         -- Compute all rules that contain v, and the position of v inside the input term
         inputRules :: [(ClosedProtoRule, Either LNTerm LNFact, ExtendedPosition)]
@@ -196,25 +208,27 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
           where
             g (nodeid, pid, tidx, term) = do
               position <- findPos v term
-              ruleSys  <- nodeRuleSafe nodeid source
-              rule     <- find ((ruleName ruleSys ==) . ruleName) rules
-              premise  <- lookupPrem pid $ L.get cprRuleAC rule
-              t'       <- protoOrInFactView premise
-              t        <- atMay t' tidx
+              ruleSys <- nodeRuleSafe nodeid source
+              rule <- find ((ruleName ruleSys ==) . ruleName) rules
+              premise <- lookupPrem pid $ L.get cprRuleAC rule
+              t' <- protoOrInFactView premise
+              t <- atMay t' tidx
               return (terms position rule t ++ facts position rule t premise)
-                where
-                  terms position rule t = do
-                    -- iterate over all positions found
-                    pos     <- position
-                    return (rule, Left t, (pid, tidx, pos))
-                  facts position rule t premise = do
-                        -- we only consider protocol facts and unprotected terms
-                    guard $ isProtoFact premise && (isPair t || isAC t || isMsgVar t)
-                        -- we only consider facts which are not already solved in the source
-                        && ((nodeid, pid) `elem` map fst (unsolvedPremises source))
-                    -- iterate over all positions found
-                    pos     <- position
-                    return (rule, Right premise, (pid, tidx, pos))
+              where
+                terms position rule t = do
+                  -- iterate over all positions found
+                  pos <- position
+                  return (rule, Left t, (pid, tidx, pos))
+                facts position rule t premise = do
+                  -- we only consider protocol facts and unprotected terms
+                  guard $
+                    isProtoFact premise
+                      && (isPair t || isAC t || isMsgVar t)
+                      -- we only consider facts which are not already solved in the source
+                      && ((nodeid, pid) `elem` map fst (unsolvedPremises source))
+                  -- iterate over all positions found
+                  pos <- position
+                  return (rule, Right premise, (pid, tidx, pos))
 
         -- a list of all input subterms to unify : Left for protected subterm and Right for non protected subterm
         premiseTermU :: [(ClosedProtoRule, Either (LNTerm, LNTerm) LNFact, ExtendedPosition)]
@@ -222,7 +236,7 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
           where
             -- cases for protected subterms : we consider the deepest protected subterm
             f (x, Left y, (pidx, tidx, z)) = do
-              v'        <- y `atPosMay` z
+              v' <- y `atPosMay` z
               protTerm' <- deepestProtSubterm y z
               -- We do not consider the case where the computed deepest
               -- protected subterm is the variable in question, as this
@@ -233,9 +247,10 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
               -- 2. blows up the lemma as a variable unifies with all outputs
               -- 3. typically only happens if a value is stored in a state fact,
               --    which is handled by the other case
-              protTerm  <- if protTerm' == v'
-                then Nothing
-                else Just protTerm'
+              protTerm <-
+                if protTerm' == v'
+                  then Nothing
+                  else Just protTerm'
               return (x, Left (protTerm, v'), (pidx, tidx, z))
             -- cases for non-protected subterms : we consider the Fact
             f (x, Right fact, (pidx, tidx, z)) =
@@ -245,140 +260,279 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
         -- returns a list of inputs together with their list of matching outputs
         inputsAndOutputs :: [(ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition)]
         inputsAndOutputs = do
-            -- iterate over all inputs
-            (rin, unify, pos) <- filterFacts premiseTermU
-            -- find matching conclusions
-            let matches = matchingConclusions rin unify
-            return (rin, matches, pos)
+          -- iterate over all inputs
+          (rin, unify, pos) <- filterFacts premiseTermU
+          -- find matching conclusions
+          let matches = matchingConclusions rin unify
+          return (rin, matches, pos)
           where
             -- we ignore fact cases which are covered by the protected subterms
             filterFacts cases = mapMaybe f cases
               where
-                f c@(r, Left  _, p) = do
+                f c@(r, Left _, p) = do
                   guard $ notElem (ruleName r, p) done
                   return c
                 f c@(r, Right _, p) = do
-                  guard $ notElem (ruleName r, p) done
-                         && null subtermCasePositions
+                  guard $
+                    notElem (ruleName r, p) done
+                      && null subtermCasePositions
                   return c
                 -- check if there are protected subterms for this variable
                 subtermCasePositions = filter (isLeft . snd3) cases
 
-            matchingConclusions rin (Left (unify, vin)) = Left (unify, vin, do
-              (rout, tout) <- allOutConcs
-              -- generate fresh instance of conclusion, avoiding the premise variables
-              let fout = tout `renameAvoiding` unify
-              -- we ignore outputs of the same rule
-              guard ((ruleName . L.get cprRuleE) rin /= (ruleName . L.get cprRuleE) rout)
-              -- check whether input and output are unifiable
-              guard (runMaude $ unifiableLNTerms unify fout)
-              return (rout, tout))
-            matchingConclusions rin (Right unify) = Right (unify, do
-              (rout, fout) <- allOutConcsNotProt
-              -- we ignore outputs of the same rule
-              guard ((ruleName . L.get cprRuleE) rin /= (ruleName . L.get cprRuleE) rout)
-              -- we ignore cases where the output fact and the input fact have different name
-              guard (factTagName (getFactTag unify) == factTagName (getFactTag fout))
-              -- check whether input and output are unifiable
-              let unifout = fout `renameAvoiding` unify
-              guard (runMaude $ unifiableLNFacts unify unifout)
-              return (rout, fout))
+            matchingConclusions rin (Left (unify, vin)) =
+              Left
+                ( unify,
+                  vin,
+                  do
+                    (rout, tout) <- allOutConcs
+                    -- generate fresh instance of conclusion, avoiding the premise variables
+                    let fout = tout `renameAvoiding` unify
+                    -- we ignore outputs of the same rule
+                    guard ((ruleName . L.get cprRuleE) rin /= (ruleName . L.get cprRuleE) rout)
+                    -- check whether input and output are unifiable
+                    guard (runMaude $ unifiableLNTerms unify fout)
+                    return (rout, tout)
+                )
+            matchingConclusions rin (Right unify) =
+              Right
+                ( unify,
+                  do
+                    (rout, fout) <- allOutConcsNotProt
+                    -- we ignore outputs of the same rule
+                    guard ((ruleName . L.get cprRuleE) rin /= (ruleName . L.get cprRuleE) rout)
+                    -- we ignore cases where the output fact and the input fact have different name
+                    guard (factTagName (getFactTag unify) == factTagName (getFactTag fout))
+                    -- check whether input and output are unifiable
+                    let unifout = fout `renameAvoiding` unify
+                    guard (runMaude $ unifiableLNFacts unify unifout)
+                    return (rout, fout)
+                )
 
         -- construct action facts for the rule annotations and formula
-        inputFactTerm pos ru terms var = Fact {factTag = ProtoFact Linear
-              ("AUTO_IN_TERM_" ++ printPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (1 + length terms),
-              factAnnotations = S.empty, factTerms = terms ++[var]}
-        inputFactFact pos ru terms = Fact {factTag = ProtoFact Linear
-              ("AUTO_IN_FACT_" ++ printFactPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (length terms),
-              factAnnotations = S.empty, factTerms = terms}
-        outputFactTerm pos ru terms = Fact {factTag = ProtoFact Linear
-              ("AUTO_OUT_TERM_" ++ printPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (length terms),
-              factAnnotations = S.empty, factTerms = terms}
-        outputFactFact pos ru terms = Fact {factTag = ProtoFact Linear
-              ("AUTO_OUT_FACT_" ++ printFactPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru)) (length terms),
-              factAnnotations = S.empty, factTerms = terms}
+        inputFactTerm pos ru terms var =
+          Fact
+            { factTag =
+                ProtoFact
+                  Linear
+                  ("AUTO_IN_TERM_" ++ printPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru))
+                  (1 + length terms),
+              factAnnotations = S.empty,
+              factTerms = terms ++ [var]
+            }
+        inputFactFact pos ru terms =
+          Fact
+            { factTag =
+                ProtoFact
+                  Linear
+                  ("AUTO_IN_FACT_" ++ printFactPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru))
+                  (length terms),
+              factAnnotations = S.empty,
+              factTerms = terms
+            }
+        outputFactTerm pos ru terms =
+          Fact
+            { factTag =
+                ProtoFact
+                  Linear
+                  ("AUTO_OUT_TERM_" ++ printPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru))
+                  (length terms),
+              factAnnotations = S.empty,
+              factTerms = terms
+            }
+        outputFactFact pos ru terms =
+          Fact
+            { factTag =
+                ProtoFact
+                  Linear
+                  ("AUTO_OUT_FACT_" ++ printFactPosition pos ++ "_" ++ getRuleName (L.get cprRuleAC ru))
+                  (length terms),
+              factAnnotations = S.empty,
+              factTerms = terms
+            }
 
         -- add labels to rules for typing lemma
-        addLabels :: [(ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition)]
-                  -> [TheoryItem ClosedProtoRule IncrementalProof s]
-                  -> [TheoryItem ClosedProtoRule IncrementalProof s]
+        addLabels ::
+          [(ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition)] ->
+          [TheoryItem ClosedProtoRule IncrementalProof s] ->
+          [TheoryItem ClosedProtoRule IncrementalProof s]
         addLabels matches = map update
           where
-            update (RuleItem ru) = RuleItem $ foldr up ru $
-                   filter ((ruleName ru ==). ruleName . fst3) acts
+            update (RuleItem ru) =
+              RuleItem $
+                foldr up ru $
+                  filter ((ruleName ru ==) . ruleName . fst3) acts
               where
-                up (r, p, Left  (Left  (t, v'))) r' = addActionClosedProtoRule r' (inputFactTerm  p r [t] v')
-                up (r, p, Left  (Right f))       r' = addActionClosedProtoRule r' (inputFactFact  p r (getFactTerms f))
-                up (_, p, Right (r, Left  t))    r' = addActionClosedProtoRule r' (outputFactTerm p r [t])
-                up (_, p, Right (r, Right f))    r' = addActionClosedProtoRule r' (outputFactFact p r (getFactTerms f))
-            update item          = item
+                up (r, p, Left (Left (t, v'))) r' = addActionClosedProtoRule r' (inputFactTerm p r [t] v')
+                up (r, p, Left (Right f)) r' = addActionClosedProtoRule r' (inputFactFact p r (getFactTerms f))
+                up (_, p, Right (r, Left t)) r' = addActionClosedProtoRule r' (outputFactTerm p r [t])
+                up (_, p, Right (r, Right f)) r' = addActionClosedProtoRule r' (outputFactFact p r (getFactTerms f))
+            update item = item
 
             acts = concatMap prepare matches
             -- Left Left means Input Term
             -- Left Right means Input Fact
             -- Right Left means Output Term
             -- Right Left means Output Fact
-            prepare (r, Left  (t, v', tl), p) = (r, p, Left (Left  (t, v'))) : map (\(r', t') -> (r', p, Right (r, Left  t'))) tl
-            prepare (r, Right (f, fl)    , p) = (r, p, Left (Right f))       : map (\(r', f') -> (r', p, Right (r, Right f'))) fl
+            prepare (r, Left (t, v', tl), p) = (r, p, Left (Left (t, v'))) : map (\(r', t') -> (r', p, Right (r, Left t'))) tl
+            prepare (r, Right (f, fl), p) = (r, p, Left (Right f)) : map (\(r', f') -> (r', p, Right (r, Right f'))) fl
 
         listOfM :: Int -> [String]
-        listOfM n = zipWith (++) (replicate n "m") $ fmap show [1..n]
+        listOfM n = zipWith (++) (replicate n "m") $ fmap show [1 .. n]
 
         -- add formula to lemma
         addFormula ::
-             [(ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition)]
-          -> LNFormula
-          -> LNFormula
+          [(ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition)] ->
+          LNFormula ->
+          LNFormula
         addFormula matches f = foldr addForm f matches
           where
             addForm ::
-                 (ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition)
-              -> LNFormula
-              -> LNFormula
+              (ClosedProtoRule, Either (LNTerm, LNTerm, [(ClosedProtoRule, LNTerm)]) (LNFact, [(ClosedProtoRule, LNFact)]), ExtendedPosition) ->
+              LNFormula ->
+              LNFormula
             -- protected subterms: if there are no matching outputs, do add a formula with only KU
-            addForm (ru, Left (_, _, []), p) f' = f' .&&. Qua All ("x", LSortMsg)
-              (Qua All ("m", LSortMsg) (Qua All ("i", LSortNode)
-              (Conn Imp (Ato (Action (varTerm (Bound 0))
-              (inputFactTerm p ru [varTerm (Bound 1)] (varTerm (Bound 2)))))
-              orKU)))
+            addForm (ru, Left (_, _, []), p) f' =
+              f'
+                .&&. Qua
+                  All
+                  ("x", LSortMsg)
+                  ( Qua
+                      All
+                      ("m", LSortMsg)
+                      ( Qua
+                          All
+                          ("i", LSortNode)
+                          ( Conn
+                              Imp
+                              ( Ato
+                                  ( Action
+                                      (varTerm (Bound 0))
+                                      (inputFactTerm p ru [varTerm (Bound 1)] (varTerm (Bound 2)))
+                                  )
+                              )
+                              orKU
+                          )
+                      )
+                  )
             -- protected subterms
-            addForm (ru, Left _, p) f' = f' .&&. Qua All ("x", LSortMsg)
-              (Qua All ("m", LSortMsg) (Qua All ("i", LSortNode)
-              (Conn Imp (Ato (Action (varTerm (Bound 0))
-              (inputFactTerm p ru [varTerm (Bound 1)] (varTerm (Bound 2)))))
-              (toFactsTerm ru p orKU))))
+            addForm (ru, Left _, p) f' =
+              f'
+                .&&. Qua
+                  All
+                  ("x", LSortMsg)
+                  ( Qua
+                      All
+                      ("m", LSortMsg)
+                      ( Qua
+                          All
+                          ("i", LSortNode)
+                          ( Conn
+                              Imp
+                              ( Ato
+                                  ( Action
+                                      (varTerm (Bound 0))
+                                      (inputFactTerm p ru [varTerm (Bound 1)] (varTerm (Bound 2)))
+                                  )
+                              )
+                              (toFactsTerm ru p orKU)
+                          )
+                      )
+                  )
             -- facts: even if there are no matching outputs, do add a formula with "false"
-            addForm (ru, Right (m, []),     p) f' = f' .&&. formulaMultArity (factArity m)
-              where formulaMultArity nb = foldr (\h -> Qua All (h,LSortMsg))
-                           (Qua All ("i", LSortNode)
-                           (Conn Imp (Ato (Action (varTerm (Bound 0))
-                           (inputFactFact p ru (listVarTerm (toInteger $ factArity m) 1))))
-                           lfalse)) (listOfM nb)
+            addForm (ru, Right (m, []), p) f' = f' .&&. formulaMultArity (factArity m)
+              where
+                formulaMultArity nb =
+                  foldr
+                    (\h -> Qua All (h, LSortMsg))
+                    ( Qua
+                        All
+                        ("i", LSortNode)
+                        ( Conn
+                            Imp
+                            ( Ato
+                                ( Action
+                                    (varTerm (Bound 0))
+                                    (inputFactFact p ru (listVarTerm (toInteger $ factArity m) 1))
+                                )
+                            )
+                            lfalse
+                        )
+                    )
+                    (listOfM nb)
             -- facts
-            addForm (ru, Right (m, outs:_), p) f' = f' .&&. formulaMultArity (factArity m)
-              where formulaMultArity nb = foldr (\h -> Qua All (h,LSortMsg))
-                           (Qua All ("i", LSortNode)
-                           (Conn Imp (Ato (Action (varTerm (Bound 0))
-                           (inputFactFact p ru (listVarTerm (toInteger $ factArity m) 1))))
-                           (toFactsFact ru p (snd outs)))) (listOfM nb)
-            orKU = Qua Ex ("j",LSortNode)
-                   (Conn And (Ato (Action (varTerm (Bound 0))
-                    Fact {factTag = KUFact, factAnnotations = S.empty,
-                          factTerms = [varTerm (Bound 3)]} ))
-                   (Ato (Less (varTerm (Bound 0)) (varTerm (Bound 1)))))
+            addForm (ru, Right (m, outs : _), p) f' = f' .&&. formulaMultArity (factArity m)
+              where
+                formulaMultArity nb =
+                  foldr
+                    (\h -> Qua All (h, LSortMsg))
+                    ( Qua
+                        All
+                        ("i", LSortNode)
+                        ( Conn
+                            Imp
+                            ( Ato
+                                ( Action
+                                    (varTerm (Bound 0))
+                                    (inputFactFact p ru (listVarTerm (toInteger $ factArity m) 1))
+                                )
+                            )
+                            (toFactsFact ru p (snd outs))
+                        )
+                    )
+                    (listOfM nb)
+            orKU =
+              Qua
+                Ex
+                ("j", LSortNode)
+                ( Conn
+                    And
+                    ( Ato
+                        ( Action
+                            (varTerm (Bound 0))
+                            Fact
+                              { factTag = KUFact,
+                                factAnnotations = S.empty,
+                                factTerms = [varTerm (Bound 3)]
+                              }
+                        )
+                    )
+                    (Ato (Less (varTerm (Bound 0)) (varTerm (Bound 1))))
+                )
             toFactsTerm ru p f'' =
-              Conn Or f''
-              (Qua Ex ("j",LSortNode)
-              (Conn And (Ato (Action (varTerm (Bound 0))
-              (outputFactTerm p ru [varTerm (Bound 2)]) ))
-              (Ato (Less (varTerm (Bound 0)) (varTerm (Bound 1))))))
+              Conn
+                Or
+                f''
+                ( Qua
+                    Ex
+                    ("j", LSortNode)
+                    ( Conn
+                        And
+                        ( Ato
+                            ( Action
+                                (varTerm (Bound 0))
+                                (outputFactTerm p ru [varTerm (Bound 2)])
+                            )
+                        )
+                        (Ato (Less (varTerm (Bound 0)) (varTerm (Bound 1))))
+                    )
+                )
             toFactsFact ru p outn =
-              Qua Ex ("j",LSortNode)
-              (Conn And (Ato (Action (varTerm (Bound 0))
-              (outputFactFact p ru (listVarTerm (toInteger $ 1 + factArity outn) 2)) ))
-              (Ato (Less (varTerm (Bound 0)) (varTerm (Bound 1)))))
-            listVarTerm q s | q == s    = [varTerm (Bound q)]
-            listVarTerm q s | otherwise = varTerm (Bound q) : listVarTerm (q-1) s
+              Qua
+                Ex
+                ("j", LSortNode)
+                ( Conn
+                    And
+                    ( Ato
+                        ( Action
+                            (varTerm (Bound 0))
+                            (outputFactFact p ru (listVarTerm (toInteger $ 1 + factArity outn) 2))
+                        )
+                    )
+                    (Ato (Less (varTerm (Bound 0)) (varTerm (Bound 1))))
+                )
+            listVarTerm q s | q == s = [varTerm (Bound q)]
+            listVarTerm q s | otherwise = varTerm (Bound q) : listVarTerm (q - 1) s
 
         -- add all cases (identified by rule name and input variable position) to the list of treated cases
         addCases matches d = d ++ map (\(r, _, p) -> (ruleName r, p)) matches
@@ -392,8 +546,6 @@ addAutoSourcesLemma hnd lemmaName (ClosedRuleCache _ raw _ _) items =
 defaultOption :: Option
 defaultOption = Option False False False False False False False False False S.empty [] 10 5
 
-
-
 -- | Default theory
 defaultOpenTheory :: Bool -> OpenTheory
 defaultOpenTheory flag = Theory "default" "default" [] [] (emptySignaturePure flag) [] [] defaultOption False
@@ -403,7 +555,7 @@ defaultOpenDiffTheory :: Bool -> OpenDiffTheory
 defaultOpenDiffTheory flag = DiffTheory "default" "default" [] [] (emptySignaturePure flag) [] [] [] [] [] defaultOption False
 
 -- Add the default Diff lemma to an Open Diff Theory
-addDefaultDiffLemma:: OpenDiffTheory -> OpenDiffTheory
+addDefaultDiffLemma :: OpenDiffTheory -> OpenDiffTheory
 addDefaultDiffLemma thy = fromMaybe thy $ addDiffLemma (unprovenDiffLemma "Observational_equivalence" []) thy
 
 -- Add the rule labels to an Open Diff Theory
@@ -412,18 +564,18 @@ addProtoRuleLabel rule = addProtoDiffLabel rule ("DiffProto" ++ (getOpenProtoRul
 
 -- Get the left openProtoRules
 getLeftProtoRule :: DiffProtoRule -> OpenProtoRule
-getLeftProtoRule (DiffProtoRule ruE Nothing)       = OpenProtoRule (getLeftRule ruE) []
-getLeftProtoRule (DiffProtoRule _   (Just (l, _))) = l
+getLeftProtoRule (DiffProtoRule ruE Nothing) = OpenProtoRule (getLeftRule ruE) []
+getLeftProtoRule (DiffProtoRule _ (Just (l, _))) = l
 
 -- Get the rigth openProtoRules
 getRightProtoRule :: DiffProtoRule -> OpenProtoRule
-getRightProtoRule (DiffProtoRule ruE Nothing)       = OpenProtoRule (getRightRule ruE) []
-getRightProtoRule (DiffProtoRule _   (Just (_, r))) = r
+getRightProtoRule (DiffProtoRule ruE Nothing) = OpenProtoRule (getRightRule ruE) []
+getRightProtoRule (DiffProtoRule _ (Just (_, r))) = r
 
 -- Add the rule labels to an Open Diff Theory
-addIntrRuleLabels:: OpenDiffTheory -> OpenDiffTheory
+addIntrRuleLabels :: OpenDiffTheory -> OpenDiffTheory
 addIntrRuleLabels thy =
-    modify diffThyCacheLeft (map addRuleLabel) $ modify diffThyDiffCacheLeft (map addRuleLabel) $ modify diffThyDiffCacheRight (map addRuleLabel) $ modify diffThyCacheRight (map addRuleLabel) thy
+  modify diffThyCacheLeft (map addRuleLabel) $ modify diffThyDiffCacheLeft (map addRuleLabel) $ modify diffThyDiffCacheRight (map addRuleLabel) $ modify diffThyCacheRight (map addRuleLabel) thy
   where
     addRuleLabel :: IntrRuleAC -> IntrRuleAC
     addRuleLabel rule = addDiffLabel rule ("DiffIntr" ++ (getRuleName rule))
@@ -433,8 +585,8 @@ containsManualRuleVariants :: [TheoryItem OpenProtoRule p s] -> Bool
 containsManualRuleVariants = foldl f False
   where
     f hasVariants (RuleItem (OpenProtoRule _ [])) = hasVariants
-    f _           (RuleItem (OpenProtoRule _ _ )) = True
-    f hasVariants _                               = hasVariants
+    f _ (RuleItem (OpenProtoRule _ _)) = True
+    f hasVariants _ = hasVariants
 
 -- | Merges variants of the same protocol rule modulo E
 mergeOpenProtoRules :: [TheoryItem OpenProtoRule p s] -> [TheoryItem OpenProtoRule p s]
@@ -443,128 +595,130 @@ mergeOpenProtoRules = concatMap (foldr mergeRules []) . groupBy comp
     comp (RuleItem (OpenProtoRule ruE _)) (RuleItem (OpenProtoRule ruE' _)) = ruE == ruE'
     comp (RuleItem _) _ = False
     comp _ (RuleItem _) = False
-    comp _ _            = True
+    comp _ _ = True
 
-    mergeRules (RuleItem r)                          []                                              = [RuleItem r]
-    mergeRules (RuleItem (OpenProtoRule ruE' ruAC')) [RuleItem (OpenProtoRule ruE ruAC)] | ruE==ruE' = [RuleItem (OpenProtoRule ruE (ruAC'++ruAC))]
-    mergeRules (RuleItem _)                          _                                               = error "Error in mergeOpenProtoRules. Please report bug."
-    mergeRules item                                  l                                               = item:l
+    mergeRules (RuleItem r) [] = [RuleItem r]
+    mergeRules (RuleItem (OpenProtoRule ruE' ruAC')) [RuleItem (OpenProtoRule ruE ruAC)] | ruE == ruE' = [RuleItem (OpenProtoRule ruE (ruAC' ++ ruAC))]
+    mergeRules (RuleItem _) _ = error "Error in mergeOpenProtoRules. Please report bug."
+    mergeRules item l = item : l
 
 -- | Returns true if there are DiffProtoRules containing manual instances or variants
 containsManualRuleVariantsDiff :: [DiffTheoryItem DiffProtoRule r p p2] -> Bool
 containsManualRuleVariantsDiff = foldl f False
   where
-    f hasVariants (DiffRuleItem (DiffProtoRule _ Nothing )) = hasVariants
-    f _           (DiffRuleItem (DiffProtoRule _ (Just _))) = True
-    f hasVariants _                                         = hasVariants
+    f hasVariants (DiffRuleItem (DiffProtoRule _ Nothing)) = hasVariants
+    f _ (DiffRuleItem (DiffProtoRule _ (Just _))) = True
+    f hasVariants _ = hasVariants
 
 -- | Merges variants of the same protocol rule modulo E
 mergeOpenProtoRulesDiff :: [DiffTheoryItem r OpenProtoRule p p2] -> [DiffTheoryItem r OpenProtoRule p p2]
 mergeOpenProtoRulesDiff = concatMap (foldr mergeRules []) . groupBy comp
   where
-    comp (EitherRuleItem (s, OpenProtoRule ruE _)) (EitherRuleItem (s', OpenProtoRule ruE' _)) = ruE==ruE' && s==s'
+    comp (EitherRuleItem (s, OpenProtoRule ruE _)) (EitherRuleItem (s', OpenProtoRule ruE' _)) = ruE == ruE' && s == s'
     comp (EitherRuleItem _) _ = False
     comp _ (EitherRuleItem _) = False
-    comp _ _                  = True
+    comp _ _ = True
 
-    mergeRules (EitherRuleItem r)                             [] = [EitherRuleItem r]
+    mergeRules (EitherRuleItem r) [] = [EitherRuleItem r]
     mergeRules (EitherRuleItem (s, OpenProtoRule ruE' ruAC')) [EitherRuleItem (s', OpenProtoRule ruE ruAC)]
-                                            | ruE==ruE' && s==s' = [EitherRuleItem (s, OpenProtoRule ruE (ruAC'++ruAC))]
-    mergeRules (EitherRuleItem _)                             _  = error "Error in mergeOpenProtoRulesDiff. Please report bug."
-    mergeRules item                                           l  = item:l
+      | ruE == ruE' && s == s' = [EitherRuleItem (s, OpenProtoRule ruE (ruAC' ++ ruAC))]
+    mergeRules (EitherRuleItem _) _ = error "Error in mergeOpenProtoRulesDiff. Please report bug."
+    mergeRules item l = item : l
 
 -- | Merges left and right instances with initial diff rule
 mergeLeftRightRulesDiff :: (Show p, Show p2) => [DiffTheoryItem DiffProtoRule OpenProtoRule p p2] -> [DiffTheoryItem DiffProtoRule OpenProtoRule p p2]
 mergeLeftRightRulesDiff rs = map clean $ concatMap (foldr mergeRules []) $ groupBy comp' $ sortBy comp rs
   where
     comp (EitherRuleItem (_, OpenProtoRule ruE _)) (EitherRuleItem (_, OpenProtoRule ruE' _)) = compare (ruleName ruE) (ruleName ruE')
-    comp (EitherRuleItem (_, OpenProtoRule ruE _)) (DiffRuleItem (DiffProtoRule ruE' _))      = compare (ruleName ruE) (ruleName ruE')
-    comp (DiffRuleItem (DiffProtoRule ruE _))      (EitherRuleItem (_, OpenProtoRule ruE' _)) = compare (ruleName ruE) (ruleName ruE')
-    comp (DiffRuleItem (DiffProtoRule ruE _))      (DiffRuleItem (DiffProtoRule ruE' _))      = compare (ruleName ruE) (ruleName ruE')
+    comp (EitherRuleItem (_, OpenProtoRule ruE _)) (DiffRuleItem (DiffProtoRule ruE' _)) = compare (ruleName ruE) (ruleName ruE')
+    comp (DiffRuleItem (DiffProtoRule ruE _)) (EitherRuleItem (_, OpenProtoRule ruE' _)) = compare (ruleName ruE) (ruleName ruE')
+    comp (DiffRuleItem (DiffProtoRule ruE _)) (DiffRuleItem (DiffProtoRule ruE' _)) = compare (ruleName ruE) (ruleName ruE')
     comp (EitherRuleItem _) _ = LT
     comp _ (EitherRuleItem _) = GT
-    comp (DiffRuleItem _) _   = LT
-    comp _ (DiffRuleItem _)   = GT
-    comp _ _                  = EQ
+    comp (DiffRuleItem _) _ = LT
+    comp _ (DiffRuleItem _) = GT
+    comp _ _ = EQ
 
     comp' a b = comp a b == EQ
 
-    mergeRules (EitherRuleItem r)                                 [] = [EitherRuleItem r]
-    mergeRules (DiffRuleItem r)                                   [] = [DiffRuleItem r]
-    mergeRules (EitherRuleItem (s, ru@(OpenProtoRule ruE _)))     [EitherRuleItem (s', ru'@(OpenProtoRule ruE' _))]
-                                            | ruleName ruE==ruleName ruE' && s==LHS && s'==RHS = [DiffRuleItem (DiffProtoRule ruE (Just (ru, ru')))]
-    mergeRules (EitherRuleItem (s, ru@(OpenProtoRule ruE _)))     [EitherRuleItem (s', ru'@(OpenProtoRule ruE' _))]
-                                            | ruleName ruE==ruleName ruE' && s==RHS && s'==LHS = [DiffRuleItem (DiffProtoRule ruE (Just (ru', ru)))]
-    mergeRules (EitherRuleItem (_, ru@(OpenProtoRule ruE _)))     [DiffRuleItem (DiffProtoRule dru Nothing)]
-                                            | ruleName ruE==ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru)))]
-    mergeRules (DiffRuleItem (DiffProtoRule dru Nothing))         [EitherRuleItem (_, ru@(OpenProtoRule ruE _))]
-                                            | ruleName ruE==ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru)))]
-    mergeRules (EitherRuleItem (LHS, ru@(OpenProtoRule ruE _)))   [DiffRuleItem (DiffProtoRule dru (Just (_, ru')))]
-                                            | ruleName ruE==ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru')))]
-    mergeRules (EitherRuleItem (RHS, ru@(OpenProtoRule ruE _)))   [DiffRuleItem (DiffProtoRule dru (Just (ru', _)))]
-                                            | ruleName ruE==ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru', ru)))]
+    mergeRules (EitherRuleItem r) [] = [EitherRuleItem r]
+    mergeRules (DiffRuleItem r) [] = [DiffRuleItem r]
+    mergeRules (EitherRuleItem (s, ru@(OpenProtoRule ruE _))) [EitherRuleItem (s', ru'@(OpenProtoRule ruE' _))]
+      | ruleName ruE == ruleName ruE' && s == LHS && s' == RHS = [DiffRuleItem (DiffProtoRule ruE (Just (ru, ru')))]
+    mergeRules (EitherRuleItem (s, ru@(OpenProtoRule ruE _))) [EitherRuleItem (s', ru'@(OpenProtoRule ruE' _))]
+      | ruleName ruE == ruleName ruE' && s == RHS && s' == LHS = [DiffRuleItem (DiffProtoRule ruE (Just (ru', ru)))]
+    mergeRules (EitherRuleItem (_, ru@(OpenProtoRule ruE _))) [DiffRuleItem (DiffProtoRule dru Nothing)]
+      | ruleName ruE == ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru)))]
+    mergeRules (DiffRuleItem (DiffProtoRule dru Nothing)) [EitherRuleItem (_, ru@(OpenProtoRule ruE _))]
+      | ruleName ruE == ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru)))]
+    mergeRules (EitherRuleItem (LHS, ru@(OpenProtoRule ruE _))) [DiffRuleItem (DiffProtoRule dru (Just (_, ru')))]
+      | ruleName ruE == ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru')))]
+    mergeRules (EitherRuleItem (RHS, ru@(OpenProtoRule ruE _))) [DiffRuleItem (DiffProtoRule dru (Just (ru', _)))]
+      | ruleName ruE == ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru', ru)))]
     mergeRules (DiffRuleItem (DiffProtoRule dru (Just (_, ru')))) [EitherRuleItem (LHS, ru@(OpenProtoRule ruE _))]
-                                            | ruleName ruE==ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru')))]
+      | ruleName ruE == ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru, ru')))]
     mergeRules (DiffRuleItem (DiffProtoRule dru (Just (ru', _)))) [EitherRuleItem (RHS, ru@(OpenProtoRule ruE _))]
-                                            | ruleName ruE==ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru', ru)))]
+      | ruleName ruE == ruleName dru = [DiffRuleItem (DiffProtoRule dru (Just (ru', ru)))]
     mergeRules (DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))) [DiffRuleItem (DiffProtoRule dru' Nothing)]
-                                            | ruleName dru==ruleName dru' = [DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))]
-    mergeRules (DiffRuleItem (DiffProtoRule dru Nothing))         [DiffRuleItem (DiffProtoRule dru' (Just (lr, rr)))]
-                                            | ruleName dru==ruleName dru' = [DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))]
+      | ruleName dru == ruleName dru' = [DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))]
+    mergeRules (DiffRuleItem (DiffProtoRule dru Nothing)) [DiffRuleItem (DiffProtoRule dru' (Just (lr, rr)))]
+      | ruleName dru == ruleName dru' = [DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))]
     mergeRules (DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))) [DiffRuleItem (DiffProtoRule dru' (Just (lr', rr')))]
-                                            | ruleName dru==ruleName dru' && equalOpenRuleUpToDiffAnnotation lr lr' && equalOpenRuleUpToDiffAnnotation rr rr' = [DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))]
-    mergeRules (EitherRuleItem _)                                 _  = error "Error in mergeLeftRightRulesDiff. Please report bug."
-    mergeRules (DiffRuleItem _)                                   _  = error "Error in mergeLeftRightRulesDiff. Please report bug."
-    mergeRules item                                               l  = item:l
+      | ruleName dru == ruleName dru' && equalOpenRuleUpToDiffAnnotation lr lr' && equalOpenRuleUpToDiffAnnotation rr rr' = [DiffRuleItem (DiffProtoRule dru (Just (lr, rr)))]
+    mergeRules (EitherRuleItem _) _ = error "Error in mergeLeftRightRulesDiff. Please report bug."
+    mergeRules (DiffRuleItem _) _ = error "Error in mergeLeftRightRulesDiff. Please report bug."
+    mergeRules item l = item : l
 
     clean (DiffRuleItem (DiffProtoRule ruE (Just (OpenProtoRule ruEL [], OpenProtoRule ruER []))))
-       | getLeftRule ruE `equalRuleUpToDiffAnnotation` ruEL
-        && getRightRule ruE `equalRuleUpToDiffAnnotation` ruER = DiffRuleItem (DiffProtoRule ruE Nothing)
-    clean i                                                    = i
-
+      | getLeftRule ruE `equalRuleUpToDiffAnnotation` ruEL
+          && getRightRule ruE `equalRuleUpToDiffAnnotation` ruER =
+          DiffRuleItem (DiffProtoRule ruE Nothing)
+    clean i = i
 
 -- | Find the open protocol rule with the given name.
 lookupOpenProtoRule :: ProtoRuleName -> OpenTheory -> Maybe OpenProtoRule
 lookupOpenProtoRule name =
-    find ((name ==) . L.get (preName . rInfo . oprRuleE)) . theoryRules
+  find ((name ==) . L.get (preName . rInfo . oprRuleE)) . theoryRules
 
 -- | Find the open protocol rule with the given name.
 lookupOpenDiffProtoDiffRule :: ProtoRuleName -> OpenDiffTheory -> Maybe DiffProtoRule
 lookupOpenDiffProtoDiffRule name =
-    find ((name ==) . L.get (preName . rInfo . dprRule)) . diffTheoryDiffRules
+  find ((name ==) . L.get (preName . rInfo . dprRule)) . diffTheoryDiffRules
 
 -- | Add new protocol rules. Fails, if a protocol rule with the same name
 -- exists.
 addOpenProtoRule :: OpenProtoRule -> OpenTheory -> Maybe OpenTheory
 addOpenProtoRule ru@(OpenProtoRule ruE ruAC) thy = do
-    guard nameNotUsedForDifferentRule
-    guard allRuleNamesAreDifferent
-    return $ modify thyItems (++ [RuleItem ru]) thy
+  guard nameNotUsedForDifferentRule
+  guard allRuleNamesAreDifferent
+  return $ modify thyItems (++ [RuleItem ru]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True (ru ==) $ lookupOpenProtoRule (L.get (preName . rInfo . oprRuleE) ru) thy
-    allRuleNamesAreDifferent = (S.size (S.fromList (ruleName ruE:map ruleName ruAC)))
+      maybe True (ru ==) $ lookupOpenProtoRule (L.get (preName . rInfo . oprRuleE) ru) thy
+    allRuleNamesAreDifferent =
+      (S.size (S.fromList (ruleName ruE : map ruleName ruAC)))
         == ((length ruAC) + 1)
 
 -- | Add a new protocol rules. Fails, if a protocol rule with the same name
 -- exists.
 addOpenProtoDiffRule :: DiffProtoRule -> OpenDiffTheory -> Maybe OpenDiffTheory
-addOpenProtoDiffRule ru@(DiffProtoRule _ Nothing)  thy = do
-    guard nameNotUsedForDifferentRule
-    return $ modify diffThyItems (++ [DiffRuleItem ru]) thy
+addOpenProtoDiffRule ru@(DiffProtoRule _ Nothing) thy = do
+  guard nameNotUsedForDifferentRule
+  return $ modify diffThyItems (++ [DiffRuleItem ru]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True (ru ==) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo . dprRule) ru) thy
+      maybe True (ru ==) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo . dprRule) ru) thy
 addOpenProtoDiffRule ru@(DiffProtoRule _ (Just (lr, rr))) thy = do
-    guard nameNotUsedForDifferentRule
-    guard $ allRuleNamesAreDifferent lr
-    guard $ allRuleNamesAreDifferent rr
-    guard leftAndRightHaveSameName
-    return $ modify diffThyItems (++ [DiffRuleItem ru]) thy
+  guard nameNotUsedForDifferentRule
+  guard $ allRuleNamesAreDifferent lr
+  guard $ allRuleNamesAreDifferent rr
+  guard leftAndRightHaveSameName
+  return $ modify diffThyItems (++ [DiffRuleItem ru]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True (ru ==) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo . dprRule) ru) thy
-    allRuleNamesAreDifferent (OpenProtoRule ruE ruAC) = (S.size (S.fromList (ruleName ruE:map ruleName ruAC)))
+      maybe True (ru ==) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo . dprRule) ru) thy
+    allRuleNamesAreDifferent (OpenProtoRule ruE ruAC) =
+      (S.size (S.fromList (ruleName ruE : map ruleName ruAC)))
         == ((length ruAC) + 1)
     leftAndRightHaveSameName = ruleName ru == ruleName lr && ruleName lr == ruleName rr
 
@@ -572,21 +726,21 @@ addOpenProtoDiffRule ru@(DiffProtoRule _ (Just (lr, rr))) thy = do
 -- exists. Ignore _restrict construct.
 addProtoRule :: ProtoRuleE -> OpenTheory -> Maybe OpenTheory
 addProtoRule ruE thy = do
-    guard nameNotUsedForDifferentRule
-    return $ modify thyItems (++ [RuleItem (OpenProtoRule ruE [])]) thy
+  guard nameNotUsedForDifferentRule
+  return $ modify thyItems (++ [RuleItem (OpenProtoRule ruE [])]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True (ruE ==) $ fmap (L.get oprRuleE) $ lookupOpenProtoRule (L.get (preName . rInfo) ruE) thy
+      maybe True (ruE ==) $ fmap (L.get oprRuleE) $ lookupOpenProtoRule (L.get (preName . rInfo) ruE) thy
 
 -- | Add a new protocol rules. Fails, if a protocol rule with the same name
 -- exists.
 addProtoDiffRule :: ProtoRuleE -> OpenDiffTheory -> Maybe OpenDiffTheory
 addProtoDiffRule ruE thy = do
-    guard nameNotUsedForDifferentRule
-    return $ modify diffThyItems (++ [DiffRuleItem (DiffProtoRule ruE Nothing)]) thy
+  guard nameNotUsedForDifferentRule
+  return $ modify diffThyItems (++ [DiffRuleItem (DiffProtoRule ruE Nothing)]) thy
   where
     nameNotUsedForDifferentRule =
-        maybe True (ruE ==) $ fmap (L.get dprRule) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo) ruE) thy
+      maybe True (ruE ==) $ fmap (L.get dprRule) $ lookupOpenDiffProtoDiffRule (L.get (preName . rInfo) ruE) thy
 
 -- | Add intruder proof rules after Translate.
 addIntrRuleACsAfterTranslate :: [IntrRuleAC] -> OpenTranslatedTheory -> OpenTranslatedTheory
@@ -629,131 +783,163 @@ addIntrRuleACsDiffRight rs' thy = modify (diffThyCacheRight) (\rs -> nub $ rs ++
 -- strictly) for semantic equality; e.g., when testing the parser.
 normalizeTheory :: OpenTheory -> OpenTheory
 normalizeTheory =
-    L.modify thyCache sort
-  . L.modify thyItems (\items -> do
-      item <- items
-      return $ case item of
-          LemmaItem lem ->
+  L.modify thyCache sort
+    . L.modify
+      thyItems
+      ( \items -> do
+          item <- items
+          return $ case item of
+            LemmaItem lem ->
               LemmaItem $ L.modify lProof stripProofAnnotations $ lem
-          RuleItem _    -> item
-          TextItem _    -> item
-          ConfigBlockItem _ -> item
-          RestrictionItem _   -> item
-          TranslationItem _   -> item
-          PredicateItem _   -> item
-          MacroItem _ -> item
-          )
+            RuleItem _ -> item
+            TextItem _ -> item
+            ConfigBlockItem _ -> item
+            RestrictionItem _ -> item
+            TranslationItem _ -> item
+            PredicateItem _ -> item
+            MacroItem _ -> item
+      )
   where
     stripProofAnnotations :: ProofSkeleton -> ProofSkeleton
     stripProofAnnotations = fmap stripProofStepAnnotations
-    stripProofStepAnnotations (ProofStep method ()) = ProofStep
-      (case method of
-        Sorry _         -> Sorry Nothing
-        Finished (Contradictory _) -> Finished (Contradictory Nothing)
-        _               -> method)
-      ()
-
-
-
-
-
-
-
+    stripProofStepAnnotations (ProofStep method ()) =
+      ProofStep
+        ( case method of
+            Sorry _ -> Sorry Nothing
+            Finished (Contradictory _) -> Finished (Contradictory Nothing)
+            _ -> method
+        )
+        ()
 
 -- | Pretty print an open rule together with its assertion soundness proof.
-prettyOpenProtoRule :: HighlightDocument d => OpenProtoRule -> d
-prettyOpenProtoRule (OpenProtoRule ruE [])       = prettyProtoRuleE ruE
-prettyOpenProtoRule (OpenProtoRule _   [ruAC])   = prettyProtoRuleACasE ruAC
-prettyOpenProtoRule (OpenProtoRule ruE variants) = prettyProtoRuleE ruE $-$
-    nest 1 (kwVariants $-$ nest 1 (ppList prettyProtoRuleAC variants))
+prettyOpenProtoRule :: (HighlightDocument d) => OpenProtoRule -> d
+prettyOpenProtoRule (OpenProtoRule ruE []) = prettyProtoRuleE ruE
+prettyOpenProtoRule (OpenProtoRule _ [ruAC]) = prettyProtoRuleACasE ruAC
+prettyOpenProtoRule (OpenProtoRule ruE variants) =
+  prettyProtoRuleE ruE
+    $-$ nest 1 (kwVariants $-$ nest 1 (ppList prettyProtoRuleAC variants))
   where
-    ppList _  []     = emptyDoc
-    ppList pp [x]    = pp x
-    ppList pp (x:xr) = pp x $-$ comma $-$ ppList pp xr
+    ppList _ [] = emptyDoc
+    ppList pp [x] = pp x
+    ppList pp (x : xr) = pp x $-$ comma $-$ ppList pp xr
 
 -- | Pretty print an open rule together with its assertion soundness proof.
-prettyOpenProtoRuleAsClosedRule :: HighlightDocument d => OpenProtoRule -> d
-prettyOpenProtoRuleAsClosedRule (OpenProtoRule ruE [])
-    = prettyProtoRuleE ruE $--$
+prettyOpenProtoRuleAsClosedRule :: (HighlightDocument d) => OpenProtoRule -> d
+prettyOpenProtoRuleAsClosedRule (OpenProtoRule ruE []) =
+  prettyProtoRuleE ruE
+    $--$
     -- cannot show loop breakers here, as we do not have the information
-    (nest 2 $ emptyDoc $-$
-     multiComment_ ["has exactly the trivial AC variant"])
-prettyOpenProtoRuleAsClosedRule (OpenProtoRule _ [ruAC@(Rule (ProtoRuleACInfo _ _ (Disj disj) _) _ _ _ _)])
-    = prettyProtoRuleACasE ruAC $--$
-    (nest 2 $ prettyLoopBreakers (L.get rInfo ruAC) $-$
-     if length disj == 1 then
-       multiComment_ ["has exactly the trivial AC variant"]
-     else
-       multiComment $ prettyProtoRuleAC ruAC
+    ( nest 2 $
+        emptyDoc
+          $-$ multiComment_ ["has exactly the trivial AC variant"]
     )
-prettyOpenProtoRuleAsClosedRule (OpenProtoRule ruE variants) = prettyProtoRuleE ruE $-$
-    nest 1 (kwVariants $-$ nest 1 (ppList prettyProtoRuleAC variants))
+prettyOpenProtoRuleAsClosedRule (OpenProtoRule _ [ruAC@(Rule (ProtoRuleACInfo _ _ (Disj disj) _) _ _ _ _)]) =
+  prettyProtoRuleACasE ruAC
+    $--$ ( nest 2 $
+             prettyLoopBreakers (L.get rInfo ruAC)
+               $-$ if length disj == 1
+                 then multiComment_ ["has exactly the trivial AC variant"]
+                 else multiComment $ prettyProtoRuleAC ruAC
+         )
+prettyOpenProtoRuleAsClosedRule (OpenProtoRule ruE variants) =
+  prettyProtoRuleE ruE
+    $-$ nest 1 (kwVariants $-$ nest 1 (ppList prettyProtoRuleAC variants))
   where
-    ppList _  []     = emptyDoc
-    ppList pp [x]    = pp x
-    ppList pp (x:xr) = pp x $-$ comma $-$ ppList pp xr
+    ppList _ [] = emptyDoc
+    ppList pp [x] = pp x
+    ppList pp (x : xr) = pp x $-$ comma $-$ ppList pp xr
 
 -- | Pretty print a diff rule
-prettyDiffRule :: HighlightDocument d => DiffProtoRule -> d
-prettyDiffRule (DiffProtoRule ruE Nothing           ) = prettyProtoRuleE ruE
-prettyDiffRule (DiffProtoRule ruE (Just (ruL,  ruR))) = prettyProtoRuleE ruE $-$
-    nest 1
-    (kwLeft  $-$ nest 1 (prettyOpenProtoRule ruL) $-$
-     kwRight $-$ nest 1 (prettyOpenProtoRule ruR))
+prettyDiffRule :: (HighlightDocument d) => DiffProtoRule -> d
+prettyDiffRule (DiffProtoRule ruE Nothing) = prettyProtoRuleE ruE
+prettyDiffRule (DiffProtoRule ruE (Just (ruL, ruR))) =
+  prettyProtoRuleE ruE
+    $-$ nest
+      1
+      ( kwLeft
+          $-$ nest 1 (prettyOpenProtoRule ruL)
+          $-$ kwRight
+          $-$ nest 1 (prettyOpenProtoRule ruR)
+      )
 
 -- | Pretty print an either rule
-prettyEitherRule :: HighlightDocument d => (Side, OpenProtoRule) -> d
+prettyEitherRule :: (HighlightDocument d) => (Side, OpenProtoRule) -> d
 prettyEitherRule (_, p) = prettyProtoRuleE $ L.get oprRuleE p
 
-
-
-
 -- | Pretty print an open theory.
-prettyOpenTheory :: HighlightDocument d => OpenTheory -> d
+prettyOpenTheory :: (HighlightDocument d) => OpenTheory -> d
 prettyOpenTheory thy =
-    prettyTheory (prettySignaturePureExcept funsyms)
-                 (const emptyDoc) prettyOpenProtoRule prettyProof prettyTranslationElement thy
-                 -- prettyIntrVariantsSection prettyOpenProtoRule prettyProof
-                 where
-                    funsyms = S.fromList $ map fst' $ theoryFunctionTypingInfos thy
-                        -- function symbols that are printed by sapic printer already
-                    fst' (a,_,_) = a
+  prettyTheory
+    prettySignaturePure
+    (const emptyDoc)
+    prettyOpenProtoRule
+    prettyProof
+    prettyTranslationElement
+    thy
+  where
+    -- prettyIntrVariantsSection prettyOpenProtoRule prettyProof
+
+    funsyms = S.fromList $ map fst' $ theoryFunctionTypingInfos thy
+    -- function symbols that are printed by sapic printer already
+    fst' (a, _, _) = a
 
 -- | Pretty print an open theory.
-prettyOpenDiffTheory :: HighlightDocument d => OpenDiffTheory -> d
+prettyOpenDiffTheory :: (HighlightDocument d) => OpenDiffTheory -> d
 prettyOpenDiffTheory =
-    prettyDiffTheory prettySignaturePure
-                 (const emptyDoc) prettyEitherRule prettyDiffProof prettyProof
-                 -- prettyIntrVariantsSection prettyOpenProtoRule prettyProof
+  prettyDiffTheory
+    prettySignaturePure
+    (const emptyDoc)
+    prettyEitherRule
+    prettyDiffProof
+    prettyProof
+
+-- prettyIntrVariantsSection prettyOpenProtoRule prettyProof
 
 -- | Pretty print a translated Open Theory
-prettyOpenTranslatedTheory :: HighlightDocument d => OpenTranslatedTheory -> d
+prettyOpenTranslatedTheory :: (HighlightDocument d) => OpenTranslatedTheory -> d
 prettyOpenTranslatedTheory =
-    prettyTheory prettySignaturePure
-                 (const emptyDoc) prettyOpenProtoRule prettyProof emptyString
-
+  prettyTheory
+    prettySignaturePure
+    (const emptyDoc)
+    prettyOpenProtoRule
+    prettyProof
+    emptyString
 
 -- | Pretty print a diff theory.
-prettyDiffTheory :: HighlightDocument d
-                 => (sig -> d) -> (c -> d) -> ((Side, r2) -> d) -> (p -> d) -> (p2 -> d)
-                 -> DiffTheory sig c DiffProtoRule r2 p p2 -> d
-prettyDiffTheory ppSig ppCache ppRule ppDiffPrf ppPrf thy = vsep $
-    [ kwTheoryHeader $ text $ L.get diffThyName thy
-    , lineComment_ "Function signature and definition of the equational theory E"
-    , ppSig $ L.get diffThySignature thy
-    , if thyT == [] then text "" else vcat $ map prettyTactic thyT
-    , if thyH == [] then text "" else text "heuristic: " <> text (prettyGoalRankings thyH)
-    , prettyMacros $ diffTheoryMacros thy
-    , ppCache $ L.get diffThyCacheLeft thy
-    , ppCache $ L.get diffThyCacheRight thy
-    , ppCache $ L.get diffThyDiffCacheLeft thy
-    , ppCache $ L.get diffThyDiffCacheRight thy
-    ] ++
-    parMap rdeepseq ppItem (L.get diffThyItems thy) ++
-    [ kwEnd ]
+prettyDiffTheory ::
+  (HighlightDocument d) =>
+  (sig -> d) ->
+  (c -> d) ->
+  ((Side, r2) -> d) ->
+  (p -> d) ->
+  (p2 -> d) ->
+  DiffTheory sig c DiffProtoRule r2 p p2 ->
+  d
+prettyDiffTheory ppSig ppCache ppRule ppDiffPrf ppPrf thy =
+  vsep $
+    [ kwTheoryHeader $ text $ L.get diffThyName thy,
+      lineComment_ "Function signature and definition of the equational theory E",
+      ppSig $ L.get diffThySignature thy,
+      if thyT == [] then text "" else vcat $ map prettyTactic thyT,
+      if thyH == [] then text "" else text "heuristic: " <> text (prettyGoalRankings thyH),
+      prettyMacros $ diffTheoryMacros thy,
+      ppCache $ L.get diffThyCacheLeft thy,
+      ppCache $ L.get diffThyCacheRight thy,
+      ppCache $ L.get diffThyDiffCacheLeft thy,
+      ppCache $ L.get diffThyDiffCacheRight thy
+    ]
+      ++ parMap rdeepseq ppItem (L.get diffThyItems thy)
+      ++ [kwEnd]
   where
-    ppItem = foldDiffTheoryItem
-        prettyDiffRule ppRule (prettyDiffLemma ppDiffPrf) (prettyEitherLemma ppPrf) prettyEitherRestriction (const emptyDoc) (uncurry prettyFormalComment) prettyConfigBlock
+    ppItem =
+      foldDiffTheoryItem
+        prettyDiffRule
+        ppRule
+        (prettyDiffLemma ppDiffPrf)
+        (prettyEitherLemma ppPrf)
+        prettyEitherRestriction
+        (const emptyDoc)
+        (uncurry prettyFormalComment)
+        prettyConfigBlock
     thyH = L.get diffThyHeuristic thy
     thyT = L.get diffThyTactic thy
-

--- a/lib/theory/src/Theory/Model/Signature.hs
+++ b/lib/theory/src/Theory/Model/Signature.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DeriveDataTypeable   #-}
-{-# LANGUAGE DeriveFunctor        #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
 -- |
 -- Copyright   : (c) 2010-2012 Benedikt Schmidt & Simon Meier
 -- License     : GPL v3 (see LICENSE)
@@ -13,53 +15,45 @@
 -- Signatures for the terms and multiset rewriting rules used to model and
 -- reason about a security protocol.
 -- modulo the full Diffie-Hellman equational theory and once modulo AC.
-module Theory.Model.Signature (
+module Theory.Model.Signature
+  ( -- * Signature type
+    Signature (..),
 
-  -- * Signature type
-    Signature(..)
+    -- ** Pure signatures
+    SignaturePure,
+    emptySignaturePure,
+    sigpMaudeSig,
 
-  -- ** Pure signatures
-  , SignaturePure
-  , emptySignaturePure
-  , sigpMaudeSig
+    -- ** Using Maude to handle operations relative to a 'Signature'
+    SignatureWithMaude,
+    toSignatureWithMaude,
+    toSignaturePure,
+    sigmMaudeHandle,
 
-  -- ** Using Maude to handle operations relative to a 'Signature'
-  , SignatureWithMaude
-  , toSignatureWithMaude
-  , toSignaturePure
-  , sigmMaudeHandle
-
-  -- ** Pretty-printing
-  , prettySignaturePure
-  , prettySignaturePureExcept
-  , prettySignatureWithMaude
-
-  ) where
-
-import           Data.Binary
-import qualified Data.Label           as L
-import qualified Data.Set             as S
+    -- ** Pretty-printing
+    prettySignaturePure,
+    prettySignatureWithMaude,
+  )
+where
 
 -- import           Control.Applicative
-import           Control.DeepSeq
-
-import           System.IO.Unsafe     (unsafePerformIO)
-
-import           Term.Maude.Process   (MaudeHandle, mhFilePath, mhMaudeSig, startMaude)
-import           Term.Maude.Signature (MaudeSig, minimalMaudeSig, prettyMaudeSig, prettyMaudeSigExcept)
-import           Theory.Text.Pretty
-
+import Control.DeepSeq
+import Data.Binary
+import Data.Label qualified as L
+import Data.Set qualified as S
+import System.IO.Unsafe (unsafePerformIO)
 import Term.LTerm
-
+import Term.Maude.Process (MaudeHandle, mhFilePath, mhMaudeSig, startMaude)
+import Term.Maude.Signature (MaudeSig, minimalMaudeSig, prettyMaudeSig, prettyMaudeSigExcept)
+import Theory.Text.Pretty
 
 -- | A theory signature.
 data Signature a = Signature
-       { -- The signature of the message algebra
-         _sigMaudeInfo  :: a
-       }
+  { -- The signature of the message algebra
+    _sigMaudeInfo :: a
+  }
 
 $(L.mkLabels [''Signature])
-
 
 ------------------------------------------------------------------------------
 -- Pure Signatures
@@ -69,7 +63,7 @@ $(L.mkLabels [''Signature])
 type SignaturePure = Signature MaudeSig
 
 -- | Access the maude signature.
-sigpMaudeSig:: SignaturePure L.:-> MaudeSig
+sigpMaudeSig :: SignaturePure L.:-> MaudeSig
 sigpMaudeSig = sigMaudeInfo
 
 -- | The empty pure signature.
@@ -79,13 +73,15 @@ emptySignaturePure flag = Signature (minimalMaudeSig flag)
 -- Instances
 ------------
 
-deriving instance Eq       SignaturePure
-deriving instance Ord      SignaturePure
-deriving instance Show     SignaturePure
+deriving instance Eq SignaturePure
+
+deriving instance Ord SignaturePure
+
+deriving instance Show SignaturePure
 
 instance Binary SignaturePure where
-    put sig =  put (L.get sigMaudeInfo sig)
-    get     = Signature <$> get
+  put sig = put (L.get sigMaudeInfo sig)
+  get = Signature <$> get
 
 instance NFData SignaturePure where
   rnf (Signature y) = rnf y
@@ -102,23 +98,23 @@ sigmMaudeHandle :: SignatureWithMaude L.:-> MaudeHandle
 sigmMaudeHandle = sigMaudeInfo
 
 -- | Ensure that maude is running and configured with the current signature.
-toSignatureWithMaude :: FilePath            -- ^ Path to Maude executable.
-                     -> SignaturePure
-                     -> IO (SignatureWithMaude)
+toSignatureWithMaude ::
+  -- | Path to Maude executable.
+  FilePath ->
+  SignaturePure ->
+  IO (SignatureWithMaude)
 toSignatureWithMaude maudePath sig = do
-    hnd <- startMaude maudePath (L.get sigMaudeInfo sig)
-    return $ sig { _sigMaudeInfo = hnd }
-
+  hnd <- startMaude maudePath (L.get sigMaudeInfo sig)
+  return $ sig {_sigMaudeInfo = hnd}
 
 -- | The pure signature of a 'SignatureWithMaude'.
 toSignaturePure :: SignatureWithMaude -> SignaturePure
-toSignaturePure sig = sig { _sigMaudeInfo = mhMaudeSig $ L.get sigMaudeInfo sig }
+toSignaturePure sig = sig {_sigMaudeInfo = mhMaudeSig $ L.get sigMaudeInfo sig}
 
 {- TODO: There should be a finalizer in place such that as soon as the
    MaudeHandle is garbage collected, the appropriate command is sent to Maude
 
   The code below is a crutch and leads to unnecessary complication.
-
 
 -- | Stop the maude process. This operation is unsafe, as there still might be
 -- thunks that rely on the MaudeHandle to refer to a running Maude process.
@@ -149,11 +145,12 @@ instance Show SignatureWithMaude where
   show = show . toSignaturePure
 
 instance Binary SignatureWithMaude where
-    put sig@(Signature maude) = do
-        put (mhFilePath maude)
-        put (toSignaturePure sig)
-    -- FIXME: reload the right signature
-    get = unsafePerformIO <$> (toSignatureWithMaude <$> get <*> get)
+  put sig@(Signature maude) = do
+    put (mhFilePath maude)
+    put (toSignaturePure sig)
+
+  -- FIXME: reload the right signature
+  get = unsafePerformIO <$> (toSignatureWithMaude <$> get <*> get)
 
 instance NFData SignatureWithMaude where
   rnf (Signature _maude) = ()
@@ -163,19 +160,11 @@ instance NFData SignatureWithMaude where
 ------------------------------------------------------------------------------
 
 -- | Pretty-print a pure signature.
-prettySignaturePure :: HighlightDocument d => SignaturePure -> d
+prettySignaturePure :: (HighlightDocument d) => SignaturePure -> d
 prettySignaturePure sig =
-    prettyMaudeSig $ L.get sigpMaudeSig sig
-    
--- | Pretty-print a pure signature, but omit given set of
---   NoEqSym function symbols. Used for pretty-printing OpenTheories
---   with typed function declarations
-prettySignaturePureExcept :: HighlightDocument d => S.Set NoEqSym -> SignaturePure -> d
-prettySignaturePureExcept exc sig  =
-    prettyMaudeSigExcept (L.get sigpMaudeSig sig) exc
+  prettyMaudeSig $ L.get sigpMaudeSig sig
 
 -- | Pretty-print a signature with maude.
-prettySignatureWithMaude :: HighlightDocument d => SignatureWithMaude -> d
+prettySignatureWithMaude :: (HighlightDocument d) => SignatureWithMaude -> d
 prettySignatureWithMaude sig =
-    prettyMaudeSig $ mhMaudeSig $ L.get sigmMaudeHandle sig
-
+  prettyMaudeSig $ mhMaudeSig $ L.get sigmMaudeHandle sig

--- a/lib/theory/src/TheoryObject.hs
+++ b/lib/theory/src/TheoryObject.hs
@@ -1,470 +1,476 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-module TheoryObject (
-   module Lemma
-  , module Items.OptionItem
-  , module Items.ProcessItem
-  , module Items.TheoryItem
-  , module Items.CaseTestItem
-  , module Items.AccLemmaItem
-  , LemmaAttribute(..)
-  , TraceQuantifier(..)
-  , ProtoLemma(..)
-  , Theory(..)
-  , DiffTheory(..)
-  , TheoryItem(..)
-  , DiffTheoryItem(..)
-  , thyName
-  , thyInFile
-  , thySignature
-  , thyCache
-  , thyItems
-  , thyOptions
-  , thyIsSapic
-  , diffThyName
-  , diffThyInFile
-  , diffThyItems
-  , diffThySignature
-  , diffThyCacheLeft
-  , diffThyCacheRight
-  , diffThyDiffCacheLeft
-  , diffThyDiffCacheRight
-  , diffThyOptions
-  , diffThyIsSapic
-  , thyHeuristic
-  , diffThyHeuristic
-  , thyTactic
-  , diffThyTactic
-  , DiffLemma(..)
-  , ProcessDef(..)
-  , Predicate(..)
-  , Option(..)
-  , TranslationElement (..)
-  , TranslationElement (..)
-  , foldDiffTheoryItem
-  , mapTheoryItem
-  , mapDiffTheoryItem
-  , theoryRules
-  , diffTheoryDiffRules
-  , diffTheorySideRules
-  , leftTheoryRules
-  , rightTheoryRules
-  , theoryRestrictions
-  , theoryLemmas
-  , theoryProcesses
-  , theoryProcessDefs
-  , theoryPredicates
-  , theoryMacros
-  , theoryFormalComments
-  , diffTheoryRestrictions
-  , diffTheorySideRestrictions
-  , diffTheoryLemmas
-  , diffTheorySideLemmas
-  , diffTheoryDiffLemmas
-  , theoryConfigBlock
-  , diffTheoryConfigBlock
-  , diffTheoryMacros
-  , diffTheoryFormalComments
-  , expandFormula
-  , expandRestriction
-  , expandLemma
-  , addRestriction
-  , addLemma
-  , addLemmaAtIndex
-  , modifyLemma
-  , addProcess
-  , findProcess
-  , addProcessDef
-  , addPredicate
-  , setOption
-  , addRestrictionDiff
-  , addLemmaDiff
-  , addDiffLemma
-  , addHeuristic
-  , addDiffHeuristic
-  , addTactic
-  , addDiffTactic
-  , addMacros
-  , addDiffMacros
-  , removeLemma
-  , removeLemmaDiff
-  , removeDiffLemma
-  , addComment
-  , addDiffComment
-  , addStringComment
-  , addFormalComment
-  , addFormalCommentDiff
-  , isRuleItem
-  , itemToRule
-  , foldTheoryItem
-  , lookupDiffLemma
-  , lookupLemmaDiff
-  , lookupLemma
-  , lookupLemmaIndex
-  , getLemmaPreItems
-  , lookupProcessDef
-  , filterSide
-  , mapMProcesses
-  , mapMProcessesDef
-  , theoryFunctionTypingInfos
-  , theoryBuiltins
-  , theoryExportInfos
-  , theoryEquivLemmas
-  , theoryDiffEquivLemmas
-  , addFunctionTypingInfo
-  , clearFunctionTypingInfos
-  , addExportInfo
-  , setforcedInjectiveFacts
-  , filterLemma
-  , lookupFunctionTypingInfo
-  , prettyTheory
-  , prettyMacros
-  , prettyTranslationElement
-  , prettyProcessDef
-  , prettyEitherRestriction
-  , lookupExportInfo
-  , prettyRestriction
-  , prettyProcess
-  , prettyTactic
-  , prettyVarList
-  , prettyConfigBlock
-  , theoryCaseTests
-  , theoryAccLemmas
-  , addAccLemma
-  , addCaseTest
-  , lookupAccLemma
-  , lookupCaseTest
-  ) where
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE TemplateHaskell #-}
 
---import Theory.Constraint.Solver.Heuristics
+module TheoryObject
+  ( module Lemma,
+    module Items.OptionItem,
+    module Items.ProcessItem,
+    module Items.TheoryItem,
+    module Items.CaseTestItem,
+    module Items.AccLemmaItem,
+    LemmaAttribute (..),
+    TraceQuantifier (..),
+    ProtoLemma (..),
+    Theory (..),
+    DiffTheory (..),
+    TheoryItem (..),
+    DiffTheoryItem (..),
+    thyName,
+    thyInFile,
+    thySignature,
+    thyCache,
+    thyItems,
+    thyOptions,
+    thyIsSapic,
+    diffThyName,
+    diffThyInFile,
+    diffThyItems,
+    diffThySignature,
+    diffThyCacheLeft,
+    diffThyCacheRight,
+    diffThyDiffCacheLeft,
+    diffThyDiffCacheRight,
+    diffThyOptions,
+    diffThyIsSapic,
+    thyHeuristic,
+    diffThyHeuristic,
+    thyTactic,
+    diffThyTactic,
+    DiffLemma (..),
+    ProcessDef (..),
+    Predicate (..),
+    Option (..),
+    TranslationElement (..),
+    TranslationElement (..),
+    foldDiffTheoryItem,
+    mapTheoryItem,
+    mapDiffTheoryItem,
+    theoryRules,
+    diffTheoryDiffRules,
+    diffTheorySideRules,
+    leftTheoryRules,
+    rightTheoryRules,
+    theoryRestrictions,
+    theoryLemmas,
+    theoryProcesses,
+    theoryProcessDefs,
+    theoryPredicates,
+    theoryMacros,
+    theoryFormalComments,
+    diffTheoryRestrictions,
+    diffTheorySideRestrictions,
+    diffTheoryLemmas,
+    diffTheorySideLemmas,
+    diffTheoryDiffLemmas,
+    theoryConfigBlock,
+    diffTheoryConfigBlock,
+    diffTheoryMacros,
+    diffTheoryFormalComments,
+    expandFormula,
+    expandRestriction,
+    expandLemma,
+    addRestriction,
+    addLemma,
+    addLemmaAtIndex,
+    modifyLemma,
+    addProcess,
+    findProcess,
+    addProcessDef,
+    addPredicate,
+    setOption,
+    addRestrictionDiff,
+    addLemmaDiff,
+    addDiffLemma,
+    addHeuristic,
+    addDiffHeuristic,
+    addTactic,
+    addDiffTactic,
+    addMacros,
+    addDiffMacros,
+    removeLemma,
+    removeLemmaDiff,
+    removeDiffLemma,
+    addComment,
+    addDiffComment,
+    addStringComment,
+    addFormalComment,
+    addFormalCommentDiff,
+    isRuleItem,
+    itemToRule,
+    foldTheoryItem,
+    lookupDiffLemma,
+    lookupLemmaDiff,
+    lookupLemma,
+    lookupLemmaIndex,
+    getLemmaPreItems,
+    lookupProcessDef,
+    filterSide,
+    mapMProcesses,
+    mapMProcessesDef,
+    theoryFunctionTypingInfos,
+    theoryBuiltins,
+    theoryExportInfos,
+    theoryEquivLemmas,
+    theoryDiffEquivLemmas,
+    addFunctionTypingInfo,
+    clearFunctionTypingInfos,
+    addExportInfo,
+    setforcedInjectiveFacts,
+    filterLemma,
+    lookupFunctionTypingInfo,
+    prettyTheory,
+    prettyMacros,
+    prettyTranslationElement,
+    prettyProcessDef,
+    prettyEitherRestriction,
+    lookupExportInfo,
+    prettyRestriction,
+    prettyProcess,
+    prettyTactic,
+    prettyVarList,
+    prettyConfigBlock,
+    theoryCaseTests,
+    theoryAccLemmas,
+    addAccLemma,
+    addCaseTest,
+    lookupAccLemma,
+    lookupCaseTest,
+  )
+where
+
+-- import Theory.Constraint.Solver.Heuristics
+
+import Control.Basics
+import Control.Category
+import Control.Parallel.Strategies
+import Data.Binary
+import Data.ByteString.Char8 (unpack)
+import Data.ByteString.Char8 qualified as BC
 import Data.Label as L
-import Theory.Model.Restriction
-import Theory.Model.Fact
-import Term.LTerm
-import Term.Macro
-import Theory.Constraint.Solver
-
+import Data.Label.Poly qualified
+import Data.Label.Total qualified as Data.Label.Point
+import Data.List
+import Data.Maybe
+import Data.Set qualified as S
+import GHC.Generics
+import Items.AccLemmaItem
+import Items.CaseTestItem
+import Items.ExportInfo
 import Items.OptionItem
 import Items.ProcessItem
 import Items.TheoryItem
-import Items.CaseTestItem
-import Items.AccLemmaItem
 import Lemma
-import qualified Data.Label.Poly
-import qualified Data.Label.Total as Data.Label.Point
-import qualified Data.ByteString.Char8      as BC
-
-
-import           Prelude                             hiding (id, (.))
-
-import           Data.List
-import           Data.Maybe
-
-import           Control.Basics
-import           Control.Category
-
-import           Theory.Model
-
-import           Theory.Text.Pretty
-
-import           Prelude                             hiding (id, (.))
-
 import Pretty
-import Theory.Sapic.Print
-import Control.Parallel.Strategies
-import GHC.Generics
-import Data.Binary
+import Term.LTerm
+import Term.Macro
+import Theory.Constraint.Solver
+import Theory.Model
 import Theory.Sapic
-import Items.ExportInfo
-import qualified Data.Set as S
+import Theory.Sapic.Print
 import Theory.Syntactic.Predicate
-import Data.ByteString.Char8 (unpack)
+import Theory.Text.Pretty
+import Prelude hiding (id, (.))
 
 -- | A theory contains a single set of rewriting rules modeling a protocol
 -- and the lemmas that
-data Theory sig c r p s = Theory {
-         _thyName      :: String
-       , _thyInFile    :: String
-       , _thyHeuristic :: [GoalRanking ProofContext]
-       , _thyTactic    :: [Tactic ProofContext]
-       , _thySignature :: sig
-       , _thyCache     :: c
-       , _thyItems     :: [TheoryItem r p s]
-       , _thyOptions   :: Option
-       , _thyIsSapic   :: Bool
-       }
-       deriving( Eq, Ord, Show, Generic, NFData, Binary )
+data Theory sig c r p s = Theory
+  { _thyName :: String,
+    _thyInFile :: String,
+    _thyHeuristic :: [GoalRanking ProofContext],
+    _thyTactic :: [Tactic ProofContext],
+    _thySignature :: sig,
+    _thyCache :: c,
+    _thyItems :: [TheoryItem r p s],
+    _thyOptions :: Option,
+    _thyIsSapic :: Bool
+  }
+  deriving (Eq, Ord, Show, Generic, NFData, Binary)
 
 $(mkLabels [''Theory])
 
-
 -- | A diff theory contains a set of rewriting rules with diff modeling two instances
-data DiffTheory sig c r r2 p p2 = DiffTheory {
-         _diffThyName           :: String
-       , _diffThyInFile         :: String
-       , _diffThyHeuristic      :: [GoalRanking ProofContext]
-       , _diffThyTactic        :: [Tactic ProofContext]
-       , _diffThySignature      :: sig
-       , _diffThyCacheLeft      :: c
-       , _diffThyCacheRight     :: c
-       , _diffThyDiffCacheLeft  :: c
-       , _diffThyDiffCacheRight :: c
-       , _diffThyItems          :: [DiffTheoryItem r r2 p p2]
-       , _diffThyOptions        :: Option
-       , _diffThyIsSapic        :: Bool
-       }
-       deriving( Eq, Ord, Show, Generic, NFData, Binary )
-$(mkLabels [''DiffTheory])
+data DiffTheory sig c r r2 p p2 = DiffTheory
+  { _diffThyName :: String,
+    _diffThyInFile :: String,
+    _diffThyHeuristic :: [GoalRanking ProofContext],
+    _diffThyTactic :: [Tactic ProofContext],
+    _diffThySignature :: sig,
+    _diffThyCacheLeft :: c,
+    _diffThyCacheRight :: c,
+    _diffThyDiffCacheLeft :: c,
+    _diffThyDiffCacheRight :: c,
+    _diffThyItems :: [DiffTheoryItem r r2 p p2],
+    _diffThyOptions :: Option,
+    _diffThyIsSapic :: Bool
+  }
+  deriving (Eq, Ord, Show, Generic, NFData, Binary)
 
+$(mkLabels [''DiffTheory])
 
 -- Shared theory modification functions
 ---------------------------------------
 
 filterSide :: Side -> [(Side, a)] -> [a]
 filterSide s l = case l of
-                    x:xs -> if (fst x) == s then (snd x):(filterSide s xs) else (filterSide s xs)
-                    []   -> []
+  x : xs -> if (fst x) == s then (snd x) : (filterSide s xs) else (filterSide s xs)
+  [] -> []
 
 -- | Fold a theory item.
-foldTheoryItem
-    :: (r -> a) -> (Restriction -> a) -> (Lemma p -> a) -> (FormalComment -> a) -> (ConfigBlock -> a) -> (Predicate -> a) -> ([Macro] -> a) -> (s -> a)
-    -> TheoryItem r p s -> a
-foldTheoryItem fRule fRestriction fLemma fText  fConfigBlock fPredicate fMacroItem fTranslationItem i = case i of
-    RuleItem ru   -> fRule ru
-    LemmaItem lem -> fLemma lem
-    TextItem txt  -> fText txt
-    ConfigBlockItem b -> fConfigBlock b
-    RestrictionItem rstr  -> fRestriction rstr
-    PredicateItem     p  -> fPredicate p
-    MacroItem m -> fMacroItem m
-    TranslationItem s -> fTranslationItem s
+foldTheoryItem ::
+  (r -> a) ->
+  (Restriction -> a) ->
+  (Lemma p -> a) ->
+  (FormalComment -> a) ->
+  (ConfigBlock -> a) ->
+  (Predicate -> a) ->
+  ([Macro] -> a) ->
+  (s -> a) ->
+  TheoryItem r p s ->
+  a
+foldTheoryItem fRule fRestriction fLemma fText fConfigBlock fPredicate fMacroItem fTranslationItem i = case i of
+  RuleItem ru -> fRule ru
+  LemmaItem lem -> fLemma lem
+  TextItem txt -> fText txt
+  ConfigBlockItem b -> fConfigBlock b
+  RestrictionItem rstr -> fRestriction rstr
+  PredicateItem p -> fPredicate p
+  MacroItem m -> fMacroItem m
+  TranslationItem s -> fTranslationItem s
 
 -- | Fold a theory item.
-foldDiffTheoryItem
-    :: (r -> a) -> ((Side, r2) -> a) -> (DiffLemma p -> a) -> ((Side, Lemma p2) -> a) -> ((Side, Restriction) -> a) -> ([Macro] -> a) -> (FormalComment -> a) -> (ConfigBlock -> a)
-    -> DiffTheoryItem r r2 p p2 -> a
+foldDiffTheoryItem ::
+  (r -> a) ->
+  ((Side, r2) -> a) ->
+  (DiffLemma p -> a) ->
+  ((Side, Lemma p2) -> a) ->
+  ((Side, Restriction) -> a) ->
+  ([Macro] -> a) ->
+  (FormalComment -> a) ->
+  (ConfigBlock -> a) ->
+  DiffTheoryItem r r2 p p2 ->
+  a
 foldDiffTheoryItem fDiffRule fEitherRule fDiffLemma fEitherLemma fRestriction fMacroItem fText fConfigBlock i = case i of
-    DiffRuleItem ru   -> fDiffRule ru
-    EitherRuleItem (side, ru) -> fEitherRule (side, ru)
-    DiffLemmaItem lem -> fDiffLemma lem
-    EitherLemmaItem (side, lem) -> fEitherLemma (side, lem)
-    EitherRestrictionItem (side, rstr)  -> fRestriction (side, rstr)
-    DiffMacroItem m -> fMacroItem m
-    DiffTextItem txt  -> fText txt
-    DiffConfigBlockItem b -> fConfigBlock b
+  DiffRuleItem ru -> fDiffRule ru
+  EitherRuleItem (side, ru) -> fEitherRule (side, ru)
+  DiffLemmaItem lem -> fDiffLemma lem
+  EitherLemmaItem (side, lem) -> fEitherLemma (side, lem)
+  EitherRestrictionItem (side, rstr) -> fRestriction (side, rstr)
+  DiffMacroItem m -> fMacroItem m
+  DiffTextItem txt -> fText txt
+  DiffConfigBlockItem b -> fConfigBlock b
 
 -- | Map a theory item.
 mapTheoryItem :: (r -> r') -> (p -> p') -> TheoryItem r p s -> TheoryItem r' p' s
 mapTheoryItem f g =
-    foldTheoryItem (RuleItem . f) RestrictionItem (LemmaItem . fmap g) TextItem ConfigBlockItem PredicateItem MacroItem TranslationItem
+  foldTheoryItem (RuleItem . f) RestrictionItem (LemmaItem . fmap g) TextItem ConfigBlockItem PredicateItem MacroItem TranslationItem
 
 -- | Map a diff theory item.
 mapDiffTheoryItem :: (r -> r') -> ((Side, r2) -> (Side, r2')) -> (DiffLemma p -> DiffLemma p') -> ((Side, Lemma p2) -> (Side, Lemma p2')) -> DiffTheoryItem r r2 p p2 -> DiffTheoryItem r' r2' p' p2'
 mapDiffTheoryItem f g h i =
-    foldDiffTheoryItem (DiffRuleItem . f) (EitherRuleItem . g) (DiffLemmaItem . h) (EitherLemmaItem . i) EitherRestrictionItem DiffMacroItem DiffTextItem DiffConfigBlockItem
+  foldDiffTheoryItem (DiffRuleItem . f) (EitherRuleItem . g) (DiffLemmaItem . h) (EitherLemmaItem . i) EitherRestrictionItem DiffMacroItem DiffTextItem DiffConfigBlockItem
 
 -- | Map a process
-mapMProcesses :: Monad m => (PlainProcess -> m(PlainProcess)) -> Theory sig c r p TranslationElement -> m (Theory sig c r p TranslationElement)
+mapMProcesses :: (Monad m) => (PlainProcess -> m (PlainProcess)) -> Theory sig c r p TranslationElement -> m (Theory sig c r p TranslationElement)
 mapMProcesses f thy = do
-        itms' <- mapM f' itms
-        return $ L.set thyItems itms' thy
-    where
-        itms =  L.get thyItems thy
-        f' (TranslationItem (ProcessItem p)) = TranslationItem . ProcessItem <$> f p
-        f' (TranslationItem (DiffEquivLemma p)) = TranslationItem . DiffEquivLemma <$> f p
-        f' (TranslationItem (EquivLemma p1 p2)) = do
-          fp1 <- f p1
-          fp2 <- f p2
-          return $ TranslationItem (EquivLemma fp1 fp2)
-        f' other                       = return other
-
+  itms' <- mapM f' itms
+  return $ L.set thyItems itms' thy
+  where
+    itms = L.get thyItems thy
+    f' (TranslationItem (ProcessItem p)) = TranslationItem . ProcessItem <$> f p
+    f' (TranslationItem (DiffEquivLemma p)) = TranslationItem . DiffEquivLemma <$> f p
+    f' (TranslationItem (EquivLemma p1 p2)) = do
+      fp1 <- f p1
+      fp2 <- f p2
+      return $ TranslationItem (EquivLemma fp1 fp2)
+    f' other = return other
 
 -- | Map a process definition
-mapMProcessesDef :: Monad m => (ProcessDef -> m(ProcessDef)) -> Theory sig c r p TranslationElement -> m (Theory sig c r p TranslationElement)
+mapMProcessesDef :: (Monad m) => (ProcessDef -> m (ProcessDef)) -> Theory sig c r p TranslationElement -> m (Theory sig c r p TranslationElement)
 mapMProcessesDef f thy = do
-        itms' <- mapM f' itms
-        return $ L.set thyItems itms' thy
-    where
-        itms =  L.get thyItems thy
-        f' (TranslationItem (ProcessDefItem p)) = TranslationItem . ProcessDefItem <$> f p
-        f' other                       = return other
+  itms' <- mapM f' itms
+  return $ L.set thyItems itms' thy
+  where
+    itms = L.get thyItems thy
+    f' (TranslationItem (ProcessDefItem p)) = TranslationItem . ProcessDefItem <$> f p
+    f' other = return other
 
 -- | All rules of a theory.
 theoryRules :: Theory sig c r p s -> [r]
 theoryRules =
-    foldTheoryItem return (const []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get thyItems
+  foldTheoryItem return (const []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get thyItems
 
 -- | All diff rules of a theory.
 diffTheoryDiffRules :: DiffTheory sig c r r2 p p2 -> [r]
 diffTheoryDiffRules =
-    foldDiffTheoryItem return (const []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem return (const []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | All rules of a theory.
 diffTheorySideRules :: Side -> DiffTheory sig c r r2 p p2 -> [r2]
 diffTheorySideRules s =
-    foldDiffTheoryItem (const []) (\(x, y) -> if (x == s) then [y] else []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (\(x, y) -> if (x == s) then [y] else []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | All left rules of a theory.
 leftTheoryRules :: DiffTheory sig c r r2 p p2 -> [r2]
 leftTheoryRules =
-    foldDiffTheoryItem (const []) (\(x, y) -> if (x == LHS) then [y] else []) (const []) (const []) (const [])  (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (\(x, y) -> if (x == LHS) then [y] else []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | All right rules of a theory.
 rightTheoryRules :: DiffTheory sig c r r2 p p2 -> [r2]
 rightTheoryRules =
-    foldDiffTheoryItem (const []) (\(x, y) -> if (x == RHS) then [y] else []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (\(x, y) -> if (x == RHS) then [y] else []) (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
--- | All macros of a theory.
+-- |  All macros of a theory.
 theoryMacros :: Theory sig c r p s -> [Macro]
 theoryMacros =
-    foldTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) (\m -> m) (const []) <=< L.get thyItems
+  foldTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) (\m -> m) (const []) <=< L.get thyItems
 
--- | All formal comments of a theory.
+-- |  All formal comments of a theory.
 theoryFormalComments :: Theory sig c r p s -> [FormalComment]
 theoryFormalComments =
-    foldTheoryItem (const []) (const []) (const []) return (const []) (const []) (const []) (const []) <=< L.get thyItems
+  foldTheoryItem (const []) (const []) (const []) return (const []) (const []) (const []) (const []) <=< L.get thyItems
 
 -- | All restrictions of a theory.
 theoryRestrictions :: Theory sig c r p s -> [Restriction]
 theoryRestrictions =
-    foldTheoryItem (const []) return (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get thyItems
+  foldTheoryItem (const []) return (const []) (const []) (const []) (const []) (const []) (const []) <=< L.get thyItems
 
 -- | All lemmas of a theory.
 theoryLemmas :: Theory sig c r p s -> [Lemma p]
 theoryLemmas =
-    foldTheoryItem (const []) (const []) return (const []) (const []) (const []) (const []) (const []) <=< L.get thyItems
+  foldTheoryItem (const []) (const []) return (const []) (const []) (const []) (const []) (const []) <=< L.get thyItems
 
 translationElements :: Theory sig c1 b p c2 -> [c2]
 translationElements = foldTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) (const []) return <=< L.get thyItems
 
 -- | All CaseTest definitions of a theory.
 theoryCaseTests :: Theory sig c r p TranslationElement -> [CaseTest]
-theoryCaseTests t = [ i | CaseTestItem i <- translationElements t]
+theoryCaseTests t = [i | CaseTestItem i <- translationElements t]
 
 -- | All AccLemmas definitions of a theory.
 theoryAccLemmas :: Theory sig c r p TranslationElement -> [AccLemma]
-theoryAccLemmas t =  [ i | AccLemmaItem i <- translationElements t]
+theoryAccLemmas t = [i | AccLemmaItem i <- translationElements t]
 
 -- | All processes of a theory (TODO give warning if there is more than one...)
 theoryProcesses :: Theory sig c r p TranslationElement -> [PlainProcess]
-theoryProcesses t = [ i | ProcessItem i <- translationElements t]
+theoryProcesses t = [i | ProcessItem i <- translationElements t]
 
 -- | All process definitions of a theory.
 theoryProcessDefs :: Theory sig c r p TranslationElement -> [ProcessDef]
-theoryProcessDefs t = [ i | ProcessDefItem i <- translationElements t]
+theoryProcessDefs t = [i | ProcessDefItem i <- translationElements t]
 
 -- | All function typing information in a theory.
 theoryFunctionTypingInfos :: Theory sig c r p TranslationElement -> [SapicFunSym]
-theoryFunctionTypingInfos t = [ i | FunctionTypingInfo i <- translationElements t]
+theoryFunctionTypingInfos t = [i | FunctionTypingInfo i <- translationElements t]
 
 -- | All process definitions of a theory.
 theoryPredicates :: Theory sig c r p s -> [Predicate]
-theoryPredicates =  foldTheoryItem (const []) (const []) (const []) (const []) (const []) return (const []) (const []) <=< L.get thyItems
+theoryPredicates = foldTheoryItem (const []) (const []) (const []) (const []) (const []) return (const []) (const []) <=< L.get thyItems
 
 -- | All export info definitions of a theory.
 theoryExportInfos :: Theory sig c b p TranslationElement -> [ExportInfo]
-theoryExportInfos t = [ i | ExportInfoItem i <- translationElements t]
+theoryExportInfos t = [i | ExportInfoItem i <- translationElements t]
 
 -- | All Builtins of a theory
 theoryBuiltins :: Theory sig c r p TranslationElement -> [String]
-theoryBuiltins t = [ i | SignatureBuiltin i <- translationElements t]
+theoryBuiltins t = [i | SignatureBuiltin i <- translationElements t]
 
 -- | All Equivalence queries of a theory
 theoryEquivLemmas :: Theory sig c r p TranslationElement -> [(PlainProcess, PlainProcess)]
-theoryEquivLemmas t =  [ (p1,p2) | EquivLemma p1 p2 <- translationElements t]
+theoryEquivLemmas t = [(p1, p2) | EquivLemma p1 p2 <- translationElements t]
 
 -- | All Equivalence queries of a theory
 theoryDiffEquivLemmas :: Theory sig c r p TranslationElement -> [PlainProcess]
-theoryDiffEquivLemmas t =  [ p | DiffEquivLemma p <- translationElements t]
+theoryDiffEquivLemmas t = [p | DiffEquivLemma p <- translationElements t]
 
 -- | All restrictions of a theory.
 diffTheoryRestrictions :: DiffTheory sig c r r2 p p2 -> [(Side, Restriction)]
 diffTheoryRestrictions =
-    foldDiffTheoryItem (const []) (const []) (const []) (const []) return (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) (const []) (const []) return (const []) (const []) (const []) <=< L.get diffThyItems
 
--- | All macros of a diff theory.
+-- |  All macros of a diff theory.
 diffTheoryMacros :: DiffTheory sig c r r2 p p2 -> [Macro]
 diffTheoryMacros =
-    foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (\m -> m) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (\m -> m) (const []) (const []) <=< L.get diffThyItems
 
--- | All formal comments of a diff theory.
+-- |  All formal comments of a diff theory.
 diffTheoryFormalComments :: DiffTheory sig c r r2 p p2 -> [FormalComment]
 diffTheoryFormalComments =
-    foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) return (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) return (const []) <=< L.get diffThyItems
 
 -- | All restrictions of one side of a theory.
 diffTheorySideRestrictions :: Side -> DiffTheory sig c r r2 p p2 -> [Restriction]
 diffTheorySideRestrictions s =
-    foldDiffTheoryItem (const []) (const []) (const []) (const []) (\(x, y) -> if (x == s) then [y] else []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) (const []) (const []) (\(x, y) -> if (x == s) then [y] else []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | All lemmas of a theory.
 diffTheoryLemmas :: DiffTheory sig c r r2 p p2 -> [(Side, Lemma p2)]
 diffTheoryLemmas =
-   foldDiffTheoryItem (const []) (const []) (const []) return (const []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) (const []) return (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | All lemmas of a theory.
 diffTheorySideLemmas :: Side -> DiffTheory sig c r r2 p p2 -> [Lemma p2]
 diffTheorySideLemmas s =
-    foldDiffTheoryItem (const []) (const []) (const []) (\(x, y) -> if (x == s) then [y] else []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) (const []) (\(x, y) -> if (x == s) then [y] else []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | All lemmas of a theory.
 diffTheoryDiffLemmas :: DiffTheory sig c r r2 p p2 -> [DiffLemma p]
 diffTheoryDiffLemmas =
-    foldDiffTheoryItem (const []) (const []) return (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
+  foldDiffTheoryItem (const []) (const []) return (const []) (const []) (const []) (const []) (const []) <=< L.get diffThyItems
 
 -- | The configuration block of a theory.
 theoryConfigBlock :: Theory sig c r p s -> ConfigBlock
-theoryConfigBlock = foldTheoryItem (const[]) (const[]) (const[]) (const[]) id (const[]) (const[]) (const []) <=< L.get thyItems
+theoryConfigBlock = foldTheoryItem (const []) (const []) (const []) (const []) id (const []) (const []) (const []) <=< L.get thyItems
 
 -- | The configuration block of a theory.
 diffTheoryConfigBlock :: DiffTheory sig c r r2 p p2 -> ConfigBlock
-diffTheoryConfigBlock = foldDiffTheoryItem (const[]) (const[]) (const[]) (const[]) (const[]) (const[]) (const[]) id <=< L.get diffThyItems
+diffTheoryConfigBlock = foldDiffTheoryItem (const []) (const []) (const []) (const []) (const []) (const []) (const []) id <=< L.get diffThyItems
 
-expandRestriction :: Theory sig c r p s -> ProtoRestriction SyntacticLNFormula
-    -> Either FactTag (ProtoRestriction LNFormula)
-expandRestriction thy (Restriction n f) =  Restriction n <$> expandFormula (theoryPredicates thy) f
+expandRestriction ::
+  Theory sig c r p s ->
+  ProtoRestriction SyntacticLNFormula ->
+  Either FactTag (ProtoRestriction LNFormula)
+expandRestriction thy (Restriction n f) = Restriction n <$> expandFormula (theoryPredicates thy) f
 
-
-expandLemma :: Theory sig c r p1 s
-               -> ProtoLemma SyntacticLNFormula p2
-               -> Either FactTag (ProtoLemma LNFormula p2)
-expandLemma thy (Lemma n u m tq f a p) =  (\f' -> Lemma n u m tq f' a p) <$> expandFormula (theoryPredicates thy) f
-
+expandLemma ::
+  Theory sig c r p1 s ->
+  ProtoLemma SyntacticLNFormula p2 ->
+  Either FactTag (ProtoLemma LNFormula p2)
+expandLemma thy (Lemma n u m tq f a p) = (\f' -> Lemma n u m tq f' a p) <$> expandFormula (theoryPredicates thy) f
 
 -- | Add a new restriction. Fails, if restriction with the same name exists.
 addRestriction :: Restriction -> Theory sig c r p s -> Maybe (Theory sig c r p s)
 addRestriction l thy = do
-    guard (isNothing $ lookupRestriction (L.get rstrName l) thy)
-    return $ modify thyItems (++ [RestrictionItem l]) thy
+  guard (isNothing $ lookupRestriction (L.get rstrName l) thy)
+  return $ modify thyItems (++ [RestrictionItem l]) thy
 
 -- | Add a new lemma. Fails, if a lemma with the same name exists.
 addLemma :: Lemma p -> Theory sig c r p s -> Maybe (Theory sig c r p s)
 addLemma l thy = do
-    guard (isNothing $ lookupLemma (L.get lName l) thy)
-    return $ modify thyItems (++ [LemmaItem l]) thy
+  guard (isNothing $ lookupLemma (L.get lName l) thy)
+  return $ modify thyItems (++ [LemmaItem l]) thy
 
 -- | Add a new lemma at a specific index. Fails, if a lemma with the same name exists.
 addLemmaAtIndex :: Lemma p -> Int -> Theory sig c r p s -> Maybe (Theory sig c r p s)
 addLemmaAtIndex l i thy = do
-    guard (isNothing $ lookupLemma (L.get lName l) thy)
-    return $ modify thyItems (\ls -> (take i ls) ++ [LemmaItem l] ++ (drop i ls)) thy
-
-
+  guard (isNothing $ lookupLemma (L.get lName l) thy)
+  return $ modify thyItems (\ls -> (take i ls) ++ [LemmaItem l] ++ (drop i ls)) thy
 
 -- | apply function on lemmas, temporary test
 modifyLemma :: (Lemma p -> Lemma p) -> Theory sig c r p s -> Maybe (Theory sig c r p s)
 modifyLemma f thy = do
-    return $ modify thyItems (map mlemma) thy
+  return $ modify thyItems (map mlemma) thy
   where
     mlemma (LemmaItem l) = (LemmaItem (f l))
-    mlemma i             = i
-
-addProcess :: PlainProcess -> Theory sig c r p TranslationElement -> Theory sig c r p TranslationElement
-addProcess l = modify thyItems (++ [TranslationItem (ProcessItem l)])
+    mlemma i = i
 
 -- | Add a new process expression.  Since expression (and not definitions)
 -- could appear several times, checking for doubled occurrence isn't necessary
+addProcess :: PlainProcess -> Theory sig c r p TranslationElement -> Theory sig c r p TranslationElement
+addProcess l = modify thyItems (++ [TranslationItem (ProcessItem l)])
+
+-- | Add function typing info to a theory
 addFunctionTypingInfo :: SapicFunSym -> Theory sig c r p TranslationElement -> Theory sig c r p TranslationElement
 addFunctionTypingInfo l = modify thyItems (++ [TranslationItem $ FunctionTypingInfo l])
 
@@ -481,19 +487,19 @@ clearFunctionTypingInfos :: Theory sig c r p TranslationElement -> Theory sig c 
 clearFunctionTypingInfos = modify thyItems (filter f)
   where
     f (TranslationItem (FunctionTypingInfo _)) = False
-    f _                                  = True
+    f _ = True
+
 -- | Add a new case test. Fails if CaseTest with the same name already exists.
 addCaseTest :: CaseTest -> Theory sig c r p TranslationElement -> Maybe (Theory sig c r p TranslationElement)
 addCaseTest cTest thy = do
-    guard (isNothing  $ lookupCaseTest (L.get cName cTest) thy)
-    return $ modify thyItems (++ [TranslationItem (CaseTestItem cTest)]) thy
+  guard (isNothing $ lookupCaseTest (L.get cName cTest) thy)
+  return $ modify thyItems (++ [TranslationItem (CaseTestItem cTest)]) thy
 
 -- | Add a new AccLemma  fails if AccLemma with the same name already exists
 addAccLemma :: AccLemma -> Theory sig c r p TranslationElement -> Maybe (Theory sig c r p TranslationElement)
 addAccLemma aLem thy = do
-    guard (isNothing $ lookupAccLemma (L.get aName aLem) thy)
-    return $ modify thyItems (++ [TranslationItem (AccLemmaItem aLem)]) thy
-
+  guard (isNothing $ lookupAccLemma (L.get aName aLem) thy)
+  return $ modify thyItems (++ [TranslationItem (AccLemmaItem aLem)]) thy
 
 -- | Add a new process expression.
 addExportInfo :: ExportInfo -> Theory sig c r p TranslationElement -> (Theory sig c r p TranslationElement)
@@ -502,62 +508,70 @@ addExportInfo eInfo thy = do
 
 -- search process
 findProcess :: String -> Theory sig c r p TranslationElement -> Maybe (Theory sig c r p TranslationElement)
-findProcess s thy =  do
-                guard (isJust $ lookupProcessDef s thy)
-                return thy
+findProcess s thy = do
+  guard (isJust $ lookupProcessDef s thy)
+  return thy
 
 -- | Add a new process definition. fails if process with the same name already exists
 addProcessDef :: ProcessDef -> Theory sig c r p TranslationElement -> Maybe (Theory sig c r p TranslationElement)
 addProcessDef pDef thy = do
-    guard (isNothing $ lookupProcessDef (L.get pName pDef) thy)
-    return $ modify thyItems (++ [TranslationItem (ProcessDefItem pDef)]) thy
+  guard (isNothing $ lookupProcessDef (L.get pName pDef) thy)
+  return $ modify thyItems (++ [TranslationItem (ProcessDefItem pDef)]) thy
 
 -- | Add a new process definition. fails if process with the same name already exists
 addPredicate :: Predicate -> Theory sig c r p TranslationElement -> Maybe (Theory sig c r p TranslationElement)
 addPredicate pDef thy = do
-    guard (isNothing $ lookupPredicate (L.get pFact pDef) (theoryPredicates thy))
-    return $ modify thyItems (++ [PredicateItem pDef]) thy
+  guard (isNothing $ lookupPredicate (L.get pFact pDef) (theoryPredicates thy))
+  return $ modify thyItems (++ [PredicateItem pDef]) thy
 
 -- | Add a new option. Overwrite previous settings
-setOption :: Data.Label.Poly.Lens
-               Data.Label.Point.Total (Option -> Option) (Bool -> Bool)
-             -> Theory sig c r p s -> Theory sig c r p s
+setOption ::
+  Data.Label.Poly.Lens
+    Data.Label.Point.Total
+    (Option -> Option)
+    (Bool -> Bool) ->
+  Theory sig c r p s ->
+  Theory sig c r p s
 setOption l = L.set (l . thyOptions) True
 
-setforcedInjectiveFacts :: S.Set FactTag
-             -> Theory sig c r p s -> Theory sig c r p s
+setforcedInjectiveFacts ::
+  S.Set FactTag ->
+  Theory sig c r p s ->
+  Theory sig c r p s
 setforcedInjectiveFacts = L.set (forcedInjectiveFacts . thyOptions)
 
 -- | Add a new restriction. Fails, if restriction with the same name exists.
 addRestrictionDiff :: Side -> Restriction -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
 addRestrictionDiff s l thy = do
-    guard (isNothing $ lookupRestrictionDiff s (L.get rstrName l) thy)
-    return $ modify diffThyItems (++ [EitherRestrictionItem (s, l)]) thy
+  guard (isNothing $ lookupRestrictionDiff s (L.get rstrName l) thy)
+  return $ modify diffThyItems (++ [EitherRestrictionItem (s, l)]) thy
 
 filterLemma :: (ProtoLemma LNFormula p -> Bool) -> Theory sig c r p s -> Theory sig c r p s
 filterLemma lemmaSelector = modify thyItems (concatMap fItem)
-    where
-    fItem   = foldTheoryItem (return . RuleItem)
-                             (return . RestrictionItem)
-                             check
-                             (return . TextItem)
-                             (return . ConfigBlockItem)
-                             (return . PredicateItem)
-                             (return . MacroItem)
-                             (return . TranslationItem)
+  where
+    fItem =
+      foldTheoryItem
+        (return . RuleItem)
+        (return . RestrictionItem)
+        check
+        (return . TextItem)
+        (return . ConfigBlockItem)
+        (return . PredicateItem)
+        (return . MacroItem)
+        (return . TranslationItem)
     check l = do guard (lemmaSelector l); return (LemmaItem l)
 
 -- | Add a new lemma. Fails, if a lemma with the same name exists.
 addLemmaDiff :: Side -> Lemma p2 -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
 addLemmaDiff s l thy = do
-    guard (isNothing $ lookupLemmaDiff s (L.get lName l) thy)
-    return $ modify diffThyItems (++ [EitherLemmaItem (s, l)]) thy
+  guard (isNothing $ lookupLemmaDiff s (L.get lName l) thy)
+  return $ modify diffThyItems (++ [EitherLemmaItem (s, l)]) thy
 
 -- | Add a new lemma. Fails, if a lemma with the same name exists.
 addDiffLemma :: DiffLemma p -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
 addDiffLemma l thy = do
-    guard (isNothing $ lookupDiffLemma (L.get lDiffName l) thy)
-    return $ modify diffThyItems (++ [DiffLemmaItem l]) thy
+  guard (isNothing $ lookupDiffLemma (L.get lDiffName l) thy)
+  return $ modify diffThyItems (++ [DiffLemmaItem l]) thy
 
 -- | Add a new default heuristic. Fails if a heuristic is already defined.
 addHeuristic :: [GoalRanking ProofContext] -> Theory sig c r p s -> Maybe (Theory sig c r p s)
@@ -570,59 +584,66 @@ addDiffHeuristic _ _ = Nothing
 
 addTactic :: Tactic ProofContext -> Theory sig c r p s -> Maybe (Theory sig c r p s)
 addTactic t (Theory n f h [] sig c i o sapic) = Just (Theory n f h [t] sig c i o sapic)
-addTactic t (Theory n f h l sig c i o sapic) = Just (Theory n f h (l++[t]) sig c i o sapic)
+addTactic t (Theory n f h l sig c i o sapic) = Just (Theory n f h (l ++ [t]) sig c i o sapic)
+
 -- addTactic _ _ = Nothing
 
 addDiffTactic :: Tactic ProofContext -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
 addDiffTactic t (DiffTheory n f h [] sig cl cr dcl dcr i o sapic) = Just (DiffTheory n f h [t] sig cl cr dcl dcr i o sapic)
-addDiffTactic t (DiffTheory n f h l sig cl cr dcl dcr i o sapic) = Just (DiffTheory n f h (l++[t]) sig cl cr dcl dcr i o sapic)
+addDiffTactic t (DiffTheory n f h l sig cl cr dcl dcr i o sapic) = Just (DiffTheory n f h (l ++ [t]) sig cl cr dcl dcr i o sapic)
 
 -- | Remove a lemma by name. Fails, if the lemma does not exist.
 removeLemma :: String -> Theory sig c r p s -> Maybe (Theory sig c r p s)
 removeLemma lemmaName thy = do
-    _ <- lookupLemma lemmaName thy
-    return $ modify thyItems (concatMap fItem) thy
+  _ <- lookupLemma lemmaName thy
+  return $ modify thyItems (concatMap fItem) thy
   where
-    fItem   = foldTheoryItem (return . RuleItem)
-                             (return . RestrictionItem)
-                             check
-                             (return . TextItem)
-                             (return . ConfigBlockItem)
-                             (return . PredicateItem)
-                             (return . MacroItem)
-                             (return . TranslationItem)
+    fItem =
+      foldTheoryItem
+        (return . RuleItem)
+        (return . RestrictionItem)
+        check
+        (return . TextItem)
+        (return . ConfigBlockItem)
+        (return . PredicateItem)
+        (return . MacroItem)
+        (return . TranslationItem)
     check l = do guard (L.get lName l /= lemmaName); return (LemmaItem l)
 
 -- | Remove a lemma by name. Fails, if the lemma does not exist.
 removeLemmaDiff :: Side -> String -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
 removeLemmaDiff s lemmaName thy = do
-    _ <- lookupLemmaDiff s lemmaName thy
-    return $ modify diffThyItems (concatMap fItem) thy
+  _ <- lookupLemmaDiff s lemmaName thy
+  return $ modify diffThyItems (concatMap fItem) thy
   where
-    fItem   = foldDiffTheoryItem (return . DiffRuleItem)
-                                 (return . EitherRuleItem)
-                                 (return . DiffLemmaItem)
-                                 check
-                                 (return . EitherRestrictionItem)
-                                 (return . DiffMacroItem)
-                                 (return . DiffTextItem)
-                                 (return . DiffConfigBlockItem)
-    check (s', l) = do guard (L.get lName l /= lemmaName || s'/=s); return (EitherLemmaItem (s, l))
+    fItem =
+      foldDiffTheoryItem
+        (return . DiffRuleItem)
+        (return . EitherRuleItem)
+        (return . DiffLemmaItem)
+        check
+        (return . EitherRestrictionItem)
+        (return . DiffMacroItem)
+        (return . DiffTextItem)
+        (return . DiffConfigBlockItem)
+    check (s', l) = do guard (L.get lName l /= lemmaName || s' /= s); return (EitherLemmaItem (s, l))
 
 -- | Remove a lemma by name. Fails, if the lemma does not exist.
 removeDiffLemma :: String -> DiffTheory sig c r r2 p p2 -> Maybe (DiffTheory sig c r r2 p p2)
 removeDiffLemma lemmaName thy = do
-    _ <- lookupDiffLemma lemmaName thy
-    return $ modify diffThyItems (concatMap fItem) thy
+  _ <- lookupDiffLemma lemmaName thy
+  return $ modify diffThyItems (concatMap fItem) thy
   where
-    fItem   = foldDiffTheoryItem (return . DiffRuleItem)
-                                 (return . EitherRuleItem)
-                                 check
-                                 (return . EitherLemmaItem)
-                                 (return . EitherRestrictionItem)
-                                 (return . DiffMacroItem)
-                                 (return . DiffTextItem)
-                                 (return . DiffConfigBlockItem)
+    fItem =
+      foldDiffTheoryItem
+        (return . DiffRuleItem)
+        (return . EitherRuleItem)
+        check
+        (return . EitherLemmaItem)
+        (return . EitherRestrictionItem)
+        (return . DiffMacroItem)
+        (return . DiffTextItem)
+        (return . DiffConfigBlockItem)
     check l = do guard (L.get lDiffName l /= lemmaName); return (DiffLemmaItem l)
 
 -- | Find the restriction with the given name.
@@ -634,10 +655,10 @@ lookupLemma :: String -> Theory sig c r p s -> Maybe (Lemma p)
 lookupLemma name = find ((name ==) . L.get lName) . theoryLemmas
 
 lookupLemmaIndex :: String -> Theory sig c r p s -> Maybe Int
-lookupLemmaIndex name ti = (+1) <$> findIndex (\i -> case i of (LemmaItem l) -> name == L.get lName l; _ -> False) (L.get thyItems ti)
+lookupLemmaIndex name ti = (+ 1) <$> findIndex (\i -> case i of (LemmaItem l) -> name == L.get lName l; _ -> False) (L.get thyItems ti)
 
 getLemmaPreItems :: String -> Theory sig c r p s -> [TheoryItem r p s]
-getLemmaPreItems name ti = fromMaybe [] $ (\li -> [i | (nr, i) <- zip [1..] (L.get thyItems ti), nr < li]) <$> lookupLemmaIndex name ti
+getLemmaPreItems name ti = fromMaybe [] $ (\li -> [i | (nr, i) <- zip [1 ..] (L.get thyItems ti), nr < li]) <$> lookupLemmaIndex name ti
 
 -- | Find the case test with the given name.
 lookupCaseTest :: CaseIdentifier -> Theory sig c r p TranslationElement -> Maybe CaseTest
@@ -653,7 +674,7 @@ lookupProcessDef name = find ((name ==) . L.get pName) . theoryProcessDefs
 
 -- | Find the function typing info for a given function symbol.
 lookupFunctionTypingInfo :: NoEqSym -> Theory sig c r p TranslationElement -> Maybe SapicFunSym
-lookupFunctionTypingInfo tag = find (\(fs,_,_) -> tag == fs) . theoryFunctionTypingInfos
+lookupFunctionTypingInfo tag = find (\(fs, _, _) -> tag == fs) . theoryFunctionTypingInfos
 
 -- | Find the export info for the given tag.
 lookupExportInfo :: String -> Theory sig c r p TranslationElement -> [ExportInfo]
@@ -691,152 +712,171 @@ addFormalCommentDiff c = modify diffThyItems (++ [DiffTextItem c])
 
 isRuleItem :: TheoryItem r p s -> Bool
 isRuleItem (RuleItem _) = True
-isRuleItem _            = False
+isRuleItem _ = False
 
 itemToRule :: TheoryItem r p s -> Maybe r
 itemToRule (RuleItem r) = Just r
-itemToRule _            = Nothing
-
+itemToRule _ = Nothing
 
 ------------------------------------------------------------------------------
 -- Pretty Print
 ------------------------------------------------------------------------------
 
---Pretty print a theory
-prettyTheory :: HighlightDocument d
-             => (sig -> d) -> (c -> d) -> (r -> d) -> (p -> d) -> (s -> d)
-             -> Theory sig c r p s -> d
-prettyTheory ppSig ppCache ppRule ppPrf ppSap thy = vsep $
-    [ kwTheoryHeader $ text $ L.get thyName thy
-    , lineComment_ "Function signature and definition of the equational theory E"
-    , ppSig $ L.get thySignature thy
-    , if thyT == [] then text "" else vcat $ map prettyTactic thyT
-    , if null thyH then text "" else text "heuristic: " <> text (prettyGoalRankings thyH)
-    , ppCache $ L.get thyCache thy
-    ] ++
-    parMap rdeepseq ppItem (L.get thyItems thy) ++
-    [ kwEnd ]
+-- Pretty print a theory
+prettyTheory ::
+  (HighlightDocument d) =>
+  (sig -> d) ->
+  (c -> d) ->
+  (r -> d) ->
+  (p -> d) ->
+  (s -> d) ->
+  Theory sig c r p s ->
+  d
+prettyTheory ppSig ppCache ppRule ppPrf ppSap thy =
+  vsep $
+    [ kwTheoryHeader $ text $ L.get thyName thy,
+      lineComment_ "Function signature and definition of the equational theory E",
+      ppSig $ L.get thySignature thy,
+      if thyT == [] then text "" else vcat $ map prettyTactic thyT,
+      if null thyH then text "" else text "heuristic: " <> text (prettyGoalRankings thyH),
+      ppCache $ L.get thyCache thy
+    ]
+      ++ parMap rdeepseq ppItem (L.get thyItems thy)
+      ++ [kwEnd]
   where
-    ppItem = foldTheoryItem
-        ppRule prettyRestriction (prettyLemma ppPrf) (uncurry prettyFormalComment) prettyConfigBlock prettyPredicate prettyMacros ppSap
+    ppItem =
+      foldTheoryItem
+        ppRule
+        prettyRestriction
+        (prettyLemma ppPrf)
+        (uncurry prettyFormalComment)
+        prettyConfigBlock
+        prettyPredicate
+        prettyMacros
+        ppSap
     thyH = L.get thyHeuristic thy
     thyT = L.get thyTactic thy
 
-
-prettyTranslationElement :: HighlightDocument d => TranslationElement -> d
+prettyTranslationElement :: (HighlightDocument d) => TranslationElement -> d
 prettyTranslationElement (ProcessItem p) = text "process" <> colon $-$ (nest 2 $ prettyProcess p)
 prettyTranslationElement (DiffEquivLemma p) = text "diffEquivLemma" <> colon $-$ (nest 2 $ prettyProcess p)
 prettyTranslationElement (EquivLemma p1 p2) = text "equivLemma" <> colon $-$ (nest 2 $ prettyProcess p1) $$ (nest 2 $ prettyProcess p2)
 prettyTranslationElement (AccLemmaItem a) = prettyAccLemma a
 prettyTranslationElement (CaseTestItem c) = prettyCaseTest c
 prettyTranslationElement (ProcessDefItem p) =
-    (text "let ")
-    <->
-    (text (L.get pName p))
-    <->
-    (case L.get pVars p of
-        Nothing -> emptyDoc
-        Just l  -> text ("(" ++ intercalate "," (map show l) ++ ")")
-    )
-    <->
-    (text "=")
-    <->
-    nest 2 (prettyProcess $ L.get pBody p)
-prettyTranslationElement (FunctionTypingInfo ((fsn,(_,priv,_)), intypes, outtype)) =
-    (text "function:")
-    <->
-    text (unpack fsn)
-    <->
-    parens (fsep $ punctuate comma $ map printType intypes)
-    <->
-    text ":"
-    <->
-    printType outtype
-    <->
-    text (showPriv priv)
-    where
-        printType = maybe (text defaultSapicTypeS) text
-        showPriv Private = " [private]"
-        showPriv Public  = ""
+  (text "let ")
+    <-> (text (L.get pName p))
+    <-> ( case L.get pVars p of
+            Nothing -> emptyDoc
+            Just l -> text ("(" ++ intercalate "," (map show l) ++ ")")
+        )
+    <-> (text "=")
+    <-> nest 2 (prettyProcess $ L.get pBody p)
+prettyTranslationElement (FunctionTypingInfo ((fsn, (_, priv, _)), intypes, outtype)) =
+  (text "function:")
+    <-> text (unpack fsn)
+    <-> parens (fsep $ punctuate comma $ map printType intypes)
+    <-> text ":"
+    <-> printType outtype
+    <-> text (showPriv priv)
+  where
+    printType = maybe (text defaultSapicTypeS) text
+    showPriv Private = " [private]"
+    showPriv Public = ""
 prettyTranslationElement (ExportInfoItem eInfo) =
-    (text "export: ")
-    <->
-    text (L.get eTag eInfo)
-    <->
-    nest 2 (doubleQuotes $ text $ L.get eText eInfo)
-prettyTranslationElement (SignatureBuiltin s) = (text "builtin ")<->(text s)
+  (text "export: ")
+    <-> text (L.get eTag eInfo)
+    <-> nest 2 (doubleQuotes $ text $ L.get eText eInfo)
+prettyTranslationElement (SignatureBuiltin s) = (text "builtin ") <-> (text s)
 
-prettyPredicate :: HighlightDocument d => Predicate -> d
+prettyPredicate :: (HighlightDocument d) => Predicate -> d
 prettyPredicate p = kwPredicate <> colon <-> text (factstr ++ "<=>" ++ formulastr)
-    where
-        factstr = render $ prettyFact prettyLVar $ L.get pFact p
-        formulastr = render $ prettyLNFormula $ L.get pFormula p
+  where
+    factstr = render $ prettyFact prettyLVar $ L.get pFact p
+    formulastr = render $ prettyLNFormula $ L.get pFormula p
 
-prettyProcess :: HighlightDocument d => PlainProcess -> d
+prettyProcess :: (HighlightDocument d) => PlainProcess -> d
 prettyProcess = prettySapic
 
-prettyProcessDef :: HighlightDocument d => ProcessDef -> d
+prettyProcessDef :: (HighlightDocument d) => ProcessDef -> d
 prettyProcessDef pDef = text "let " <-> text (L.get pName pDef) <-> text " = " <-> prettySapic (L.get pBody pDef)
 
 -- | Pretty-print a comma, separated list of 'LVar's.
-prettyVarList :: Document d => [LVar] -> d
+prettyVarList :: (Document d) => [LVar] -> d
 prettyVarList = fsep . punctuate comma . map prettyLVar
 
--- | Pretty print all macros
-prettyMacros :: HighlightDocument d => [Macro] -> d 
+-- |  Pretty print all macros
+prettyMacros :: (HighlightDocument d) => [Macro] -> d
 prettyMacros m = if m == [] then text empty else vcat (keyword_ "macros:" : map prettyMacro m)
 
--- | Pretty print a macro.
-prettyMacro :: HighlightDocument d => Macro -> d
-prettyMacro (op, args, out) = vcat [ppNonEmptyList (\ds -> sep (map (nest 4) ds)) 
-                              text ([BC.unpack op ++ "("]) <-> prettyVarList args <-> text (") = " ++ show(out))]
-    where
-        ppNonEmptyList _   _  [] = emptyDoc
-        ppNonEmptyList hdr pp xs = hdr $ punctuate comma $ map pp xs
-    --"\t" ++ BC.unpack op ++ "(" ++ show (args) ++ ") = " ++ show(out) ++ "\n"
+-- |  Pretty print a macro.
+prettyMacro :: (HighlightDocument d) => Macro -> d
+prettyMacro (op, args, out) =
+  vcat
+    [ ppNonEmptyList
+        (\ds -> sep (map (nest 4) ds))
+        text
+        ([BC.unpack op ++ "("])
+        <-> prettyVarList args
+        <-> text (") = " ++ show (out))
+    ]
+  where
+    ppNonEmptyList _ _ [] = emptyDoc
+    ppNonEmptyList hdr pp xs = hdr $ punctuate comma $ map pp xs
+
+-- "\t" ++ BC.unpack op ++ "(" ++ show (args) ++ ") = " ++ show(out) ++ "\n"
 
 -- | Pretty print a restriction.
-prettyRestriction :: HighlightDocument d => Restriction -> d
+prettyRestriction :: (HighlightDocument d) => Restriction -> d
 prettyRestriction rstr =
-    kwRestriction <-> text (L.get rstrName rstr) <> colon $-$
-    (nest 2 $ doubleQuotes $ prettyLNFormula $ L.get rstrFormula rstr) $-$
-    (nest 2 $ if safety then lineComment_ "safety formula" else emptyDoc)
+  kwRestriction <-> text (L.get rstrName rstr)
+    <> colon
+      $-$ (nest 2 $ doubleQuotes $ prettyLNFormula $ L.get rstrFormula rstr)
+      $-$ (nest 2 $ if safety then lineComment_ "safety formula" else emptyDoc)
   where
     safety = isSafetyFormula $ formulaToGuarded_ $ L.get rstrFormula rstr
 
 -- | Pretty print an either restriction.
-prettyEitherRestriction :: HighlightDocument d => (Side, Restriction) -> d
+prettyEitherRestriction :: (HighlightDocument d) => (Side, Restriction) -> d
 prettyEitherRestriction (s, rstr) =
-    kwRestriction <-> text (L.get rstrName rstr) <-> prettySide s <> colon $-$
-    (nest 2 $ doubleQuotes $ prettyLNFormula $ L.get rstrFormula rstr) $-$
-    (nest 2 $ if safety then lineComment_ "safety formula" else emptyDoc)
+  kwRestriction <-> text (L.get rstrName rstr) <-> prettySide s
+    <> colon
+      $-$ (nest 2 $ doubleQuotes $ prettyLNFormula $ L.get rstrFormula rstr)
+      $-$ (nest 2 $ if safety then lineComment_ "safety formula" else emptyDoc)
   where
     safety = isSafetyFormula $ formulaToGuarded_ $ L.get rstrFormula rstr
 
--- | Pretty print a configuration block. 
-prettyConfigBlock :: HighlightDocument d => ConfigBlock -> d
+-- | Pretty print a configuration block.
+prettyConfigBlock :: (HighlightDocument d) => ConfigBlock -> d
 prettyConfigBlock cb = text "configuration: " <> doubleQuotes (text cb)
 
-prettyTactic :: HighlightDocument d => Tactic ProofContext -> d
-prettyTactic tactic = kwTactic <> colon <> space <> (text $ _name tactic) 
-    $-$ kwPresort <> colon <> space <> (char $ goalRankingToChar $ _presort tactic) $-$ sep
-        [ ppTabTab  "prio"  (map stringRankingPrio $ _prios tactic) (map stringsPrio $ _prios tactic)
-        , ppTabTab "deprio" (map stringRankingDeprio $ _deprios tactic) (map stringsDeprio $ _deprios tactic)
-        , char '\n'
+prettyTactic :: (HighlightDocument d) => Tactic ProofContext -> d
+prettyTactic tactic =
+  kwTactic
+    <> colon
+    <> space
+    <> (text $ _name tactic)
+      $-$ kwPresort
+    <> colon
+    <> space
+    <> (char $ goalRankingToChar $ _presort tactic)
+      $-$ sep
+        [ ppTabTab "prio" (map stringRankingPrio $ _prios tactic) (map stringsPrio $ _prios tactic),
+          ppTabTab "deprio" (map stringRankingDeprio $ _deprios tactic) (map stringsDeprio $ _deprios tactic),
+          char '\n'
         ]
-   where 
+  where
+    -- pretty print for a prio block
+    ppTab "prio" (rankingName, xs) = kwPrio <> colon <> space <> braces (text rankingName) $-$ (nest 2 $ vcat $ map prettify (map words xs))
+    ppTab "deprio" (rankingName, xs) = kwDeprio <> colon <> space <> braces (text rankingName) $-$ (nest 2 $ vcat $ map prettify (map words xs))
+    ppTab _ _ = emptyDoc
 
-        -- pretty print for a prio block
-        ppTab "prio" (rankingName,xs) = kwPrio <> colon <> space <> braces (text rankingName) $-$ (nest 2 $ vcat $ map prettify (map words xs))
-        ppTab "deprio" (rankingName,xs) = kwDeprio <> colon <> space <> braces (text rankingName) $-$ (nest 2 $ vcat $ map prettify (map words xs))
-        ppTab _ _ = emptyDoc
+    ppTabTab _ _ [] = emptyDoc
+    ppTabTab param rankingName listFunctions = vcat (map (ppTab param) (zip rankingName listFunctions))
 
-        ppTabTab _ _ [] = emptyDoc
-        ppTabTab param rankingName listFunctions = vcat (map (ppTab param) (zip rankingName listFunctions))
-
-        prettify :: HighlightDocument d => [String] -> d
-        prettify []    = emptyDoc
-        prettify ("|":t) = (operator_ " | ") <> prettify t-- if (s == "|") || (s == "&") || (s == "not") then (operator_ s) <> prettify t else text s <> prettify t
-        prettify ("&":t) = (operator_ " & ") <> prettify t
-        prettify ("not":t) = (operator_ "not ") <> prettify t
-        prettify (s:t) = text s <> prettify t
+    prettify :: (HighlightDocument d) => [String] -> d
+    prettify [] = emptyDoc
+    prettify ("|" : t) = (operator_ " | ") <> prettify t -- if (s == "|") || (s == "&") || (s == "not") then (operator_ s) <> prettify t else text s <> prettify t
+    prettify ("&" : t) = (operator_ " & ") <> prettify t
+    prettify ("not" : t) = (operator_ "not ") <> prettify t
+    prettify (s : t) = text s <> prettify t

--- a/lib/theory/tamarin-prover-theory.cabal
+++ b/lib/theory/tamarin-prover-theory.cabal
@@ -1,167 +1,160 @@
-name:               tamarin-prover-theory
+name: tamarin-prover-theory
+cabal-version: >= 1.8
+build-type: Simple
+version: 1.11.0
+license: GPL
+license-file: LICENSE
+category: Theorem Provers
+author:
+  Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
+  Simon Meier <simon.meier@inf.ethz.ch>,
+  Jannik Dreier <research@jannikdreier.net>,
+  Ralf Sasse <ralf.sasse@gmail.com>
 
-cabal-version:      >= 1.8
-build-type:         Simple
-version:            1.11.0
-license:            GPL
-license-file:       LICENSE
-category:           Theorem Provers
-author:             Benedikt Schmidt <benedikt.schmidt@inf.ethz.ch>,
-                    Simon Meier <simon.meier@inf.ethz.ch>,
-                    Jannik Dreier <research@jannikdreier.net>,
-                    Ralf Sasse <ralf.sasse@gmail.com>
-maintainer:         Jannik Dreier <research@jannikdreier.net>,
-                    Ralf Sasse <ralf.sasse@gmail.com>
-                    Cas Cremers <cremers@cispa.de>
-copyright:          Benedikt Schmidt, Simon Meier, Cas Cremers, Jannik Dreier, Ralf Sasse, 2010-2023
+maintainer:
+  Jannik Dreier <research@jannikdreier.net>,
+  Ralf Sasse <ralf.sasse@gmail.com>
+  Cas Cremers <cremers@cispa.de>
 
-synopsis:           Security protocol types and constraint solver library for the tamarin prover.
+copyright: Benedikt Schmidt, Simon Meier, Cas Cremers, Jannik Dreier, Ralf Sasse, 2010-2023
+synopsis: Security protocol types and constraint solver library for the tamarin prover.
+description:
+  This is an internal library of the Tamarin prover for
+  security protocol verification
+  (<hackage.haskell.org/package/tamarin-prover>).
+  .
+  This library provides the types to represent security
+  protocols, and it implements the constraint solver.
 
-description:        This is an internal library of the Tamarin prover for
-                    security protocol verification
-                    (<hackage.haskell.org/package/tamarin-prover>).
-                    .
-                    This library provides the types to represent security
-                    protocols, and it implements the constraint solver.
-
-homepage:           https://tamarin-prover.github.io/
-
+homepage: https://tamarin-prover.github.io/
 
 source-repository head
-  type:     git
+  type: git
   location: https://github.com/tamarin-prover/tamarin-prover.git
 
 ----------------------
 -- library stanzas
 ----------------------
-
 library
-    ghc-options:       -Wall -fwarn-tabs
+  ghc-options:
+    -Wall
+    -fwarn-tabs
 
-    ghc-prof-options:  -auto-all
+  ghc-prof-options: -auto-all
+  build-depends:
+    aeson,
+    aeson-pretty,
+    array,
+    attoparsec,
+    base,
+    binary,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    dlist,
+    exceptions,
+    fclabels,
+    filepath,
+    mtl,
+    parallel,
+    parsec,
+    pretty,
+    process,
+    regex-pcre-builtin,
+    regex-posix,
+    safe,
+    split,
+    tamarin-prover-term,
+    tamarin-prover-utils,
+    text,
+    transformers,
+    uniplate
 
-    build-depends:
-        aeson
-      , aeson-pretty
-      , array
-      , attoparsec
-      , base
-      , binary
-      , bytestring
-      , containers
-      , deepseq
-      , directory
-      , dlist
-      , fclabels
-      , filepath
-      , mtl
-      , parallel
-      , parsec
-      , pretty
-      , process
-      , regex-pcre-builtin
-      , regex-posix
-      , safe
-      , split
-      , text
-      , transformers
-      , uniplate
-      , exceptions
+  hs-source-dirs: src
+  exposed-modules:
+    ClosedTheory
+    Items.AccLemmaItem
+    Items.CaseTestItem
+    Items.ExportInfo
+    Items.LemmaItem
+    Items.OpenTheoryItem
+    Items.OptionItem
+    Items.ProcessItem
+    Items.RuleItem
+    Items.TheoryItem
+    Lemma
+    OpenTheory
+    Pretty
+    Prover
+    Rule
+    Theory
+    Theory.Constraint.Solver
+    Theory.Constraint.Solver.AnnotatedGoals
+    Theory.Constraint.Solver.Contradictions
+    Theory.Constraint.Solver.Goals
+    Theory.Constraint.Solver.ProofMethod
+    Theory.Constraint.Solver.Reduction
+    Theory.Constraint.Solver.Simplify
+    Theory.Constraint.Solver.Sources
+    Theory.Constraint.System
+    Theory.Constraint.System.Constraints
+    Theory.Constraint.System.Dot
+    Theory.Constraint.System.Graph.Abbreviation
+    Theory.Constraint.System.Graph.Graph
+    Theory.Constraint.System.Graph.GraphRepr
+    Theory.Constraint.System.Graph.Simplification
+    Theory.Constraint.System.Guarded
+    Theory.Constraint.System.JSON
+    Theory.Model
+    Theory.Model.Atom
+    Theory.Model.Fact
+    Theory.Model.Formula
+    Theory.Model.Restriction
+    Theory.Model.Rule
+    Theory.Model.Signature
+    Theory.Module
+    Theory.Proof
+    Theory.ProofSkeleton
+    Theory.Sapic
+    Theory.Sapic.Annotation
+    Theory.Sapic.Pattern
+    Theory.Sapic.Position
+    Theory.Sapic.Print
+    Theory.Sapic.Process
+    Theory.Sapic.Term
+    Theory.Text.Parser
+    Theory.Text.Parser.Macro
+    Theory.Text.Parser.Restriction
+    Theory.Text.Parser.Signature
+    Theory.Text.Parser.Token
+    Theory.Text.Pretty
+    Theory.Tools.AbstractInterpretation
+    Theory.Tools.EquationStore
+    Theory.Tools.InjectiveFactInstances
+    Theory.Tools.IntruderRules
+    Theory.Tools.LoopBreakers
+    Theory.Tools.MessageDerivationChecks
+    Theory.Tools.RuleVariants
+    Theory.Tools.SubtermStore
+    Theory.Tools.Wellformedness
+    TheoryObject
 
-      , tamarin-prover-utils
-      , tamarin-prover-term
+  other-modules:
+    Theory.Sapic.PlainProcess
+    Theory.Sapic.Substitution
+    Theory.Syntactic.Predicate
+    Theory.Text.Parser.Accountability
+    Theory.Text.Parser.Exceptions
+    Theory.Text.Parser.Fact
+    Theory.Text.Parser.Formula
+    Theory.Text.Parser.Lemma
+    Theory.Text.Parser.Let
+    Theory.Text.Parser.Proof
+    Theory.Text.Parser.Rule
+    Theory.Text.Parser.Sapic
+    Theory.Text.Parser.Tactics
+    Theory.Text.Parser.Term
 
-
-    hs-source-dirs: src
-
-    exposed-modules:
-      Theory
-      Theory.Proof
-      Theory.ProofSkeleton
-
-      Theory.Constraint.Solver
-      Theory.Constraint.Solver.Sources
-      Theory.Constraint.Solver.Contradictions
-      Theory.Constraint.Solver.AnnotatedGoals
-      Theory.Constraint.Solver.Goals
-      Theory.Constraint.Solver.ProofMethod
-      Theory.Constraint.Solver.Reduction
-      Theory.Constraint.Solver.Simplify
-
-      Theory.Constraint.System
-      Theory.Constraint.System.Constraints
-      Theory.Constraint.System.Dot
-      Theory.Constraint.System.JSON
-      Theory.Constraint.System.Guarded
-      Theory.Constraint.System.Graph.GraphRepr
-      Theory.Constraint.System.Graph.Abbreviation
-      Theory.Constraint.System.Graph.Simplification
-      Theory.Constraint.System.Graph.Graph
-
-      Theory.Sapic.Term
-      Theory.Sapic.Pattern
-      Theory.Sapic.Process
-      Theory.Sapic.Position
-      Theory.Sapic.Annotation
-      Theory.Sapic
-      Theory.Sapic.Print
-
-      Theory.Model
-      Theory.Model.Atom
-      Theory.Model.Fact
-      Theory.Model.Formula
-      Theory.Model.Rule
-      Theory.Model.Signature
-      Theory.Model.Restriction
-
-      Theory.Module
-
-      Theory.Text.Pretty
-      Theory.Text.Parser
-      Theory.Text.Parser.Token
-      Theory.Text.Parser.Restriction
-      Theory.Text.Parser.Signature
-      Theory.Text.Parser.Macro 
-
-      Theory.Tools.MessageDerivationChecks
-      Theory.Tools.AbstractInterpretation
-      Theory.Tools.EquationStore
-      Theory.Tools.InjectiveFactInstances
-      Theory.Tools.IntruderRules
-      Theory.Tools.LoopBreakers
-      Theory.Tools.RuleVariants
-      Theory.Tools.SubtermStore
-      Theory.Tools.Wellformedness
-      TheoryObject
-      Lemma
-      OpenTheory
-      ClosedTheory
-      Rule
-      Prover
-      Items.LemmaItem
-      Items.OpenTheoryItem
-      Items.OptionItem
-      Items.RuleItem
-      Items.ProcessItem
-      Items.TheoryItem
-      Items.ExportInfo
-      Items.CaseTestItem
-      Items.AccLemmaItem
-      Pretty
-
-
-    other-modules:
-      Theory.Syntactic.Predicate
-      Theory.Text.Parser.Accountability
-      Theory.Text.Parser.Exceptions
-      Theory.Text.Parser.Fact
-      Theory.Text.Parser.Formula
-      Theory.Text.Parser.Lemma
-      Theory.Text.Parser.Let
-      Theory.Text.Parser.Proof
-      Theory.Text.Parser.Rule
-      Theory.Text.Parser.Sapic
-      Theory.Text.Parser.Tactics
-      Theory.Text.Parser.Term
-      Theory.Sapic.PlainProcess
-      Theory.Sapic.Substitution
+  default-extensions:
+    ImportQualifiedPost


### PR DESCRIPTION
Ref: https://github.com/tamarin-prover/tamarin-prover/issues/721

This PR changes pretty printing so typed function symbols appear twice. First, when printing the pure maude signature, they appear as untyped. Then, when printing the type information (which is external to the maude signature, a `TranslationItem`), they appear as typed. The parse seems to accept this, see the small example below.

```
theory issue721 begin

// Function signature and definition of the equational theory E

functions: senc/2, sdec/2

equations:
    sdec(k, senc(k, m)) = m

function: senc (Cool, Any) : Any
function: sdec (Any, Any) : Any


process:
    in(x);
    new k:Cool;
    out(senc(k,x))

end
```

(Sorry for the large diff, btw. Newer versions of HLS seems to impose some pretty-printing on every save. Should we just live with this or actively fight it? I might even make our code base more consistently formatted, over time.)