### PR TITLE
[WIP] Tree-sitter hightlight

### DIFF
--- a/tree-sitter/tree-sitter-spthy/queries/highlights.scm
+++ b/tree-sitter/tree-sitter-spthy/queries/highlights.scm
@@ -1,0 +1,84 @@
+; Tamarin syntax highlight
+
+; File structure
+[
+  "theory"
+  "begin"
+  "end"
+] @keyword
+(theory theory_name: (ident) @module)
+
+; builtins
+"builtins" @keyword
+(built_in) @module.builtin
+
+; rule
+[
+  "rule"
+  "let"
+  "in"
+  "color="
+  "colour="
+  "role"
+] @keyword
+(simple_rule rule_identifier: (ident) @function)
+(rule_role role_identifier: (ident) @string)
+
+; lemma
+"lemma" @keyword
+(lemma lemma_identifier: (ident) @function)
+[
+  "All"
+  "∀"
+  "Ex"
+  "∃"
+  "all-traces"
+  "exists-trace"
+] @property
+
+; other keywords
+"equations" @keyword
+
+(nary_app function_identifier: (ident) @function.builtin)
+
+(temporal_var) @variable.temporal
+(fresh_var) @variable.fresh
+(pub_var) @constant
+(nat_var) @variable.natural
+(msg_var_or_nullary_fun) @variable
+
+; operators
+[
+  "&"
+  "<"
+  "="
+  "==>"
+  ">"
+  "@"
+  "^"
+  "|"
+  "¬"
+  "not"
+] @operator
+
+; facts
+(linear_fact fact_identifier: (ident) @function)
+"!" @punctuation.special
+(persistent_fact fact_identifier: (ident) @function)
+
+; comments
+(single_comment) @comment.line
+(multi_comment) @comment.block
+
+; brackets
+[
+  "["
+  "]"
+  "--["
+  "]->"
+  "-->" ; not a bracket, but shuld be the same color
+] @punctuation.bracket
+
+; literal
+(pub_name) @string.public
+(fresh_name) @string.fresh

--- a/tree-sitter/tree-sitter-spthy/test/highlight/simple.spthy
+++ b/tree-sitter/tree-sitter-spthy/test/highlight/simple.spthy
@@ -1,0 +1,19 @@
+theory simple
+// <- keyword
+//      ^ module
+begin
+
+rule Rule1:
+// <- keyword
+//    ^ function
+	[] --[]-> []
+
+lemma Lemma1:
+// <- keyword
+//     ^ function
+	exists-trace
+	// ^ property
+	"T"
+
+end
+// <- keyword

--- a/tree-sitter/tree-sitter-spthy/tree-sitter.json
+++ b/tree-sitter/tree-sitter-spthy/tree-sitter.json
@@ -5,8 +5,12 @@
       "camelcase": "Spthy",
       "scope": "source.spthy",
       "path": ".",
-      "file-types": null,
-      "injection-regex": "^spthy$"
+      "file-types": [
+        "spthy",
+        "splib"
+      ],
+      "injection-regex": "^spthy$",
+      "highlights": "queries/highlights.scm"
     }
   ],
   "metadata": {


### PR DESCRIPTION
This adds highlighting to tree-sitter-spthy.
This is useful for text editors that use Tree-Sitter for highlighting, such as Helix.
I have added a test to check if everything is working.

I am new to tree-sitter, so this may not be the best way of implementing it, but it works for me now.

Edit: Removed CI file because of incompatible abi versions for tree-sitter.