### PR TITLE
Fix macro parser (Issue 777)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ accountability-case-studies:	$(ACCOUNTABILITY_CS_TARGETS)
 ## Regression (old issues)
 ##########################
 
-FAST_REGRESSION_CASE_STUDIES=issue446-1.spthy issue446-2.spthy issue753-4.spthy
+FAST_REGRESSION_CASE_STUDIES=issue446-1.spthy issue446-2.spthy issue753-4.spthy issue777.spthy
 FAST_REGRESSION_TARGETS=$(subst .spthy,_analyzed.spthy,$(addprefix case-studies$(SUBDIR)regression/trace/,$(FAST_REGRESSION_CASE_STUDIES)))
 
 

--- a/case-studies-regression/fast-tests/regression/trace/issue777_analyzed.spthy
+++ b/case-studies-regression/fast-tests/regression/trace/issue777_analyzed.spthy
@@ -1,0 +1,56 @@
+theory ExpMacro
+
+begin
+
+// Function signature and definition of the equational theory E
+
+builtins: diffie-hellman
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+
+
+
+
+
+
+macros: pk( x ) =  'g'^x
+
+rule (modulo E) A:
+   [ Fr( ~x ) ] --> [ Out( pk(~x) ) ]
+
+  /*
+  rule (modulo AC) A:
+     [ Fr( ~x ) ] --> [ Out( 'g'^~x ) ]
+  */
+
+
+
+
+
+
+
+/* All wellformedness checks were successful. */
+
+/*
+Generated from:
+Tamarin version 1.11.0
+Maude version 3.5.1
+Git revision: 416cbfe3281f13caadedb1f6a3bd33b9eae37052 (with uncommited changes), branch: fix-macro-parser
+Compiled at: 2026-02-20 12:26:01.024789 UTC
+*/
+
+end
+/* Output
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/trace/issue777.spthy
+
+  output:          examples/regression/trace/issue777.spthy.tmp
+  processing time: 0.02s
+  
+
+==============================================================================
+*/

--- a/case-studies-regression/regression/trace/issue777_analyzed.spthy
+++ b/case-studies-regression/regression/trace/issue777_analyzed.spthy
@@ -1,0 +1,56 @@
+theory ExpMacro
+
+begin
+
+// Function signature and definition of the equational theory E
+
+builtins: diffie-hellman
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+
+
+
+
+
+
+macros: pk( x ) =  'g'^x
+
+rule (modulo E) A:
+   [ Fr( ~x ) ] --> [ Out( pk(~x) ) ]
+
+  /*
+  rule (modulo AC) A:
+     [ Fr( ~x ) ] --> [ Out( 'g'^~x ) ]
+  */
+
+
+
+
+
+
+
+/* All wellformedness checks were successful. */
+
+/*
+Generated from:
+Tamarin version 1.11.0
+Maude version 3.5.1
+Git revision: 416cbfe3281f13caadedb1f6a3bd33b9eae37052 (with uncommited changes), branch: fix-macro-parser
+Compiled at: 2026-02-20 12:26:01.024789 UTC
+*/
+
+end
+/* Output
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/trace/issue777.spthy
+
+  output:          examples/regression/trace/issue777.spthy.tmp
+  processing time: 0.02s
+  
+
+==============================================================================
+*/

--- a/examples/regression/trace/issue777.spthy
+++ b/examples/regression/trace/issue777.spthy
@@ -1,0 +1,13 @@
+theory ExpMacro
+
+begin
+
+builtins: diffie-hellman
+
+macros:
+    pk(x) = 'g'^x // pk(x) = exp('g', x) works
+
+rule A:
+  [ Fr(~x) ] --> [ Out(pk(~x)) ]
+
+end

--- a/lib/theory/src/Theory/Text/Parser/Macro.hs
+++ b/lib/theory/src/Theory/Text/Parser/Macro.hs
@@ -38,7 +38,7 @@ macros = do
         args <- parens $ commaSep lvar
         unless (length args == length (nub args))
             $ error $ show op ++ " have two arguments with the same name."
-        out <- equalSign *> term llit False
+        out <- equalSign *> msetterm False llit
         sign <- sig <$> getState
         let mc = (op, args, out)
         let k = length args


### PR DESCRIPTION
This PR fixes issue [777](https://github.com/tamarin-prover/tamarin-prover/issues/777) by allowing the use of built-in symbols at top level.

Also includes a regression test.