### PR TITLE
Delay unstable XOR knowledge goals

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/Goals.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Goals.hs
@@ -77,6 +77,7 @@ openGoals sys = do
                not $    solved
                     -- message variables are not solved, except if the node already exists in the system -> facilitates finding contradictions
                     || (isMsgVar m && Nothing == M.lookup i (get sNodes sys))
+                    || (xorNeedsRefinement m && Nothing == M.lookup i (get sNodes sys))
                     || sortOfLNTerm m == LSortPub
                     || sortOfLNTerm m == LSortNat
                     -- handled by 'insertAction'
@@ -118,6 +119,11 @@ openGoals sys = do
     return (goal, (get gsNr status, useful))
   where
     existingDeps = rawLessRel sys
+    -- Delay xor knowledge goals whose top-level shape can still change after
+    -- message-variable instantiation. Otherwise solveAction may commit to an
+    -- incomplete partition of the current summands.
+    xorNeedsRefinement (viewTerm2 -> FXor ts) = any isMsgVar ts
+    xorNeedsRefinement _                      = False
     hasKUGuards  =
         any ((KUFact `elem`) . guardFactTags) $ S.toList $ get sFormulas sys
 


### PR DESCRIPTION
This fixes an unsoundness in XOR goal solving as reported in #770.

Tamarin could solve a `KU` XOR goal before all message variables inside the XOR term had been instantiated. In that situation it decomposed the term too early, based only on the current top-level XOR summands. That can exclude attacks that only become visible after substitution.

The example from #770:

```spthy
theory Simple begin

builtins:  xor, hashing

rule (modulo E) rule0:
   [ Fr(~n0), Fr( ~n1 ), Fr(~n2), Fr(~n3) ]
  --[OnlyOnce()]->
   [ Name(~n0,~n1,~n2,~n3), Out(~n0 XOR ~n2),
     Out(~n1 XOR ~n3), Out(h(~n2 XOR ~n3))]

rule (modulo E) rule1:
   [ Name(~n0,~n1,~n2,~n3), In(~n0 XOR ~n1 XOR x),
     In(h(x)) ]
  --[Secret()]->
   [ ]

restriction unique:
  "∀ #i #j. ((OnlyOnce( ) @ #i) ∧ (OnlyOnce( ) @ #j)) ⇒ (#i = #j)"

lemma alive:
  all-traces
  "∀ #i. (Secret() @ #i) ⇒ F"

end
```

This lemma should be falsified. The attacker can provide inputs that match the premises of `rule1` with `x := ~n2 XOR ~n3`.

Matching `In(h(x))` against `Out(h(~n2 XOR ~n3))` gives `x := ~n2 XOR ~n3`. Under that substitution, the first input of `rule1` becomes `~n0 XOR ~n1 XOR ~n2 XOR ~n3`. The attacker can construct exactly that message by XORing the two outputs `~n0 XOR ~n2` and `~n1 XOR ~n3`.

**The problem**

The bad proof starts by solving `KU(~n0 XOR ~n1 XOR x)` as if its top-level XOR summands were just `~n0`, `~n1`, and `x`. So it only explores splits based on that incomplete view.

Concretely, it only considers the three splits of those current summands:

- `(~n0 XOR x)` and `~n1`
- `(~n1 XOR x)` and `~n0`
- `(~n0 XOR ~n1)` and `x`

That is too early. Once `In(h(x))` is matched, we get `x := ~n2 XOR ~n3`, and these become:

- `(~n0 XOR ~n2 XOR ~n3)` and `~n1`
- `(~n1 XOR ~n2 XOR ~n3)` and `~n0`
- `(~n0 XOR ~n1)` and `(~n2 XOR ~n3)`

The attacker does not know any of these pairs of messages. In particular, it does not know `~n0`, `~n1`, `~n0 XOR ~n1`, or `~n2 XOR ~n3` as standalone messages.

After substitution, the real term becomes `~n0 XOR ~n1 XOR ~n2 XOR ~n3`. At that point there is an additional valid split:

- `(~n0 XOR ~n2)`
- `(~n1 XOR ~n3)`

This is the missing split. In the XOR constructor rule, such a split means: if the attacker knows those two messages, it can XOR them to obtain the target message. Here, XORing `(~n0 XOR ~n2)` and `(~n1 XOR ~n3)` yields exactly the first input of `rule1` after substitution.

These are exactly the two messages the attacker gets from `rule0`. Because Tamarin had already committed to the earlier decomposition of `~n0 XOR ~n1 XOR x`, this case was never explored, and the attack was missed.

**The fix**

Delay XOR knowledge goals whose top-level XOR summands still contain message variables. Once the term has been instantiated far enough that its XOR structure is stable, solve it as before.

This keeps the existing behavior for concrete XOR terms, but avoids committing to an incomplete XOR decomposition for symbolic ones.

Fixes #770 