### PR TITLE
Migrate Python oracle scripts to Python 3

### DIFF
--- a/examples/asiaccs20-eccDAA/CERTIFY/Oracle_Certify.py
+++ b/examples/asiaccs20-eccDAA/CERTIFY/Oracle_Certify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -21,7 +21,7 @@ for i in range(0,maxPrio):
   rank.append([])
   
 if lemma[0:11]=="oracle_corr": #SP1
-  print "applying oracle to oracle_correctness"
+  print("applying oracle to oracle_correctness")
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*Host_.*', line): rank[109].append(num)
@@ -57,7 +57,7 @@ if lemma[0:11]=="oracle_corr": #SP1
     elif re.match('.*\!KU\( KDF_EK\(~TPM_EK_Seed\).*', line): rank[50].append(num) 
     
 elif lemma[0:15]=="oracle_SP3_Unfo":#SP3
-  print "applying oracle to oracle_SP3_Unforgability for CERIFY"
+  print("applying oracle to oracle_SP3_Unforgability for CERIFY")
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*\!Pk\(.*', line): rank[109].append(num)
@@ -104,7 +104,7 @@ elif lemma[0:15]=="oracle_SP3_Unfo":#SP3
     elif re.match('.*\!KU\( KDF_AES\(~TPM.*', line): rank[30].append(num)
 
 elif lemma[0:17]=="oracle_auth_alive":
-  print "applying oracle to oracle_auth_alive"
+  print("applying oracle to oracle_auth_alive")
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*In_S\(.*', line): rank[106].append(num)
@@ -113,7 +113,7 @@ elif lemma[0:17]=="oracle_auth_alive":
 
 
 elif lemma[0:16]=="oracle_auth_weak" or lemma[0:15]=="oracle_auth_non" or lemma[0:21]=="oracle_auth_injective":
-  print "applying oracle to oracle_auth_weak/non/inject"
+  print("applying oracle to oracle_auth_weak/non/inject")
   for line in lines:
     num = line.split(':')[0]
 
@@ -152,7 +152,7 @@ elif lemma[0:16]=="oracle_auth_weak" or lemma[0:15]=="oracle_auth_non" or lemma[
 
 
 elif lemma[0:19]=="oracle_auth_secrecy":
-  print "applying oracle to oracle_auth_secrecy"
+  print("applying oracle to oracle_auth_secrecy")
   for line in lines:
     num = line.split(':')[0]
 
@@ -180,7 +180,7 @@ elif lemma[0:19]=="oracle_auth_secrecy":
         print ("!!!")
     elif re.match('.*In_S\(.*', line): 
         rank[107].append(num)
-        print ("Hello",line)
+        print(("Hello",line))
     elif re.match('.*\!KU\( pk\( KDF_EK\(~TPM_EK.*', line): rank[100].append(num)
     elif re.match('.*\!KU\( KDF_EK\(~TPM_EK.*', line): rank[100].append(num)
     elif re.match('.*\!KU\( curlyK\(~K_2\) \)', line): rank[91].append(num)
@@ -206,7 +206,7 @@ elif lemma[0:19]=="oracle_auth_secrecy":
 
 
 elif lemma[0:14]=="oracle_SP4_Non":
-  print "applying oracle to oracle_SP4_NonFrameability for BSN"
+  print("applying oracle to oracle_SP4_NonFrameability for BSN")
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*\!SignatureVerified.*', line): rank[108].append(num)
@@ -265,11 +265,11 @@ elif lemma[0:14]=="oracle_SP4_Non":
 
 
 else:
-    print "not applying the rule"
+    print("not applying the rule")
     exit(0)
 
 # Ordering all goals by ranking (higher first)
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/asiaccs20-eccDAA/CERTIFY/SP5_SP6_ObsEqui/ObsEquOracle.py
+++ b/examples/asiaccs20-eccDAA/CERTIFY/SP5_SP6_ObsEqui/ObsEquOracle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -20,8 +20,8 @@ maxPrio = 110
 for i in range(0,maxPrio):
   rank.append([])
 
-if lemma<>"AnyLemma":
-  print "applying lemma"
+if lemma!="AnyLemma":
+  print("applying lemma")
   for line in lines:
     num = line.split(':')[0]
 
@@ -41,4 +41,4 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/asiaccs20-eccDAA/QUOTE/Oracle_Quote.py
+++ b/examples/asiaccs20-eccDAA/QUOTE/Oracle_Quote.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -21,7 +21,7 @@ for i in range(0,maxPrio):
   rank.append([])
   
 if lemma[0:11]=="oracle_corr": #SP1
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*Host_.*', line): rank[109].append(num)
@@ -57,7 +57,7 @@ if lemma[0:11]=="oracle_corr": #SP1
     elif re.match('.*\!KU\( KDF_EK\(~TPM_EK_Seed\).*', line): rank[50].append(num) 
     
 elif lemma[0:15]=="oracle_SP3_Unfo":#SP3
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*\!Pk\(.*', line): rank[109].append(num)
@@ -104,7 +104,7 @@ elif lemma[0:15]=="oracle_SP3_Unfo":#SP3
     elif re.match('.*\!KU\( KDF_AES\(~TPM.*', line): rank[30].append(num)
 
 elif lemma[0:17]=="oracle_auth_alive":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*In_S\(.*', line): rank[106].append(num)
@@ -113,7 +113,7 @@ elif lemma[0:17]=="oracle_auth_alive":
 
 
 elif lemma[0:16]=="oracle_auth_weak" or lemma[0:15]=="oracle_auth_non" or lemma[0:21]=="oracle_auth_injective":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*In_S\( \$B,.*', line): rank[109].append(num)
@@ -151,7 +151,7 @@ elif lemma[0:16]=="oracle_auth_weak" or lemma[0:15]=="oracle_auth_non" or lemma[
 
 
 elif lemma[0:19]=="oracle_auth_secrecy":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
 
@@ -191,7 +191,7 @@ elif lemma[0:19]=="oracle_auth_secrecy":
 
 
 elif lemma[0:14]=="oracle_SP4_Non":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*\!SignatureVerified.*', line): rank[108].append(num)
@@ -247,11 +247,11 @@ elif lemma[0:14]=="oracle_SP4_Non":
 
 
 else:
-    print "not applying the rule"
+    print("not applying the rule")
     exit(0)
 
 # Ordering all goals by ranking (higher first)
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/asiaccs20-eccDAA/QUOTE/SP5_SP6_ObsEqui/ObsEquOracle.py
+++ b/examples/asiaccs20-eccDAA/QUOTE/SP5_SP6_ObsEqui/ObsEquOracle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -20,8 +20,8 @@ maxPrio = 110
 for i in range(0,maxPrio):
   rank.append([])
 
-if lemma<>"AnyLemma":
-  print "applying lemma"
+if lemma!="AnyLemma":
+  print("applying lemma")
   for line in lines:
     num = line.split(':')[0]
 
@@ -41,4 +41,4 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/asiaccs20-eccDAA/SIGN/Oracle_Sign.py
+++ b/examples/asiaccs20-eccDAA/SIGN/Oracle_Sign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -21,7 +21,7 @@ for i in range(0,maxPrio):
   rank.append([])
   
 if lemma[0:11]=="oracle_corr": #SP1
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*Host_.*', line): rank[109].append(num)
@@ -57,7 +57,7 @@ if lemma[0:11]=="oracle_corr": #SP1
     elif re.match('.*\!KU\( KDF_EK\(~TPM_EK_Seed\).*', line): rank[50].append(num) 
     
 elif lemma[0:15]=="oracle_SP3_Unfo":#SP3
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*\!Pk\(.*', line): rank[109].append(num)
@@ -108,7 +108,7 @@ elif lemma[0:15]=="oracle_SP3_Unfo":#SP3
     elif re.match('.*\!KU\( KDF_AES\(~TPM.*', line): rank[30].append(num)
 
 elif lemma[0:17]=="oracle_auth_alive":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*In_S\(.*', line): rank[106].append(num)
@@ -117,7 +117,7 @@ elif lemma[0:17]=="oracle_auth_alive":
 
 
 elif lemma[0:16]=="oracle_auth_weak" or lemma[0:15]=="oracle_auth_non" or lemma[0:21]=="oracle_auth_injective":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
 
@@ -156,7 +156,7 @@ elif lemma[0:16]=="oracle_auth_weak" or lemma[0:15]=="oracle_auth_non" or lemma[
 
 
 elif lemma[0:19]=="oracle_auth_secrecy":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*In_S\( \$B,.*', line): rank[109].append(num)
@@ -195,7 +195,7 @@ elif lemma[0:19]=="oracle_auth_secrecy":
 
 
 elif lemma[0:14]=="oracle_SP4_Non":
-  print "applying oracle to "+lemma
+  print("applying oracle to "+lemma)
   for line in lines:
     num = line.split(':')[0]
     if re.match('.*\!SignatureVerified.*', line): rank[108].append(num)
@@ -260,11 +260,11 @@ elif lemma[0:14]=="oracle_SP4_Non":
 
 
 else:
-    print "not applying the rule"
+    print("not applying the rule")
     exit(0)
 
 # Ordering all goals by ranking (higher first)
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/asiaccs20-eccDAA/SIGN/SP5_SP6_ObsEqui/ObsEquOracle.py
+++ b/examples/asiaccs20-eccDAA/SIGN/SP5_SP6_ObsEqui/ObsEquOracle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -20,8 +20,8 @@ maxPrio = 110
 for i in range(0,maxPrio):
   rank.append([])
 
-if lemma<>"AnyLemma":
-  print "applying lemma"
+if lemma!="AnyLemma":
+  print("applying lemma")
   for line in lines:
     num = line.split(':')[0]
 
@@ -41,4 +41,4 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/ccs18-5G/5G-AKA-bindingChannel/5G_AKA.oracle
+++ b/examples/ccs18-5G/5G-AKA-bindingChannel/5G_AKA.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -272,5 +272,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/ccs18-5G/5G-AKA-bindingChannel/5G_AKA_fix.oracle
+++ b/examples/ccs18-5G/5G-AKA-bindingChannel/5G_AKA_fix.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -122,5 +122,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/ccs18-5G/5G-AKA-nonBindingChannel/5G_AKA.oracle
+++ b/examples/ccs18-5G/5G-AKA-nonBindingChannel/5G_AKA.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -657,5 +657,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/ccs18-5G/5G-AKA-nonBindingChannel/5G_AKA_fix.oracle
+++ b/examples/ccs18-5G/5G-AKA-nonBindingChannel/5G_AKA_fix.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -125,5 +125,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/ccs18-5G/5G-AKA-untraceability/5G_AKA.oracle
+++ b/examples/ccs18-5G/5G-AKA-untraceability/5G_AKA.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -62,5 +62,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/ccs18-5G/5G-AKA-untraceability/5G_AKA_passive_privacy_game.oracle
+++ b/examples/ccs18-5G/5G-AKA-untraceability/5G_AKA_passive_privacy_game.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -40,5 +40,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/csf18-alethea/oracle_alethea_votingphase_Privacy
+++ b/examples/csf18-alethea/oracle_alethea_votingphase_Privacy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_Privacy
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -17,7 +17,7 @@ def prioritize(num,m):
   global priorities, plist, match
   for i in range(len(priorities)):
     if match:
-      print (m,priorities[i],re.match(priorities[i],m))
+      print((m,priorities[i],re.match(priorities[i],m)))
       if re.match(priorities[i],m):
          plist[i].append(num)
          break
@@ -75,7 +75,7 @@ plist = [ [] for i in priorities ]
 buf = []
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -87,7 +87,7 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 for i in buf:
-  print i
+  print(i)
 #print 1

--- a/examples/csf18-alethea/oracle_alethea_votingphase_RF
+++ b/examples/csf18-alethea/oracle_alethea_votingphase_RF
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -74,7 +74,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -86,5 +86,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/csf18-alethea/oracle_alethea_votingphase_abstain
+++ b/examples/csf18-alethea/oracle_alethea_votingphase_abstain
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_abstain
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -106,7 +106,7 @@ if lemma == "Universal_VerProofY_v8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -118,5 +118,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/csf18-alethea/oracle_alethea_votingphase_malS
+++ b/examples/csf18-alethea/oracle_alethea_votingphase_malS
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_malS
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -106,7 +106,7 @@ if lemma == "Universal_VerProofY_v8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -118,5 +118,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/csf18-xor/LAK06_state.oracle
+++ b/examples/csf18-xor/LAK06_state.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os

--- a/examples/csf18-xor/chaum_offline_anonymity.oracle
+++ b/examples/csf18-xor/chaum_offline_anonymity.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -35,14 +35,14 @@ if lemma == "coins":
   priorities = [ "!St_C_1",  "!Bank_Pk", "(last", "splitEqs", "Mint", "~~>", "!KU( ~r" ]
   avoid = [ ]
 else:
-  print(1)
+  print((1))
   sys.exit()
 
 plist = [ [] for i in priorities ]
 possible = []
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 

--- a/examples/csf18-xor/diff-models/KCL07-UK3.oracle
+++ b/examples/csf18-xor/diff-models/KCL07-UK3.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -70,5 +70,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-      print goal
+      print(goal)
 

--- a/examples/csf20-disputeResolution/o_mixvote_ShHh
+++ b/examples/csf20-disputeResolution/o_mixvote_ShHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -67,7 +67,7 @@ if lemma == "TalliedAsRecorded":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -79,5 +79,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/csf20-disputeResolution/o_mixvote_ShHh_RF
+++ b/examples/csf20-disputeResolution/o_mixvote_ShHh_RF
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -56,7 +56,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -68,5 +68,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/csf20-disputeResolution/o_mixvote_ShHm
+++ b/examples/csf20-disputeResolution/o_mixvote_ShHm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -38,7 +38,7 @@ if lemma == "secretSskD":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -50,5 +50,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/csf20-disputeResolution/o_mixvote_SmHh
+++ b/examples/csf20-disputeResolution/o_mixvote_SmHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -64,7 +64,7 @@ if lemma == "TalliedAsRecorded":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -76,5 +76,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/eurosp19-eccDAA/observationalEquivalence/ISOIEC_20008_2013_2_ECC_DAA.unlinkability.oracle
+++ b/examples/eurosp19-eccDAA/observationalEquivalence/ISOIEC_20008_2013_2_ECC_DAA.unlinkability.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -40,4 +40,4 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/features/auto-sources/tamarin-repo/ccs18-5G/5G-AKA-untraceability/5G_AKA.oracle
+++ b/examples/features/auto-sources/tamarin-repo/ccs18-5G/5G-AKA-untraceability/5G_AKA.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -62,5 +62,5 @@ else:
 for listGoals in reversed(rank):
   for goal in listGoals:
     sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_Privacy
+++ b/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_Privacy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_Privacy
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -66,7 +66,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -78,5 +78,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_RF
+++ b/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_RF
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -74,7 +74,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -86,5 +86,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_abstain
+++ b/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_abstain
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_abstain
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -106,7 +106,7 @@ if lemma == "Universal_VerProofY_v8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -118,5 +118,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_malS
+++ b/examples/features/auto-sources/tamarin-repo/csf18-alethea/oracle_alethea_votingphase_malS
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_malS
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -106,7 +106,7 @@ if lemma == "Universal_VerProofY_v8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -118,5 +118,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/features/xor/LAK06_state.oracle
+++ b/examples/features/xor/LAK06_state.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -228,5 +228,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-      print goal
+      print(goal)
 

--- a/examples/features/xor/chaum_offline_anonymity.oracle
+++ b/examples/features/xor/chaum_offline_anonymity.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # coding=utf-8
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -35,14 +35,14 @@ if lemma == "coins":
   priorities = [ "!St_C_1",  "!Bank_Pk", "(last", "splitEqs", "Mint", "~~>", "!KU( ~r" ]
   avoid = [ ]
 else:
-  print 1
+  print(1)
   sys.exit()
 
 plist = [ [] for i in priorities ]
 possible = []
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -54,6 +54,6 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 for j in possible:
-  print j
+  print(j)

--- a/examples/features/xor/diff-models/KCL07-UK3.oracle
+++ b/examples/features/xor/diff-models/KCL07-UK3.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -70,5 +70,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-      print goal
+      print(goal)
 

--- a/examples/fm24-cardpayments/offlineAndOnlineAuthorized/oracle/C8.oracle
+++ b/examples/fm24-cardpayments/offlineAndOnlineAuthorized/oracle/C8.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/fm24-cardpayments/offlineAndOnlineAuthorized/tools/collect
+++ b/examples/fm24-cardpayments/offlineAndOnlineAuthorized/tools/collect
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys, re, platform
 from datetime import datetime
@@ -112,14 +112,14 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 			else:
 				files += [dir + file for file in os.listdir(dir) if file.endswith('.proof')]
 		except:
-			print ('[Error] Invalid directory "%s"' % dir)
+			print(('[Error] Invalid directory "%s"' % dir))
 			return None
 
 	files.sort()
 	files.reverse() #reverse order...this is just a matter of taste
 
 	for proof_file in files:
-		print ('Parsing "%s"' % proof_file)
+		print(('Parsing "%s"' % proof_file))
 
 		results = {}
 		results['Theory file'] = theory_file = proof_file[:-6] + '.spthy'
@@ -154,8 +154,8 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 					results['Verified'] = 'No'
 		
 		if 'Theory' not in results:
-			print ('[Warning] No theory name found for "%s", so it will be ignored'\
-						% proof_file)
+			print(('[Warning] No theory name found for "%s", so it will be ignored'\
+						% proof_file))
 			continue
 
 		#rules
@@ -175,8 +175,8 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 			for line in open(theory_file).readlines():
 				m = re.match(RULE_HEADER_SPTHY_REGEX, line)
 				if m and m.group(1) not in rule_names:
-					print ('[Warning] Rule "%s" occurs in "%s" but not in "%s"'\
-								% (m.group(1), theory_file, proof_file))
+					print(('[Warning] Rule "%s" occurs in "%s" but not in "%s"'\
+								% (m.group(1), theory_file, proof_file)))
 			#lines of code
 			loc = len(open(theory_file).readlines())
 			if loc < loc_min: loc_min = loc
@@ -184,8 +184,8 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 			loc_sum  += loc
 			results['LoC'] = str(loc)
 		else:
-			print ('[Warning] File "%s" exists but not "%s"'\
-						% (proof_file, theory_file))
+			print(('[Warning] File "%s" exists but not "%s"'\
+						% (proof_file, theory_file)))
 
 		#timings
 		time_display = None
@@ -231,18 +231,18 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 	#this is specific to EMV
 	for results in global_results:
 		x_group = {}
-		for (col, res) in results.items():
+		for (col, res) in list(results.items()):
 			key = col.replace('_minimal', '')
 			res = re.sub(STEPS_REGEX, '', res)				
 			if key not in x_group:
 				x_group[key] = set()
 			x_group[key].add(res)
 		
-		differ = [k for (k,v) in x_group.items() if len(v) > 1]
+		differ = [k for (k,v) in list(x_group.items()) if len(v) > 1]
 		for col in differ:
 			proof_file = results['Proof file']
-			print ('[Warning] The results for "%s" and "%s_minimal" differ in "%s"'\
-						% (col, col, proof_file))
+			print(('[Warning] The results for "%s" and "%s_minimal" differ in "%s"'\
+						% (col, col, proof_file)))
 	
 	#add metadata
 	cols = cols + METADATA_COLUMNS
@@ -435,7 +435,7 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 		
 	#latex code ========================================
 	html += '<h2>Latex code</h2>\n\n<div class="latex-code x-scrollable">\n'
-	for (plain, rich) in LATEX_SYNTAX.items():
+	for (plain, rich) in list(LATEX_SYNTAX.items()):
 		tex = tex.replace(plain, rich)
 	html += tex +'</div>\n\n</body>\n</html>'
 	
@@ -462,11 +462,11 @@ def main(args):
 					if l != '': columns.append(l)
 	
 				if 'Theory' not in columns:
-					print ('[Error] No "Theory" column found in "%s"' % file)
+					print(('[Error] No "Theory" column found in "%s"' % file))
 					return
 			except Exception as e:
-				print ('[Warning] Something is wrong with the columns file "'\
-							+ file + '", so I will ignore')
+				print(('[Warning] Something is wrong with the columns file "'\
+							+ file + '", so I will ignore'))
 				print (e)
 				columns = 'all'
 				
@@ -486,8 +486,8 @@ def main(args):
 						tex_add[proto][lemma] = {}
 					tex_add[proto][lemma] = add[:-1]
 			except Exception as e:
-				print ('[Warning] Something is wrong with the tex-add file "'\
-							+ file + '", so I will ignore')
+				print(('[Warning] Something is wrong with the tex-add file "'\
+							+ file + '", so I will ignore'))
 				print (e)
 				tex_add = {}
 		elif arg.startswith('--split_theory_regex'):
@@ -501,7 +501,7 @@ def main(args):
 	html = create_html_code(directories, columns, tex_add, split_theory_regex)
 	
 	if html:
-		print ('Writing output to "%s"' % output)
+		print(('Writing output to "%s"' % output))
 		outfile = open(output, 'w')
 		outfile.write(html)
 		outfile.close()

--- a/examples/fm24-cardpayments/offlineAndOnlineAuthorized/tools/decomment
+++ b/examples/fm24-cardpayments/offlineAndOnlineAuthorized/tools/decomment
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/examples/fm24-cardpayments/onlineAuthorized/oracle/C8.oracle
+++ b/examples/fm24-cardpayments/onlineAuthorized/oracle/C8.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/fm24-cardpayments/onlineAuthorized/tools/collect
+++ b/examples/fm24-cardpayments/onlineAuthorized/tools/collect
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys, re, platform
 from datetime import datetime
@@ -112,14 +112,14 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 			else:
 				files += [dir + file for file in os.listdir(dir) if file.endswith('.proof')]
 		except:
-			print ('[Error] Invalid directory "%s"' % dir)
+			print(('[Error] Invalid directory "%s"' % dir))
 			return None
 
 	files.sort()
 	files.reverse() #reverse order...this is just a matter of taste
 
 	for proof_file in files:
-		print ('Parsing "%s"' % proof_file)
+		print(('Parsing "%s"' % proof_file))
 
 		results = {}
 		results['Theory file'] = theory_file = proof_file[:-6] + '.spthy'
@@ -154,8 +154,8 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 					results['Verified'] = 'No'
 		
 		if 'Theory' not in results:
-			print ('[Warning] No theory name found for "%s", so it will be ignored'\
-						% proof_file)
+			print(('[Warning] No theory name found for "%s", so it will be ignored'\
+						% proof_file))
 			continue
 
 		#rules
@@ -175,8 +175,8 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 			for line in open(theory_file).readlines():
 				m = re.match(RULE_HEADER_SPTHY_REGEX, line)
 				if m and m.group(1) not in rule_names:
-					print ('[Warning] Rule "%s" occurs in "%s" but not in "%s"'\
-								% (m.group(1), theory_file, proof_file))
+					print(('[Warning] Rule "%s" occurs in "%s" but not in "%s"'\
+								% (m.group(1), theory_file, proof_file)))
 			#lines of code
 			loc = len(open(theory_file).readlines())
 			if loc < loc_min: loc_min = loc
@@ -184,8 +184,8 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 			loc_sum  += loc
 			results['LoC'] = str(loc)
 		else:
-			print ('[Warning] File "%s" exists but not "%s"'\
-						% (proof_file, theory_file))
+			print(('[Warning] File "%s" exists but not "%s"'\
+						% (proof_file, theory_file)))
 
 		#timings
 		time_display = None
@@ -231,18 +231,18 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 	#this is specific to EMV
 	for results in global_results:
 		x_group = {}
-		for (col, res) in results.items():
+		for (col, res) in list(results.items()):
 			key = col.replace('_minimal', '')
 			res = re.sub(STEPS_REGEX, '', res)				
 			if key not in x_group:
 				x_group[key] = set()
 			x_group[key].add(res)
 		
-		differ = [k for (k,v) in x_group.items() if len(v) > 1]
+		differ = [k for (k,v) in list(x_group.items()) if len(v) > 1]
 		for col in differ:
 			proof_file = results['Proof file']
-			print ('[Warning] The results for "%s" and "%s_minimal" differ in "%s"'\
-						% (col, col, proof_file))
+			print(('[Warning] The results for "%s" and "%s_minimal" differ in "%s"'\
+						% (col, col, proof_file)))
 	
 	#add metadata
 	cols = cols + METADATA_COLUMNS
@@ -435,7 +435,7 @@ def create_html_code(directories, columns, tex_add, split_theory_regex):
 		
 	#latex code ========================================
 	html += '<h2>Latex code</h2>\n\n<div class="latex-code x-scrollable">\n'
-	for (plain, rich) in LATEX_SYNTAX.items():
+	for (plain, rich) in list(LATEX_SYNTAX.items()):
 		tex = tex.replace(plain, rich)
 	html += tex +'</div>\n\n</body>\n</html>'
 	
@@ -462,11 +462,11 @@ def main(args):
 					if l != '': columns.append(l)
 	
 				if 'Theory' not in columns:
-					print ('[Error] No "Theory" column found in "%s"' % file)
+					print(('[Error] No "Theory" column found in "%s"' % file))
 					return
 			except Exception as e:
-				print ('[Warning] Something is wrong with the columns file "'\
-							+ file + '", so I will ignore')
+				print(('[Warning] Something is wrong with the columns file "'\
+							+ file + '", so I will ignore'))
 				print (e)
 				columns = 'all'
 				
@@ -486,8 +486,8 @@ def main(args):
 						tex_add[proto][lemma] = {}
 					tex_add[proto][lemma] = add[:-1]
 			except Exception as e:
-				print ('[Warning] Something is wrong with the tex-add file "'\
-							+ file + '", so I will ignore')
+				print(('[Warning] Something is wrong with the tex-add file "'\
+							+ file + '", so I will ignore'))
 				print (e)
 				tex_add = {}
 		elif arg.startswith('--split_theory_regex'):
@@ -501,7 +501,7 @@ def main(args):
 	html = create_html_code(directories, columns, tex_add, split_theory_regex)
 	
 	if html:
-		print ('Writing output to "%s"' % output)
+		print(('Writing output to "%s"' % output))
 		outfile = open(output, 'w')
 		outfile.write(html)
 		outfile.close()

--- a/examples/fm24-cardpayments/onlineAuthorized/tools/decomment
+++ b/examples/fm24-cardpayments/onlineAuthorized/tools/decomment
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/examples/idbased/oracle_BP_IBS
+++ b/examples/idbased/oracle_BP_IBS
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -88,5 +88,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-      print goal
+      print(goal)
 

--- a/examples/jcs19-xor/LAK06_state.oracle
+++ b/examples/jcs19-xor/LAK06_state.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -138,5 +138,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-      print goal
+      print(goal)
 

--- a/examples/jcs19-xor/LD07.oracle
+++ b/examples/jcs19-xor/LD07.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -282,5 +282,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/jcs19-xor/OTYT06.oracle
+++ b/examples/jcs19-xor/OTYT06.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -147,5 +147,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-    print goal
+    print(goal)
 

--- a/examples/jcs19-xor/chaum_offline_anonymity.oracle
+++ b/examples/jcs19-xor/chaum_offline_anonymity.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -35,14 +35,14 @@ if lemma == "coins":
   priorities = [ "!St_C_1",  "!Bank_Pk", "(last", "splitEqs", "Mint", "~~>", "!KU( ~r" ]
   avoid = [ ]
 else:
-  print(1)
+  print((1))
   sys.exit()
 
 plist = [ [] for i in priorities ]
 possible = []
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 

--- a/examples/jcs19-xor/diff-models/KCL07-UK3.oracle
+++ b/examples/jcs19-xor/diff-models/KCL07-UK3.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -70,5 +70,5 @@ for listGoals in reversed(rank):
   for goal in listGoals:
     if debug:
       sys.stderr.write(goal)
-      print goal
+      print(goal)
 

--- a/examples/sapic/deprecated/csf21-acc-unbounded/mixnets/message-tracing/oracle-dmn-message-tracing
+++ b/examples/sapic/deprecated/csf21-acc-unbounded/mixnets/message-tracing/oracle-dmn-message-tracing
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 

--- a/examples/sapic/export/5G_AKA/oracle
+++ b/examples/sapic/export/5G_AKA/oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import os

--- a/examples/sapic/fast/Yubikey/oracle
+++ b/examples/sapic/fast/Yubikey/oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # coding: utf-8
 import sys
 import re
@@ -31,7 +31,7 @@ for line in lines:
     )
 
 
-print(l0, l1)
+print((l0, l1))
 ranked = l0 + l1 
 for i in ranked:
   print(i)

--- a/examples/sp14/oracle
+++ b/examples/sp14/oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import re
 import os
@@ -107,4 +107,4 @@ for line in lines:
 ranked = l1 + l2 + l3 + l4 + l5 + l6 + l7
 
 for i in ranked:
-  print i
+  print(i)

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_sel_ShHh_A
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_sel_ShHh_A
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -41,7 +41,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -53,5 +53,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_vot_ShHh
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_vot_ShHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -106,7 +106,7 @@ if lemma == "Tall_As_Rec_D_8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -118,5 +118,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_vot_ShHh_RF
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_vot_ShHh_RF
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -42,7 +42,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -54,5 +54,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_vot_SmHh
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_aletheaD_vot_SmHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -136,7 +136,7 @@ if lemma == "Tall_As_Rec_D_8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -148,5 +148,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_alethea_vot_ShHh
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_alethea_vot_ShHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -70,7 +70,7 @@ if lemma == "Tall_As_Rec_8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -82,5 +82,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_alethea_vot_ShHh_RF
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_alethea_vot_ShHh_RF
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -42,7 +42,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -54,5 +54,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_alethea_vot_SmHh
+++ b/examples/thesis-LaraSchmid-evoting/chapter3_Alethea/o_alethea_vot_SmHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -94,7 +94,7 @@ if lemma == "Tall_As_Rec_8":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -106,5 +106,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_ShHh
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_ShHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -71,7 +71,7 @@ if lemma == "Tall_As_Rec_D":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -83,5 +83,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_ShHh_RF
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_ShHh_RF
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -60,7 +60,7 @@ if lemma == "Observational_equivalence":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -72,5 +72,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_ShHm
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_ShHm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -38,7 +38,7 @@ if lemma == "secretSskD":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -50,5 +50,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_SmHh
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/o_aletheaDR_SmHh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -68,7 +68,7 @@ if lemma == "Tall_As_Rec_D":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -80,5 +80,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
-print 1
+    print(i)
+print(1)

--- a/examples/thesis-LaraSchmid-evoting/chapter5_HumanErrors/AuthenticationProtocols/o_MPAuth_VC
+++ b/examples/thesis-LaraSchmid-evoting/chapter5_HumanErrors/AuthenticationProtocols/o_MPAuth_VC
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -39,7 +39,7 @@ if lemma == "message_authentication":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -51,5 +51,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/thesis-LaraSchmid-evoting/chapter5_HumanErrors/AuthenticationProtocols/o_Phoolproof_MA
+++ b/examples/thesis-LaraSchmid-evoting/chapter5_HumanErrors/AuthenticationProtocols/o_Phoolproof_MA
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #oracle_RF
 import re
 import os
@@ -9,7 +9,7 @@ debug = False
 lines = sys.stdin.readlines()
 
 lemma = sys.argv[1]
-if debug: print >> sys.stderr, "Lemma is "+lemma
+if debug: print("Lemma is "+lemma, file=sys.stderr)
 
 priorities = []
 
@@ -39,7 +39,7 @@ if lemma == "message_authentication":
 plist = [ [] for i in priorities ]
 
 for line in lines:
-  if debug: print >> sys.stderr, "Line is "+line,
+  if debug: print("Line is "+line, end=' ', file=sys.stderr)
 
   num = line.split(':')[0]
 
@@ -51,5 +51,5 @@ for line in lines:
 
 for j in range(len(plist)):
   for i in plist[j]:
-    print i
+    print(i)
 #print 1

--- a/examples/wisec21-5G-handover/inter-5G/5GS_to_EPS_over_N26/5G_handover.oracle
+++ b/examples/wisec21-5G-handover/inter-5G/5GS_to_EPS_over_N26/5G_handover.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 import re
@@ -117,10 +117,10 @@ elif re.match('^secret\_', lemma):
 
 ## UNEXPECTED LEMMAS
 else:
-  print "Unexpected lemma: {}".format(lemma)
+  print("Unexpected lemma: {}".format(lemma))
   exit(0)
 
 for goalList in reversed(rank):
   for goal in goalList:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/wisec21-5G-handover/inter-5G/EPS_to_5GS_over_N26/5G_handover.oracle
+++ b/examples/wisec21-5G-handover/inter-5G/EPS_to_5GS_over_N26/5G_handover.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 import re
@@ -132,10 +132,10 @@ elif re.match('^secret\_', lemma):
 
 ## UNEXPECTED LEMMAS
 else:
-  print "Unexpected lemma: {}".format(lemma)
+  print("Unexpected lemma: {}".format(lemma))
   exit(0)
 
 for goalList in reversed(rank):
   for goal in goalList:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/wisec21-5G-handover/intra-5G/n2/5G_handover.oracle
+++ b/examples/wisec21-5G-handover/intra-5G/n2/5G_handover.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 import re
@@ -304,10 +304,10 @@ elif re.match('^secret\_', lemma):
 
 ## UNEXPECTED LEMMAS
 else:
-  print "Unexpected lemma: {}".format(lemma)
+  print("Unexpected lemma: {}".format(lemma))
   exit(0);
 
 for goalList in reversed(rank):
   for goal in goalList:
     sys.stderr.write(goal)
-    print goal
+    print(goal)

--- a/examples/wisec21-5G-handover/intra-5G/xn/5G_handover.oracle
+++ b/examples/wisec21-5G-handover/intra-5G/xn/5G_handover.oracle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 import re
@@ -247,10 +247,10 @@ elif re.match('^secret\_', lemma):
 
 ## UNEXPECTED LEMMAS
 else:
-  print "Unexpected lemma: {}".format(lemma)
+  print("Unexpected lemma: {}".format(lemma))
   exit(0);
 
 for goalList in reversed(rank):
   for goal in goalList:
     sys.stderr.write(goal)
-    print goal
+    print(goal)


### PR DESCRIPTION
Python 2 has been deprecated on most distributions. This PR migrates all oracles to Python 3.

- Update shebangs to use env python3
- Convert Python 2 print statements to Python 3 print() function
- Convert print >> sys.stderr to print(..., file=sys.stderr)
- Fix tuple printing syntax for Python 3 compatibility

This ensures all oracle scripts in the examples directory work with Python 3, which is now the standard Python version on most systems.