### PR TITLE
Handle _restrict #NOW in derivation checks

### DIFF
--- a/lib/term/src/Term/Unification.hs
+++ b/lib/term/src/Term/Unification.hs
@@ -326,10 +326,8 @@ sortGeqLTerm :: IsConst c => (c -> LSort) -> LVar -> LTerm c -> Bool
 sortGeqLTerm st v t = do
     case (lvarSort v, sortOfLTerm st t) of
         (s1, s2) | s1 == s2     -> True
-        -- Node is incomparable to all other sorts, invalid input
-        (LSortNode,  _        ) -> errNodeSort
-        (_,          LSortNode) -> errNodeSort
+        -- Node is incomparable to all other sorts; treat mismatches as non-matching
+        -- instead of crashing so we fail unification gracefully.
+        (LSortNode,  _        ) -> False
+        (_,          LSortNode) -> False
         (s1, s2)                -> sortCompare s1 s2 `elem` [Just EQ, Just GT]
-  where
-    errNodeSort = error $
-        "sortGeqLTerm: node sort misuse " ++ show v ++ " -> " ++ show t

--- a/lib/theory/src/Theory/Tools/MessageDerivationChecks.hs
+++ b/lib/theory/src/Theory/Tools/MessageDerivationChecks.hs
@@ -166,7 +166,10 @@ checkDiffProofStatuses thy = map (foldProof proofStepStatus . L.get lProof . snd
 -----------------------------------------------
 
 freesInThyRules :: [OpenProtoRule] -> [[LVar]]
-freesInThyRules = map (frees . L.get oprRuleE)
+freesInThyRules =
+    -- Timepoint variables such as #NOW come from _restrict annotations but
+    -- are not message variables we need to prove deducible.
+    map (filter ((/= LSortNode) . lvarSort) . frees . L.get oprRuleE)
 
 premsOfThyRules :: [OpenProtoRule] -> [[LNFact]]
 premsOfThyRules = map (L.get rPrems . L.get oprRuleE)

--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -501,9 +501,13 @@ unboundCheck info ru
     originatesFromLookup v = match v $ ruleProcess $ get preAttributes $ get rInfo ru
     match v (Just (ProcessComb (Lookup _ v') _ _ _))  = v == slvar v'
     match _ _ = False
+    isNowNode v = lvarSort v == LSortNode && lvarName v == "NOW"
     unboundVars = do
         v <- frees (get rConcs ru, get rActs ru, get rInfo ru)
-        guard $ not (lvarSort v == LSortPub || v `S.member` boundVars || originatesFromLookup v)
+        guard $ not ( isNowNode v
+                    || lvarSort v == LSortPub
+                    || v `S.member` boundVars
+                    || originatesFromLookup v)
         return v
 
 -- | Report on sort clashes.


### PR DESCRIPTION
Ensure #NOW from embedded restrictions is handled as a timepoint, not a message variable, and avoid sort-mismatch panics.

- Skip node-sorted variables (e.g., #NOW) when collecting free vars for derivation checks so they’re not treated as message vars.
- Make node vs non-node sort comparisons in unification fail gracefully instead of crashing.
- Exclude #NOW from unbound-variable reports to align with embedded restriction semantics.

Fixes #736