### PR TITLE
Fix pretty printing of SAPiC's process attribute

### DIFF
--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -1198,7 +1198,7 @@ prettyRuleAttribute attr = fsep $ punctuate comma $ catMaybes [ -- Maybe types a
     ]
     where
 
-    ppProcess   p = text "process=" <> text ("\'" ++ prettySapicTopLevel' f p ++ "\'")
+    ppProcess   p = text "process=" <> text ("\"" ++ prettySapicTopLevel' f p ++ "\"")
         where f l a r rest _ = render $ prettyRuleRestr (g l) (g a) (g r) (h rest)
               g = map toLNFact
               h = map toLFormula

--- a/regressionTests.py
+++ b/regressionTests.py
@@ -261,8 +261,8 @@ def testOutputFileParsing(path):
 		flags = "--diff" if is_diff_file else ""
 		command = f"tamarin-prover --parse-only {flags} {path}"
 		
-		if is_sapic_or_accountability_file and not settings.sapic_output_parse_test:
-			logging.warning(f"Skipping output parse test for {path} since it is a SAPIC or accountability file and the flag --sapic-output-parse-test is not set.")
+		if is_sapic_or_accountability_file and settings.no_sapic_output_parse_test:
+			logging.warning(f"Skipping output parse test for {path} since it is a SAPIC or accountability file and the flag --no-sapic-output-parse-test is set.")
 			return True, None
 
 		process = subprocess.run(command, shell=True, capture_output=True, text=True)
@@ -545,7 +545,7 @@ def getArguments():
 			, type=int, default=3)
 	parser.add_argument("-p", "--parser-test", help = "Run the parser tests.", action="store_true")
 	parser.add_argument("-nopt", "--no-output-parse-test", help="Skip testing if output files can be parsed again", action="store_true")
-	parser.add_argument("-spt", "--sapic-output-parse-test", help="Test if SAPIC output files can be parsed again", action="store_true")
+	parser.add_argument("--no-sapic-output-parse-test", dest="no_sapic_output_parse_test", help="Disable SAPIC/accountability output parse tests", action="store_true")
 	
 
 	## save the settings ##


### PR DESCRIPTION
The SAPiC process attribute is now wrapped in double quotes and can now be parsed by Tamarin again. The SAPiC/accountability parser regressions have been enabled by default again.

Fixes #756