### PR TITLE
Fix freshOrdering to prevent unification contradictions

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -443,7 +443,7 @@ freshOrdering = do
   let subterms = rawSubterms ++ [ (f,f) | (_,f) <- freshVars]  -- add a fake-subterm (f,f) for each freshVar f to the graph
   let graph = M.fromList $ map (\(_,x) -> (x, [ st | st <- subterms, x `el` fst st])) subterms  -- graph that has subterms (s,t) as nodes and edges (s,t) -> (u,v) if t `el` u
   let termsContaining = [((nid,x), map snd $ S.toList $ floodFill graph S.empty (x,x)) | (nid,x) <- freshVars]  -- (freshNodeId, t) for all terms t that have to contain x. So also the ones transitively connected by ⊏ to x
-  let newLesses = [ LessAtom i j Fresh | (j,r) <- nodes, i <- connectNodeToFreshes nonUnifiableNodes el termsContaining j r, i/=j]  -- new ordering constraints that can be added (or enhanced and then added)
+  let newLesses = [ LessAtom i j Fresh | (j,r) <- nodes, i <- connectNodeToFreshes el termsContaining r, nonUnifiableNodes i j, i/=j]  -- new ordering constraints that can be added (or enhanced and then added)
   let enhancedLesses = [ LessAtom (last rs) j Fresh | (LessAtom i j _) <- newLesses, (frI, _) <- freshVars, i == frI, rs <- [route frI], length rs > 1, all (nonUnifiableNodes j) (tail rs)]  -- improved orderings according to routeOfFreshVar
   let allLesses = newLesses ++ enhancedLesses
 
@@ -479,18 +479,13 @@ freshOrdering = do
         | (s,x) `S.member` visited = visited
         | otherwise                = foldl (floodFill graph) (S.insert (s,x) visited) (M.findWithDefault [] x graph)
 
-      connectNodeToFreshes :: (NodeId -> NodeId -> Bool) -> (LNTerm -> LNTerm -> Bool) -> [((NodeId, LNTerm), [LNTerm])] -> NodeId -> RuleACInst -> [NodeId]
-      connectNodeToFreshes _ _ [] _ _ = []
-      connectNodeToFreshes nonUnifiable el (((nid,freshVar), containing):xs) targetNode r | shouldAddOrdering =
+      connectNodeToFreshes :: (LNTerm -> LNTerm -> Bool) -> [((NodeId, LNTerm), [LNTerm])] -> RuleACInst -> [NodeId]
+      connectNodeToFreshes _ [] _ = []
+      connectNodeToFreshes el (((nid,freshVar), containing):xs) r =
           case listToMaybe [nid | t <- containing, t' <- concatMap factTerms (concatMap (`get` r) [rPrems, rActs]), t `el` t'] of
-            Just nid1 -> nid1 : connectNodeToFreshes nonUnifiable el xs targetNode r
-            _         ->        connectNodeToFreshes nonUnifiable el xs targetNode r
-        where
-          -- Only add ordering if the fresh node and target node are NOT unifiable
-          -- If they could unify (nonUnifiable returns False), adding i < j would
-          -- create i < i after unification, which is a contradiction.
-          shouldAddOrdering = nonUnifiable nid targetNode
-      connectNodeToFreshes nonUnifiable el (_:xs) targetNode r = connectNodeToFreshes nonUnifiable el xs targetNode r
+            Just nid1 -> nid1 : connectNodeToFreshes el xs r
+            _         ->        connectNodeToFreshes el xs r
+      connectNodeToFreshes el (_:xs) r = connectNodeToFreshes el xs r
 
 
 -- | simplify the subterm store

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -443,7 +443,7 @@ freshOrdering = do
   let subterms = rawSubterms ++ [ (f,f) | (_,f) <- freshVars]  -- add a fake-subterm (f,f) for each freshVar f to the graph
   let graph = M.fromList $ map (\(_,x) -> (x, [ st | st <- subterms, x `el` fst st])) subterms  -- graph that has subterms (s,t) as nodes and edges (s,t) -> (u,v) if t `el` u
   let termsContaining = [((nid,x), map snd $ S.toList $ floodFill graph S.empty (x,x)) | (nid,x) <- freshVars]  -- (freshNodeId, t) for all terms t that have to contain x. So also the ones transitively connected by ⊏ to x
-  let newLesses = [ LessAtom i j Fresh | (j,r) <- nodes, i <- connectNodeToFreshes el termsContaining r, i/=j]  -- new ordering constraints that can be added (or enhanced and then added)
+  let newLesses = [ LessAtom i j Fresh | (j,r) <- nodes, i <- connectNodeToFreshes nonUnifiableNodes el termsContaining j r, i/=j]  -- new ordering constraints that can be added (or enhanced and then added)
   let enhancedLesses = [ LessAtom (last rs) j Fresh | (LessAtom i j _) <- newLesses, (frI, _) <- freshVars, i == frI, rs <- [route frI], length rs > 1, all (nonUnifiableNodes j) (tail rs)]  -- improved orderings according to routeOfFreshVar
   let allLesses = newLesses ++ enhancedLesses
 
@@ -479,15 +479,18 @@ freshOrdering = do
         | (s,x) `S.member` visited = visited
         | otherwise                = foldl (floodFill graph) (S.insert (s,x) visited) (M.findWithDefault [] x graph)
 
-      connectNodeToFreshes :: (LNTerm -> LNTerm -> Bool) -> [((NodeId, LNTerm), [LNTerm])] -> RuleACInst -> [NodeId]
-      connectNodeToFreshes _ [] _ = []
-      connectNodeToFreshes el (((nid,freshVar), containing):xs) r | allPremsNotF =
+      connectNodeToFreshes :: (NodeId -> NodeId -> Bool) -> (LNTerm -> LNTerm -> Bool) -> [((NodeId, LNTerm), [LNTerm])] -> NodeId -> RuleACInst -> [NodeId]
+      connectNodeToFreshes _ _ [] _ _ = []
+      connectNodeToFreshes nonUnifiable el (((nid,freshVar), containing):xs) targetNode r | shouldAddOrdering =
           case listToMaybe [nid | t <- containing, t' <- concatMap factTerms (concatMap (`get` r) [rPrems, rActs]), t `el` t'] of
-            Just nid1 -> nid1 : connectNodeToFreshes el xs r
-            _         ->        connectNodeToFreshes el xs r
+            Just nid1 -> nid1 : connectNodeToFreshes nonUnifiable el xs targetNode r
+            _         ->        connectNodeToFreshes nonUnifiable el xs targetNode r
         where
-          allPremsNotF = freshFact freshVar `notElem` get rPrems r
-      connectNodeToFreshes el (_:xs) r = connectNodeToFreshes el xs r
+          -- Only add ordering if the fresh node and target node are NOT unifiable
+          -- If they could unify (nonUnifiable returns False), adding i < j would
+          -- create i < i after unification, which is a contradiction.
+          shouldAddOrdering = nonUnifiable nid targetNode
+      connectNodeToFreshes nonUnifiable el (_:xs) targetNode r = connectNodeToFreshes nonUnifiable el xs targetNode r
 
 
 -- | simplify the subterm store


### PR DESCRIPTION
This patch fixes issue #809.

The fresh ordering rule now checks if two nodes could potentially unify before adding ordering constraints. Specifically:

 1. When considering adding a fresh ordering constraint i < j where node i has a Fr(~x) premise
 2. The code now checks if nodes i and j are unifiable using nonUnifiableNodes
 3. Only if they are not unifiable does it add the ordering constraint.
 
This prevents the bug where two instances of the same rule (that will later be unified) would get an ordering constraint, creating a contradiction (i < i) after unification.

The regression tests did not show any meaningful difference.