### PR TITLE
Added link to GSVerif repository

### DIFF
--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir -p ~/.local/bin
           export PATH=$HOME/.local/bin:$PATH
-          curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+          curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
           chmod a+x ~/.local/bin/stack
           stack --no-terminal setup
           curl -L https://github.com/maude-lang/Maude/releases/download/Maude3.4/Maude-linux.zip > maude.zip

--- a/manual/src/006_protocol-specification-processes.md
+++ b/manual/src/006_protocol-specification-processes.md
@@ -342,8 +342,14 @@ The following outputs are supported:
 - *spthy:* parse .spthy file and output
 - *spthytyped* - parse and type .spthy file ad output
 - *msr* - parse and type .spthy file and translate processes to multiset-rewrite rules
-- *proverif*: - translate to [ProVerif](https://bblanche.gitlabpages.inria.fr/proverif/) input format
-- *deepsec*: - translate to [Deepsec](https://deepsec-prover.github.io/) input format
+- *proverif*: - translate to the
+  [ProVerif](https://bblanche.gitlabpages.inria.fr/proverif/) input format. 
+  The translation of lookups/inserts relies on features that are not yet
+  available in ProVerif (at the time of writing) and require preprocessing 
+  with [GSVerif](https://gitlab.inria.fr/chevalvi/gsverif).
+- *proverifequiv*: - same as `proverif`, but specifically for the translation
+  of equivalence properties aka privacy properties aka ProVerif's `diff` mode.
+- *deepsec*: - translate to [Deepsec](https://deepsec-prover.github.io/)'s input format
 
 ## Lemma selection
 


### PR DESCRIPTION
Workaround discussed in https://github.com/tamarin-prover/tamarin-prover/issues/708, long-term solution withstanding: we add a link to GSVerif, as ProVerif does not support some features we use in the export.