### PR TITLE
Fix for #793

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Formula.hs
+++ b/lib/theory/src/Theory/Text/Parser/Formula.hs
@@ -45,14 +45,14 @@ blatom :: (Hinted v, Ord v) => Parser v -> Parser v -> Parser (SyntacticAtom (VT
 blatom varp nodep = fmap (fmapTerm (fmap Free)) <$> asum
   [ Last        <$> try (symbol "last" *> parens nodevarTerm)        <?> "last atom"
   , flip Action <$> try (fact (vlit varp) <* opAt)        <*> nodevarTerm   <?> "action atom"
-  , Syntactic . Pred <$> try (fact (vlit (try varp <|> nodep) ))                    <?> "predicate atom"
-      -- Predicates can be called for timepoints in addition to other logical vars.
-      -- Note that lexemes that are ambigous (e.g., a variable without a sort)
-      -- will be interpreted by varp.
   , Subterm     <$> try (msetterm False (vlit varp) <* opSubterm) <*> msetterm False (vlit varp) <?> "subterm predicate"    
   , Less        <$> try (nodevarTerm <* opLess)    <*> nodevarTerm   <?> "less atom"
   , smallerp varp <?> "multiset comparisson"
   , EqE         <$> try (termp <* opEqual) <*> termp <?> "term equality"
+  , Syntactic . Pred <$> try (fact (vlit (try varp <|> nodep) ))                    <?> "predicate atom"
+      -- Predicates can be called for timepoints in addition to other logical vars.
+      -- Note that lexemes that are ambigous (e.g., a variable without a sort)
+      -- will be interpreted by varp.
   , EqE         <$>     (nodevarTerm  <* opEqual)  <*> nodevarTerm   <?> "node equality"
   ]
   where

--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -173,7 +173,7 @@ ensureMaude as = do
 
     --  Maude versions prior to 2.7.1 are no longer supported,
     --  because the 'get variants' command is incompatible.
-    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1", "3.4", "3.5"]
+    supportedVersions = ["2.7.1", "3.0", "3.1", "3.2.1", "3.2.2", "3.3", "3.3.1", "3.4", "3.5", "3.5.1"]
 
     errMsg' = errMsg $ "'" ++ maude ++ "' executable not found / does not work"
 


### PR DESCRIPTION
This fixes https://github.com/tamarin-prover/tamarin-prover/issues/793

Summary: previously, things beginning with a capital letter would first be parsed as a predicate. With this change, the parser will first try to match an equality, and if no = is found it will then try taking it as a predicate.

I've run this through the basic regression tests and it produced no changes on existing files (except that the current regressions tests have some files that timed out on derivation checks which did not time out on my machine)