### PR TITLE
fix #824

### DIFF
--- a/lib/theory/src/Items/CaseTestItem.hs
+++ b/lib/theory/src/Items/CaseTestItem.hs
@@ -22,7 +22,7 @@ import Text.PrettyPrint.Highlight (HighlightDocument, Document (nest, (<->), ($-
 
 type CaseIdentifier = String
 
-data CaseTest = CaseTest 
+data CaseTest = CaseTest
        { _cName       :: CaseIdentifier
        , _cFormula    :: SyntacticLNFormula
        }
@@ -31,9 +31,8 @@ data CaseTest = CaseTest
 $(mkLabels [''CaseTest])
 
 caseTestToPredicate :: CaseTest -> Maybe Predicate
-caseTestToPredicate caseTest = fmap (Predicate fact) formula
+caseTestToPredicate caseTest = fmap (mkPredicate name) formula
   where
-    fact = protoFact Linear name (frees formula)
     name = L.get cName caseTest
     formula = toLNFormula (L.get cFormula caseTest)
 

--- a/lib/theory/src/Theory/Syntactic/Predicate.hs
+++ b/lib/theory/src/Theory/Syntactic/Predicate.hs
@@ -7,6 +7,7 @@ module Theory.Syntactic.Predicate
         Predicate(..)
       , pFact
       , pFormula
+      , mkPredicate
       , smallerFact
       , builtinPredicates
     ,lookupPredicate,expandFormula)
@@ -22,6 +23,7 @@ import GHC.Generics
 import Control.DeepSeq
 import Data.Binary
 import Data.List
+import Data.Char (toUpper)
 
 ------------------------------------------------------------------------------
 -- Predicates
@@ -33,6 +35,12 @@ data Predicate = Predicate
         }
         deriving( Eq, Ord, Show, Generic, NFData, Binary )
 
+-- | smart constructor for predicates. makes sure names are capitalized
+mkPredicate name formula = Predicate fact formula
+    where
+        fact = protoFact Linear (capitalize name) (frees formula)
+        capitalize (head:tail) = toUpper head : tail
+        capitalize [] = []
 
 -- generate accessors for Predicate data structure records
 

--- a/lib/theory/src/Theory/Text/Parser/Accountability.hs
+++ b/lib/theory/src/Theory/Text/Parser/Accountability.hs
@@ -1,3 +1,4 @@
+
 -- Copyright   : (c) 2021 Robert Künnemann, Kevin Morio & Yavor Ivanov
 -- License     : GPL v3 (see LICENSE)
 --
@@ -8,7 +9,7 @@
 
 module Theory.Text.Parser.Accountability(
         caseTest
-      , lemmaAcc 
+      , lemmaAcc
 )
 where
 


### PR DESCRIPTION
adds a smart constructor that capitalizes the names of predicates so they can be properly parse when output.