### PR TITLE
Fix parsing of rule attributes.

### DIFF
--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1191,7 +1191,7 @@ prettyRuleAttribute :: (HighlightDocument d) => RuleAttributes -> d
 prettyRuleAttribute a = fsep $ punctuate comma $ catMaybes [ -- Maybe types are only printed if they are (Just x). Hence fmap.
     fmap (\c -> text "color=" <> text (rgbToHex c)) (ruleColor a),
     fmap ppProcess (ruleProcess a),
-    boolToMaybe (ignoreDerivChecks a) $ text "derivchecks",
+    boolToMaybe (ignoreDerivChecks a) $ text "no_derivcheck",
     boolToMaybe (isSAPiCRule a) $ text "issapicrule",
     fmap (\roleName -> text "role=\'" <> text roleName <> text "\'") (role a)
     ]

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1188,16 +1188,16 @@ prettyRuleName :: (HighlightDocument d, HasRuleName (Rule i)) => Rule i -> d
 prettyRuleName = ruleInfo prettyProtoRuleName prettyIntrRuleACInfo . ruleName
 
 prettyRuleAttribute :: (HighlightDocument d) => RuleAttributes -> d
-prettyRuleAttribute a = fsep $ punctuate comma $ catMaybes [ -- Maybe types are only printed if they are (Just x). Hence fmap.
-    fmap (\c -> text "color=" <> text (rgbToHex c)) (ruleColor a),
-    fmap ppProcess (ruleProcess a),
-    boolToMaybe (ignoreDerivChecks a) $ text "no_derivcheck",
-    boolToMaybe (isSAPiCRule a) $ text "issapicrule",
-    fmap (\roleName -> text "role=\'" <> text roleName <> text "\'") (role a)
+prettyRuleAttribute attr = fsep $ punctuate comma $ catMaybes [ -- Maybe types are only printed if they are (Just x). Hence fmap.
+    fmap (\c -> text "color=" <> text (rgbToHex c)) (ruleColor attr),
+    fmap ppProcess (ruleProcess attr),
+    boolToMaybe (ignoreDerivChecks attr) $ text "no_derivcheck",
+    boolToMaybe (isSAPiCRule attr) $ text "issapicrule",
+    fmap (\roleName -> text "role=\'" <> text roleName <> text "\'") (role attr)
     ]
     where
 
-    ppProcess   p = text "process=" <> text ("\"" ++ prettySapicTopLevel' f p ++ "\"")
+    ppProcess   p = text "process=" <> text ("\'" ++ prettySapicTopLevel' f p ++ "\'")
         where f l a r rest _ = render $ prettyRuleRestr (g l) (g a) (g r) (h rest)
               g = map toLNFact
               h = map toLFormula

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1187,6 +1187,7 @@ prettyDotProtoRuleName attrs rn = text $ case rn of
 prettyRuleName :: (HighlightDocument d, HasRuleName (Rule i)) => Rule i -> d
 prettyRuleName = ruleInfo prettyProtoRuleName prettyIntrRuleACInfo . ruleName
 
+-- | Pretty print the attributes of a rule. Omits values that are `Nothing :: Maybe a` or `False` by default.
 prettyRuleAttribute :: (HighlightDocument d) => RuleAttributes -> d
 prettyRuleAttribute attr = fsep $ punctuate comma $ catMaybes [ -- Maybe types are only printed if they are (Just x). Hence fmap.
     fmap (\c -> text "color=" <> text (rgbToHex c)) (ruleColor attr),

--- a/lib/theory/src/Theory/Text/Parser/Rule.hs
+++ b/lib/theory/src/Theory/Text/Parser/Rule.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Move brackets to avoid $" #-}
 -- |
 -- Copyright   : (c) 2010-2012 Simon Meier, Benedikt Schmidt
 --               contributing in 2019: Robert Künnemann, Johannes Wocker
@@ -80,7 +82,8 @@ ruleAttribute = asum
             Nothing -> fail $ "Color code " ++ show hc ++ " could not be parsed to RGB"
             Just rgb  -> return $ mempty { ruleColor = Just rgb }
     parseAndIgnore = do
-                        _ <- try (singleQuoted anyChar) <|> try (doubleQuoted anyChar)
+                        _ <- try (symbol "\'") <|> symbol "\""
+                        _ <- manyTill anyChar (try (symbol "\"") <|> (try $ symbol "'"))
                         return  mempty
     parseRole = do
         _ <- symbol "\'" <|> symbol "\""

--- a/lib/theory/src/Theory/Text/Parser/Rule.hs
+++ b/lib/theory/src/Theory/Text/Parser/Rule.hs
@@ -69,7 +69,7 @@ ruleAttribute = asum
     [ symbol "colour=" *> parseColor
     , symbol "color="  *> parseColor
     , symbol "process="  *> parseAndIgnore
-    , symbol "no_derivcheck" *> ignore
+    , symbol "no_derivcheck" *> return (mempty { ignoreDerivChecks = True })
     , symbol "role=" *> parseRole
     , symbol "issapicrule" *> return (mempty { isSAPiCRule = True })
     ]
@@ -82,7 +82,6 @@ ruleAttribute = asum
     parseAndIgnore = do
                         _ <- try (singleQuoted anyChar) <|> try (doubleQuoted anyChar)
                         return  mempty
-    ignore = return mempty
     parseRole = do
         _ <- symbol "\'" <|> symbol "\""
         role <- manyTill anyChar (try (symbol "\'" <|> symbol "\""))

--- a/lib/theory/src/Theory/Text/Parser/Rule.hs
+++ b/lib/theory/src/Theory/Text/Parser/Rule.hs
@@ -69,7 +69,6 @@ ruleAttribute = asum
     [ symbol "colour=" *> parseColor
     , symbol "color="  *> parseColor
     , symbol "process="  *> parseAndIgnore
-    , symbol "derivchecks" *> ignore
     , symbol "no_derivcheck" *> ignore
     , symbol "role=" *> parseRole
     , symbol "issapicrule" *> return (mempty { isSAPiCRule = True })
@@ -81,8 +80,7 @@ ruleAttribute = asum
             Nothing -> fail $ "Color code " ++ show hc ++ " could not be parsed to RGB"
             Just rgb  -> return $ mempty { ruleColor = Just rgb }
     parseAndIgnore = do
-                        _ <-  symbol "\""
-                        _ <- manyTill anyChar (try (symbol "\""))
+                        _ <- try (singleQuoted anyChar) <|> try (doubleQuoted anyChar)
                         return  mempty
     ignore = return mempty
     parseRole = do


### PR DESCRIPTION
To promote safe code, https://github.com/tamarin-prover/tamarin-prover/pull/739 converted RuleAttributes into a record type. I've noticed some oddities / bugs in the parsing code, which this PR aims to fix.

1. attributes `process` should be parsed in single quotes, with the same rationale as in https://github.com/tamarin-prover/tamarin-prover/pull/730. Like there, the parser still permits double quotes for backward compatibility, but the printer produces single quotes.

2. Previously, neither `derivcheck` nor `no_derivchecks` were parsed. I was bothered by the plural `s` being present in one, but not the other (I've mistyped this so often in testing). Because of this and derivcheck being the default anyway, I've removed parsing of `derivcheck`, changed `no_derivchecks` to `no_derivcheck` and parse this. @jdreier I saw the line with the previous `ignore` parser was from you. Any reason not to parse atm?

3. A bug in printing confused `derivcheck` with `no_derivcheck`, this was fixed.

## Testing

This test file:

```
theory RuleAttribute
begin

rule process  [process='anything']:
    [] --> []

rule process_backwardcompat  [process="anything"]:
    [] --> []

rule bla  [no_derivcheck,issapicrule, role='test',color='#111111', color='000000', process='anything']:
    [] --> []

rule test2 [no_derivcheck]:
    [] --> []


rule test4 [role='test', role='overwritten']:
    [] --> []

end
```

is parsed on produces

```
[...]
rule (modulo E) process:
   [ ] --> [ ]

  /* has exactly the trivial AC variant */

rule (modulo E) process_backwardcompat:
   [ ] --> [ ]

  /* has exactly the trivial AC variant */

rule (modulo E) bla[color=#000000, no_derivcheck, issapicrule,
                    role='test']:
   [ ] --> [ ]

  /* has exactly the trivial AC variant */

rule (modulo E) test2[no_derivcheck]:
   [ ] --> [ ]

  /* has exactly the trivial AC variant */

rule (modulo E) test4[role='overwritten']:
   [ ] --> [ ]
[..]
```
