### PR TITLE
Allow maude 3.5.1

### DIFF
--- a/.github/workflows/tamarin-integration-test.yaml
+++ b/.github/workflows/tamarin-integration-test.yaml
@@ -37,9 +37,8 @@ jobs:
           curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
           chmod a+x ~/.local/bin/stack
           stack --no-terminal setup
-          curl -L https://github.com/maude-lang/Maude/releases/download/Maude3.4/Maude-linux.zip > maude.zip
+          curl -L https://github.com/maude-lang/Maude/releases/download/Maude3.5.1/Maude-3.5.1-linux-x86_64.zip > maude.zip
           unzip -oj maude.zip -d ~/.local/bin/
-          mv -f ~/.local/bin/maude.linux64 ~/.local/bin/maude
           chmod a+x ~/.local/bin/maude
           mkdir -p case-studies case-studies/ake case-studies/ake/bilinear case-studies/ake/dh case-studies/related_work
           mkdir -p case-studies/related_work/StatVerif_ARR_CSF11 case-studies/related_work/AIF_Moedersheim_CCS10

--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -173,7 +173,7 @@ ensureMaude as = do
 
     --  Maude versions prior to 2.7.1 are no longer supported,
     --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1", "3.4", "3.5"]
+    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1", "3.4", "3.5", "3.5.1"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
This adds Maude 3.5.1 to the allowed versions.
Additionally, to check if this does not break the current implementation, I have updated the version on Maude used in GitHub Actions. If this is not needed, I am happy to remove this commit.

fixes #774 