### PR TITLE
Quote dot cluster IDs to allow special characters in roles

### DIFF
--- a/lib/utils/src/Text/Dot.hs
+++ b/lib/utils/src/Text/Dot.hs
@@ -136,7 +136,14 @@ getDotGenStateElements :: Dot [GraphElement]
 getDotGenStateElements = getM dgsElements
 
 createClusterNodeId :: String -> NodeId
-createClusterNodeId agentName = NodeId ("cluster_" ++ agentName)
+createClusterNodeId agentName = NodeId (quoteDotId ("cluster_" ++ agentName))
+
+quoteDotId :: String -> String
+quoteDotId str = "\"" ++ concatMap escape str ++ "\""
+  where
+    escape '"'  = "\\\""
+    escape '\\' = "\\\\"
+    escape c    = [c]
   
 createSubGraph :: Maybe NodeId -> [GraphElement] -> GraphElement
 createSubGraph = SubGraph


### PR DESCRIPTION
This change quotes cluster IDs in the dot output such that role's with special characters are supported.

Example:

```
theory RuleWildcards

begin

rule A[role="*"]:
  [ ] --[ A() ]-> [ ]

lemma A:
  exists-trace
  "Ex #i. A()@i"

end
```