### PR TITLE
Slim down and simplify Tamarin Docker image

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,18 +1,68 @@
-# Tamarin
+# Use ARGs for versions for easier updates
 ARG GHC_VERSION=9.6.6
+ARG MAUDE_VERSION=Maude3.5
 
+#----------------------------------------------------
+# Stage 1: Build Maude from source
+#----------------------------------------------------
+FROM debian:bookworm-slim AS maude-build
+ARG MAUDE_VERSION
+
+# install Maude’s build dependencies (including static libraries)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      bison \
+      flex \
+      autoconf \
+      automake \
+      libtool \
+      libtool-bin \
+      dh-autoreconf \
+      libsigsegv-dev \
+      libgmp-dev \
+      libtecla-dev \
+      libbdd-dev \
+      pkg-config \
+      git \
+      ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# bring the static GMP .a’s into /usr/lib so configure’s GMP_LIBS can see them
+RUN mkdir -p /usr/lib && \
+    ln -s /usr/lib/*-linux-gnu/libgmp.a      /usr/lib/libgmp.a     && \
+    ln -s /usr/lib/*-linux-gnu/libgmpxx.a    /usr/lib/libgmpxx.a
+
+WORKDIR /opt/maude-src
+RUN git clone --depth 1 --branch ${MAUDE_VERSION} https://github.com/maude-lang/Maude.git . \
+ && autoreconf -i
+
+RUN mkdir build && cd build && \
+    ../configure \
+      --with-yices2=no \
+      --with-cvc4=no \
+      --enable-compiler \
+      CXXFLAGS="-g -Wall -O3 -fno-stack-protector" \
+      CPPFLAGS="-I/usr/include" \
+      LDFLAGS="-L/usr/lib" \
+      GMP_LIBS="/usr/lib/libgmpxx.a /usr/lib/libgmp.a" && \
+    make -j$(nproc) && \
+    make check && \
+    make install
+
+#----------------------------------------------------
+# Stage 2: Build Haskell Dependencies
 #----------------------------------------------------
 FROM haskell:${GHC_VERSION} AS tamarin-dependencies
 
 WORKDIR /opt/build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      libncurses-dev \
-      zlib1g-dev \
-      pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+    libncurses-dev \
+    zlib1g-dev \
+    pkg-config \
+ && rm -rf /var/lib/apt/lists/*
 
-# Build from local directory
+# copy only the files & folders that stack needs to figure out its deps
 COPY stack.yaml tamarin-prover.cabal ./
 COPY LICENSE ./
 COPY lib/. ./lib/
@@ -23,6 +73,8 @@ COPY images ./images
 RUN stack build --system-ghc --dependencies-only
 
 #---------------------------------------------------
+# Stage 3: Build the Application
+#---------------------------------------------------
 FROM haskell:${GHC_VERSION} AS tamarin-build
 
 COPY --from=tamarin-dependencies /root/.stack /root/.stack
@@ -32,45 +84,45 @@ WORKDIR /opt/build
 
 RUN stack install --system-ghc --local-bin-path /opt/build/bin
 
-# Strip debugging symbols to reduce binary size
+# Install binutils, strip the tamarin binary, and clean up in one layer
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends binutils unzip && \
+    apt-get install -y --no-install-recommends binutils && \
     strip /opt/build/bin/tamarin-prover && \
+    apt-get purge -y --auto-remove binutils && \
     rm -rf /var/lib/apt/lists/*
 
-# Retrieve Maude from Git repo as APT source for bookworm is incompatible with Tamarin
-RUN wget https://github.com/maude-lang/Maude/releases/download/Maude3.5/Maude-3.5-linux-x86_64.zip && unzip Maude-3.5-linux-x86_64.zip -d /opt/build/bin 
-
+#---------------------------------------------------
+# Stage 4: Final Image
 #---------------------------------------------------
 FROM debian:bookworm-slim AS tamarin
 
-# Metadata
 LABEL version="1.0" \
       description="The Tamarin prover for security protocol verification" \
       org.opencontainers.image.authors="The Tamarin prover authors"
 
-ENV PATH="/usr/local/bin:$PATH"
-
-ENV LANG=C.UTF-8 \
+ENV MAUDE_LIB=/usr/local/share \
+    PATH="/usr/local/bin:$PATH" \
+    LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      graphviz \
- && rm -rf /var/lib/apt/lists/*
+    graphviz \
+    libbdd0c2 \
+    libtecla1 \
+    libsigsegv2 \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd -ms /bin/bash tamarin
 
-COPY --from=tamarin-build /opt/build/bin /usr/local/bin
+COPY --from=maude-build /usr/local/share/prelude.maude /usr/local/share/
+COPY --from=maude-build /usr/local/bin/maude /usr/local/bin/maude
 
-COPY etc/docker/res/entrypoint.sh /usr/local/bin/
+COPY --from=tamarin-build --chown=tamarin:tamarin /opt/build/bin /usr/local/bin
+COPY --chown=tamarin:tamarin --chmod=755 etc/docker/res/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN chmod 755 /usr/local/bin/entrypoint.sh
-
-RUN useradd -ms /bin/bash tamarin
 USER tamarin
-
 WORKDIR /home/tamarin
-COPY etc/docker/res/README .
+COPY --chown=tamarin:tamarin etc/docker/res/README .
 
 EXPOSE 3001
-
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,8 +1,8 @@
 # Tamarin
-ARG STACK_RESOLVER=lts-22.39
+ARG GHC_VERSION=9.6.6
 
 #----------------------------------------------------
-FROM fpco/stack-build-small:${STACK_RESOLVER} AS tamarin-dependencies
+FROM haskell:${GHC_VERSION} AS tamarin-dependencies
 
 WORKDIR /opt/build
 
@@ -23,7 +23,7 @@ COPY images ./images
 RUN stack build --system-ghc --dependencies-only
 
 #---------------------------------------------------
-FROM fpco/stack-build-small:${STACK_RESOLVER} AS tamarin-build
+FROM haskell:${GHC_VERSION} AS tamarin-build
 
 COPY --from=tamarin-dependencies /root/.stack /root/.stack
 COPY --from=tamarin-dependencies /opt/build /opt/build

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -34,24 +34,29 @@ RUN stack install --system-ghc --local-bin-path /opt/build/bin
 
 # Strip debugging symbols to reduce binary size
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends binutils && \
+    apt-get install -y --no-install-recommends binutils unzip && \
     strip /opt/build/bin/tamarin-prover && \
     rm -rf /var/lib/apt/lists/*
 
+# Retrieve Maude from Git repo as APT source for bookworm is incompatible with Tamarin
+RUN wget https://github.com/maude-lang/Maude/releases/download/Maude3.5/Maude-3.5-linux-x86_64.zip && unzip Maude-3.5-linux-x86_64.zip -d /opt/build/bin 
+
 #---------------------------------------------------
-FROM debian:bullseye-slim AS tamarin
+FROM debian:bookworm-slim AS tamarin
 
 # Metadata
 LABEL version="1.0" \
       description="The Tamarin prover for security protocol verification" \
       org.opencontainers.image.authors="The Tamarin prover authors"
 
+ENV PATH="/usr/local/bin:$PATH"
+
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      maude graphviz \
+      graphviz \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tamarin-build /opt/build/bin /usr/local/bin

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -107,6 +107,7 @@ ENV MAUDE_LIB=/usr/local/share \
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python3 \
     graphviz \
     libbdd0c2 \
     libtecla1 \

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,73 +1,71 @@
-# Build image
-# based on bullseye, since system-ghc is too old in buster
-FROM debian:bullseye-slim AS tamarin-build
-# install build dependencies
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get -y --no-install-recommends install \
-        haskell-stack \
-        ca-certificates \
-        build-essential \
-        netbase \
-        locales \
-        ghc \
-        zlib1g \
-        zlib1g-dev
-WORKDIR /workspace
-# copy dependency specifications first (need stack.yaml for resolver spec)
-RUN mkdir -p lib/export lib/theory lib/sapic lib/tools lib/term lib/accountability
+# Tamarin
+ARG STACK_RESOLVER=lts-22.39
+
+#----------------------------------------------------
+FROM fpco/stack-build-small:${STACK_RESOLVER} AS tamarin-dependencies
+
+WORKDIR /opt/build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libncurses-dev \
+      zlib1g-dev \
+      pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build from local directory
 COPY stack.yaml tamarin-prover.cabal ./
-
-COPY lib/sapic/tamarin-prover-sapic.cabal lib/sapic/
-COPY lib/term/tamarin-prover-term.cabal lib/term/
-COPY lib/theory/tamarin-prover-theory.cabal lib/theory/
-COPY lib/utils/tamarin-prover-utils.cabal lib/utils/
-COPY lib/export/tamarin-prover-export.cabal lib/export/
-COPY lib/accountability/tamarin-prover-accountability.cabal lib/accountability
-# cache stack package index
-RUN stack update
-RUN stack upgrade
-# > Compiling language-javascript requires a UTF-8 locale.
-# (https://github.com/erikd/language-javascript/issues/86)
-# thankfully we're only in a temporary build container, so let's change that real quick
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-# build dependencies first, for caching
-RUN stack build --system-ghc --dependencies-only --ghc-options="+RTS -M600M"
-# now copy rest of source code
 COPY LICENSE ./
-# lib needs special handling since it already exists
 COPY lib/. ./lib/
 COPY src ./src
 COPY data ./data
 COPY images ./images
 
-# build the entire thing
-RUN stack build --system-ghc
-RUN stack install --system-ghc --local-bin-path /usr/local/bin
+RUN stack build --system-ghc --dependencies-only
 
-# Assemble final image
-# again, based on buillseye, since our build linked to bullseye libs
-FROM debian:bullseye-slim
+#---------------------------------------------------
+FROM fpco/stack-build-small:${STACK_RESOLVER} AS tamarin-build
+
+COPY --from=tamarin-dependencies /root/.stack /root/.stack
+COPY --from=tamarin-dependencies /opt/build /opt/build
+
+WORKDIR /opt/build
+
+RUN stack install --system-ghc --local-bin-path /opt/build/bin
+
+# Strip debugging symbols to reduce binary size
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends binutils && \
+    strip /opt/build/bin/tamarin-prover && \
+    rm -rf /var/lib/apt/lists/*
+
+#---------------------------------------------------
+FROM debian:bullseye-slim AS tamarin
+
 # Metadata
 LABEL version="1.0" \
       description="The Tamarin prover for security protocol verification" \
       org.opencontainers.image.authors="The Tamarin prover authors"
-# install runtime dependencies
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get -y --no-install-recommends install \
-        maude \
-        graphviz
-COPY --from=tamarin-build /usr/local/bin /usr/local/bin
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      maude graphviz \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=tamarin-build /opt/build/bin /usr/local/bin
+
 COPY etc/docker/res/entrypoint.sh /usr/local/bin/
+
 RUN chmod 755 /usr/local/bin/entrypoint.sh
+
 RUN useradd -ms /bin/bash tamarin
 USER tamarin
+
 WORKDIR /home/tamarin
-EXPOSE 3001
 COPY etc/docker/res/README .
+
+EXPOSE 3001
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
This PR simplifies the main Dockerfile with the following changes:

- switch to fpco/stack-build-small multi-stage build for faster, cached Haskell builds
- split “dependencies” and “build” stages to leverage Docker layer caching
- pin resolver via ARG STACK_RESOLVER=lts-22.39
- strip debugging symbols from tamarin-prover binary to reduce size
- remove leftover apt lists in both build and final stages