### PR TITLE
Injective fact detections: uses restrictions

### DIFF
--- a/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
+++ b/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
@@ -216,7 +216,6 @@ simpleInjectiveFactInstances reducible rules = S.fromList $ do
                 getBehaviour (t1, t2) | elemNotBelowReducible reducible t2 t1 = StrictlyDecreasing
                 getBehaviour (t1, t2) | (t1,t2) `elem` constraints = StrictlyIncreasing
                 getBehaviour (t1, t2) | (t2,t1) `elem` constraints = StrictlyDecreasing
-                -- getBehaviour constraints (t1, t2) | (t1,t2) `elem` constraints = StrictlyIncreasing
                 getBehaviour _ = Unstable
 
                 behaviours =

--- a/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
+++ b/lib/theory/src/Theory/Tools/InjectiveFactInstances.hs
@@ -49,6 +49,19 @@ instance Show MonotonicBehaviour where
   show Unstable = "."
   show Unspecified = "?"
 
+
+-- | under-approximate monotonicity constraints from a formula.
+-- For now, we only deal with a formula that corresponds to a subterm atom
+-- If we want to express things like OR, we need to return a more refined value.
+extractConstraints :: (Ord c, Ord b) => ProtoFormula syn s c b -> [(Term (Lit c b), Term (Lit c b))]
+extractConstraints (Ato (Subterm t1 t2)) = [(bvarToLVar t1, bvarToLVar t2)]
+    where
+        bvarToLVar =
+            fmapTerm (fmap (foldBVar boundError id))
+        boundError _ = error "implementation error: bounded variable in top-level atom"
+extractConstraints _ = []
+
+
 -- | Compute a simple under-approximation to the set of facts with injective
 -- instances. A fact-tag is has injective instances, if there is no state of
 -- the protocol with more than one instance with the same term as a first
@@ -135,7 +148,7 @@ simpleInjectiveFactInstances reducible rules = S.fromList $ do
       combineAll (Just (map (map combine) $ zipWith zip behaviours behaviours1) : rest) tag
     combineAll [x] _ = x
     combineAll [] tag = M.lookup tag candidates -- start with the empty shape of Unspecified
-    combineAll _ _ = error "the haskell compiler is too dumb to know that the pattern matching is actually exhaustive"
+    combineAll _ _ = error "The haskell compiler is too dumb to know that the pattern matching is actually exhaustive."
 
     combine :: (MonotonicBehaviour, MonotonicBehaviour) -> MonotonicBehaviour
     combine (x, y) | x == y = x
@@ -161,6 +174,7 @@ simpleInjectiveFactInstances reducible rules = S.fromList $ do
       where
         prems = L.get rPrems ru
         copies = filter ((tag ==) . factTag) (L.get rConcs ru)
+        constraints = concatMap extractConstraints (L.get preRestriction (L.get rInfo ru))
         firstTerm = headMay . factTerms
 
         -- duplicateFirstTerms are the first terms that appear at least twice - i.e. the corresponding fact cannot be injective
@@ -200,6 +214,9 @@ simpleInjectiveFactInstances reducible rules = S.fromList $ do
                 getBehaviour (t1, t2) | t1 == t2 = Constant
                 getBehaviour (t1, t2) | elemNotBelowReducible reducible t1 t2 = StrictlyIncreasing
                 getBehaviour (t1, t2) | elemNotBelowReducible reducible t2 t1 = StrictlyDecreasing
+                getBehaviour (t1, t2) | (t1,t2) `elem` constraints = StrictlyIncreasing
+                getBehaviour (t1, t2) | (t2,t1) `elem` constraints = StrictlyDecreasing
+                -- getBehaviour constraints (t1, t2) | (t1,t2) `elem` constraints = StrictlyIncreasing
                 getBehaviour _ = Unstable
 
                 behaviours =


### PR DESCRIPTION
I had an example where a rule increases a position in a fact to some number that is always larger, but Tamarin fails to detect the position in this fact is always increasing. This is because the detection is ignoring _restrict statement altogether. (No MWE needed, this is clear from the source.) Instead of the restrict statement, I could have had the attacker send us a natural number that is added in this position, but this leads to more cases in the analysis due to the additional variable and was unsuitable in that particular use case.

This PR extracts constraints on existing terms from top-level sub-term atoms in all rule restrictions and use them to detect  facts that are strictly increasing or decreasing. My understanding of the subterm precomputation comes from the paper, but is superficial. I'd like one of the original authors to double check this. I saw @rsasse reviewed the original PR, so I picked him. (Hi! :D) I hope that's alright, this change is just a couple of lines and should be trivial.

Limitations: This really just treats a toplevel atom ` --[ _restrict(a << b) ]-> `.