### PR TITLE
Refactor tamarin-prover-sapic records

### DIFF
--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -23,7 +23,6 @@ import Control.Monad.Trans.PreciseFresh qualified as Precise
 import Data.ByteString.Char8 qualified as BC
 import Data.Char
 import Data.Data
-import Data.Function (on)
 import Data.Functor.Identity qualified
 import Data.List as List
 import Data.Map qualified as M
@@ -1393,7 +1392,7 @@ loadHeaders tc thy typeEnv = do
     typedHeaderOfFunSym = foldMap headerOfFunSym userDeclaredFunctions
 
     -- events headers
-    eventHeaders = M.foldrWithKey (\tag types acc -> HEvent ('e' : factTagName tag) ("(" ++ makeArgtypes types ++ ")") `S.insert` acc) S.empty (events typeEnv)
+    eventHeaders = M.foldrWithKey (\tag types acc -> HEvent ('e' : factTagName tag) ("(" ++ makeArgtypes types ++ ")") `S.insert` acc) S.empty typeEnv.events
     -- generating headers for equations
     sigRules = S.toList (stRules sig)
 
@@ -1418,7 +1417,7 @@ headersOfRule tc typeEnv r | (lhs `RRule` rhs) <- ctxtStRuleToRRule r = do
         FApp (NoEq (_, (_, Private, Destructor))) _ -> " [private]"
         _ -> ""
       freesr = frees lhs `union` frees rhs
-      freesrTyped = map (\v -> (v, M.lookup v $ vars tye)) freesr
+      freesrTyped = map (\v -> (v, M.lookup v tye.vars)) freesr
       hrule =
         Eq
           prefix

--- a/lib/sapic/src/Sapic.hs
+++ b/lib/sapic/src/Sapic.hs
@@ -135,7 +135,7 @@ gen (trans_null, trans_action, trans_comb) anP p tildex = do
       msr' <-  gen trans anP (p++[1]) tildex'
       return $ mapToAnnotatedRule proc' msrs ++ msr'
     where
-      map_prems f = map (\r -> r { prems = map f (prems r) })
+      map_prems f = map (\r -> r { prems = map f r.prems })
       --  Substitute every occurence of  State(p_old,v) with State(p_new,v)
       substStatePos p_old p_new fact
         | (State s p' vs) <- fact, p'==p_old, not $ isSemiState s = State LState p_new vs

--- a/lib/sapic/src/Sapic/Annotation.hs
+++ b/lib/sapic/src/Sapic/Annotation.hs
@@ -61,7 +61,7 @@ data ProcessAnnotation v = ProcessAnnotation
 
 instance GoodAnnotation (ProcessAnnotation v)
     where
-        getProcessParsedAnnotation = parsingAnn
+        getProcessParsedAnnotation = (.parsingAnn)
         setProcessParsedAnnotation pn an = an { parsingAnn = pn }
         defaultAnnotation   = mempty
 
@@ -75,15 +75,15 @@ instance Monoid (ProcessAnnotation v) where
 
 instance Semigroup (ProcessAnnotation v) where
   (<>)  p1 p2 = ProcessAnnotation
-        (parsingAnn p1 <> parsingAnn p2)
-        (lock p1 <> lock p2)
-        (unlock p1 <> unlock p2)
-        (secretChannel p1 <> secretChannel p2)
-        (mayMerge (destructorEquation p1) (destructorEquation p2))
-        (elseBranch p2)
-        (pureState p1 || pureState p2)
-        (stateChannel p1 <> stateChannel p2)
-        (mayMerge (isStateChannel p1) (isStateChannel p2))
+        (p1.parsingAnn <> p2.parsingAnn)
+        (p1.lock <> p2.lock)
+        (p1.unlock <> p2.unlock)
+        (p1.secretChannel <> p2.secretChannel)
+        (mayMerge p1.destructorEquation p2.destructorEquation)
+        p2.elseBranch
+        (p1.pureState || p2.pureState)
+        (p1.stateChannel <> p2.stateChannel)
+        (mayMerge p1.isStateChannel p2.isStateChannel)
 
 getProcessNames :: GoodAnnotation ann => ann -> [String]
 getProcessNames = processnames . getProcessParsedAnnotation

--- a/lib/sapic/src/Sapic/Facts.hs
+++ b/lib/sapic/src/Sapic/Facts.hs
@@ -138,10 +138,10 @@ mapAct ::
 mapAct f anrule =
   let (l', a', r', res') =
         f
-          ( prems anrule,
-            acts anrule,
-            concs anrule,
-            restr anrule
+          ( anrule.prems,
+            anrule.acts,
+            anrule.concs,
+            anrule.restr
           )
    in anrule {prems = l', acts = a', concs = r', restr = res'}
 

--- a/lib/sapic/src/Sapic/Locks.hs
+++ b/lib/sapic/src/Sapic/Locks.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 -- |
 -- Copyright   : (c) 2019 Robert Künnemann
 -- License     : GPL v3 (see LICENSE)
@@ -111,5 +110,5 @@ checkLocks p = case run $ annotateLocks' $ toAnProcess p of
         run a = runExcept $ evalFreshT a 0
         checkUnmatchedUnlock = getAny . pfoldMap (Any . isUnmatchedUnlock)
         isUnmatchedUnlock (ProcessAction (Unlock _) annotation _)
-                | Nothing <- lock annotation = True
+                | Nothing <- annotation.lock = True
         isUnmatchedUnlock _ = False

--- a/lib/sapic/src/Sapic/Report.hs
+++ b/lib/sapic/src/Sapic/Report.hs
@@ -43,7 +43,7 @@ reportInit anP (initrules,initTx) = return (reportrule : initrules, initTx)
 -- | This rules use the builtin restriction system to bind the Report predicate (which must be defined by the user), to this rule.
 opt_loc :: Maybe SapicTerm -> ProcessAnnotation v -> Maybe SapicTerm
 opt_loc loc ann =
- case (location $ parsingAnn ann) of
+ case location ann.parsingAnn of
   Nothing -> loc
   Just x -> Just x
 

--- a/lib/sapic/src/Sapic/States.hs
+++ b/lib/sapic/src/Sapic/States.hs
@@ -211,7 +211,7 @@ annotateEachPureStates (ProcessComb comb an pl pr ) pureStates
               pl' = annotateEachPureStates pl pureStates
               pr' = annotateEachPureStates pr pureStates
 annotateEachPureStates (ProcessAction ac an p) pureStates
-  | New _ <- ac, Just cid <- isStateChannel an =
+  | New _ <- ac, Just cid <- an.isStateChannel =
       if fst $ isPureState p cid False then
         ProcessAction ac an{pureState=True, isStateChannel = Just cid} (annotateEachPureStates p (cid `S.insert` pureStates))
       else

--- a/lib/sapic/tamarin-prover-sapic.cabal
+++ b/lib/sapic/tamarin-prover-sapic.cabal
@@ -84,4 +84,6 @@ library
     other-modules:
 
     default-extensions:
+      DuplicateRecordFields
+      NoFieldSelectors
       OverloadedRecordDot


### PR DESCRIPTION
Enables `DuplicateRecordFields` and `NoFieldSelectors` for tamarin-prover-sapic package.