### PR TITLE
Conservative node abstraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ endif
 # Try to install Tamarin
 default: tamarin
 
-FRONTEND = data/js/intdot-graph.es.js data/js/intdot-staticgraph.es.js data/js/intdot-dynamicgraph.es.js data/css/intdot-style.css
-$(FRONTEND):
+.PHONY: frontend
+frontend:
 	cd frontend && npm install && npm run build
 	cp frontend/dist/intdot-graph.es.js data/js/
 	cp frontend/dist/intdot-staticgraph.es.js data/js/
@@ -23,19 +23,19 @@ $(FRONTEND):
 
 # Default Tamarin installation via stack, multi-threaded
 .PHONY: tamarin
-tamarin: $(FRONTEND)
+tamarin: frontend
 	stack setup
 	stack install
 
 # Single-threaded Tamarin
 .PHONY: single
-single: $(FRONTEND)
+single: frontend
 	stack setup
 	stack install --flag tamarin-prover:-threaded
 
 # Tamarin with profiling options, single-threaded
 .PHONY: profiling
-profiling: $(FRONTEND)
+profiling: frontend
 	stack setup
 	stack install --no-system-ghc --executable-profiling --library-profiling --ghc-options="-fprof-auto -rtsopts" --flag tamarin-prover:-threaded
 
@@ -47,10 +47,6 @@ tamarin-clean:
 # Clean Tamarin
 .PHONY: clean
 clean:	tamarin-clean
-
-.PHONY: frontend
-frontend:
-	$(MAKE) $(FRONTEND)
 
 # ###########################################################################
 # NOTE the remainder makefile is FOR DEVELOPERS ONLY.

--- a/frontend/src/wcs/graph.ts
+++ b/frontend/src/wcs/graph.ts
@@ -10,6 +10,7 @@ const ARROW_HEAD_WIDTH = 7;
 const ARROW_HEAD_HEIGHT = 10;
 const ARROW_HEAD_HALF_WIDTH = ARROW_HEAD_WIDTH / 2;
 const MAX_FONT = 30;
+const ABSTRACT_VIEW_TRIGGER_FONT_PX = 5;
 
 type ZoomLevel = "ZoomIn" | "ZoomOut";
 
@@ -591,8 +592,8 @@ export class DotGraphViz extends HTMLElement {
     // see https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/preserveAspectRatio
     const screen_fs = (this.svgg.getCTM()!).a * 8;
 
-    // 12px is a threshold for determining showing detail view or abstract view
-    const zoomLevel = screen_fs >= 12 ? "ZoomIn" : "ZoomOut";
+    // Keep detailed node rendering until nodes are much smaller on screen.
+    const zoomLevel = screen_fs >= ABSTRACT_VIEW_TRIGGER_FONT_PX ? "ZoomIn" : "ZoomOut";
 
     // do nothing when zoom level didn't change
     if (zoomLevel === this.zoomLevel)


### PR DESCRIPTION
I find that nodes were replaced by timepoint + rule name way too early. The new zooming out limit is much more conservative and applied at a higher zoom level.