### PR TITLE
#849 constant function symbol in equivalence mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ ccs15-case-studies:	$(CCS15_TARGETS)
 	grep "verified\|falsified\|processing time" case-studies$(SUBDIR)ccs15/*.spthy
 
 
-REGRESSION_OBSEQ_CASE_STUDIES=issue223.spthy issue198-1.spthy issue198-2.spthy issue324.spthy issue331.spthy
+REGRESSION_OBSEQ_CASE_STUDIES=issue223.spthy issue198-1.spthy issue198-2.spthy issue324.spthy issue331.spthy issue849-diffF.spthy issue849-diffG.spthy issue849-diffS.spthy
 REGRESSION_OBSEQ_TARGETS=$(subst .spthy,_analyzed-diff.spthy,$(addprefix case-studies$(SUBDIR)regression/diff/,$(REGRESSION_OBSEQ_CASE_STUDIES)))
 
 TESTOBSEQ_CASE_STUDIES=AxiomDiffTest1.spthy AxiomDiffTest2.spthy AxiomDiffTest3.spthy AxiomDiffTest4.spthy N5N6DiffTest.spthy MacroDiffprobEnc.spthy

--- a/case-studies-regression/fast-tests/regression/diff/issue849-diffF_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/regression/diff/issue849-diffF_analyzed-diff.spthy
@@ -1,0 +1,159 @@
+theory issue849_diffF
+
+begin
+
+// Function signature and definition of the equational theory E
+
+builtins: multiset
+functions: c/0, f/2, fst/1, g/1, h/1, pair/2, snd/1
+equations:
+    f(h(g(x)), h(g(x))) = c,
+    fst(<x.1, x.2>) = x.1,
+    snd(<x.1, x.2>) = x.2
+
+rule (modulo E) Setup:
+   [ Fr( ~x ) ]
+  --[ Setup( ) ]->
+   [ Out( diff(f(h(g(~x)), h(g(~x))), c) ), Out( diff(~x, g(~x)) ) ]
+
+diffLemma Observational_equivalence:
+rule-equivalence
+  case Rule_Destrd_union
+  backward-search
+    case LHS
+    step( simplify )
+    step( solve( !KD( (x++y) ) ▶₀ #i ) )
+      case Setup_case_1
+      by step( contradiction /* impossible chain */ )
+    next
+      case Setup_case_2
+      by step( contradiction /* impossible chain */ )
+    qed
+  next
+    case RHS
+    step( simplify )
+    step( solve( !KD( (x++y) ) ▶₀ #i ) )
+      case Setup_case_1
+      by step( contradiction /* impossible chain */ )
+    next
+      case Setup_case_2
+      by step( contradiction /* impossible chain */ )
+    qed
+  qed
+next
+  case Rule_Equality
+  backward-search
+    case LHS
+    step( simplify )
+    step( solve( !KD( x ) ▶₁ #i ) )
+      case Setup_case_1
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case c
+        step( solve( !KU( c ) @ #vk ) )
+          case c_c
+          MIRRORED
+        next
+          case coerce
+          step( solve( !KD( c ) ▶₀ #vk ) )
+            case Setup_case_1
+            by step( contradiction /* impossible chain */ )
+          next
+            case Setup_case_2
+            by step( contradiction /* impossible chain */ )
+          qed
+        qed
+      qed
+    next
+      case Setup_case_2
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case Var_fresh_1_x
+        step( solve( !KU( ~x ) @ #vk ) )
+          case Setup
+          MIRRORED
+        qed
+      qed
+    qed
+  next
+    case RHS
+    step( simplify )
+    step( solve( !KD( x ) ▶₁ #i ) )
+      case Setup_case_1
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case c
+        step( solve( !KU( c ) @ #vk ) )
+          case c_c
+          MIRRORED
+        next
+          case coerce
+          step( solve( !KD( c ) ▶₀ #vk ) )
+            case Setup_case_1
+            by step( contradiction /* impossible chain */ )
+          next
+            case Setup_case_2
+            by step( contradiction /* impossible chain */ )
+          qed
+        qed
+      qed
+    next
+      case Setup_case_2
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case g
+        step( solve( !KU( g(~x) ) @ #vk ) )
+          case Setup
+          MIRRORED
+        next
+          case c_g
+          by step( solve( !KU( ~x ) @ #vk.1 ) )
+        qed
+      qed
+    qed
+  qed
+next
+  case Rule_Send
+  backward-search
+    case LHS
+    step( simplify )
+    MIRRORED
+  next
+    case RHS
+    step( simplify )
+    MIRRORED
+  qed
+next
+  case Rule_Setup
+  backward-search
+    case LHS
+    step( simplify )
+    MIRRORED
+  next
+    case RHS
+    step( simplify )
+    MIRRORED
+  qed
+qed
+
+/* All wellformedness checks were successful. */
+
+/*
+Generated from:
+Tamarin version 1.13.0
+Maude version 3.5.1
+Git revision: 255986bd733baaba138941cbc13e093e3bfebd6c (with uncommited changes), branch: develop
+Compiled at: 2026-04-07 05:16:12.507987 UTC
+*/
+
+end
+/* Output
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/diff/issue849-diffF.spthy
+
+  output:          examples/regression/diff/issue849-diffF.spthy.tmp
+  processing time: 0.05s
+  
+  DiffLemma:  Observational_equivalence : verified (44 steps)
+
+==============================================================================
+*/

--- a/case-studies-regression/fast-tests/regression/diff/issue849-diffG_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/regression/diff/issue849-diffG_analyzed-diff.spthy
@@ -1,0 +1,159 @@
+theory issue849_diffG
+
+begin
+
+// Function signature and definition of the equational theory E
+
+builtins: multiset
+functions: c/0, f/2, fst/1, g/1, pair/2, snd/1
+equations:
+    f(g(x), g(x)) = c,
+    fst(<x.1, x.2>) = x.1,
+    snd(<x.1, x.2>) = x.2
+
+rule (modulo E) Setup:
+   [ Fr( ~x ) ]
+  --[ Setup( ) ]->
+   [ Out( diff(f(g(~x), g(~x)), c) ), Out( diff(~x, g(~x)) ) ]
+
+diffLemma Observational_equivalence:
+rule-equivalence
+  case Rule_Destrd_union
+  backward-search
+    case LHS
+    step( simplify )
+    step( solve( !KD( (x++y) ) ▶₀ #i ) )
+      case Setup_case_1
+      by step( contradiction /* impossible chain */ )
+    next
+      case Setup_case_2
+      by step( contradiction /* impossible chain */ )
+    qed
+  next
+    case RHS
+    step( simplify )
+    step( solve( !KD( (x++y) ) ▶₀ #i ) )
+      case Setup_case_1
+      by step( contradiction /* impossible chain */ )
+    next
+      case Setup_case_2
+      by step( contradiction /* impossible chain */ )
+    qed
+  qed
+next
+  case Rule_Equality
+  backward-search
+    case LHS
+    step( simplify )
+    step( solve( !KD( x ) ▶₁ #i ) )
+      case Setup_case_1
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case c
+        step( solve( !KU( c ) @ #vk ) )
+          case c_c
+          MIRRORED
+        next
+          case coerce
+          step( solve( !KD( c ) ▶₀ #vk ) )
+            case Setup_case_1
+            by step( contradiction /* impossible chain */ )
+          next
+            case Setup_case_2
+            by step( contradiction /* impossible chain */ )
+          qed
+        qed
+      qed
+    next
+      case Setup_case_2
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case Var_fresh_1_x
+        step( solve( !KU( ~x ) @ #vk ) )
+          case Setup
+          MIRRORED
+        qed
+      qed
+    qed
+  next
+    case RHS
+    step( simplify )
+    step( solve( !KD( x ) ▶₁ #i ) )
+      case Setup_case_1
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case c
+        step( solve( !KU( c ) @ #vk ) )
+          case c_c
+          MIRRORED
+        next
+          case coerce
+          step( solve( !KD( c ) ▶₀ #vk ) )
+            case Setup_case_1
+            by step( contradiction /* impossible chain */ )
+          next
+            case Setup_case_2
+            by step( contradiction /* impossible chain */ )
+          qed
+        qed
+      qed
+    next
+      case Setup_case_2
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case g
+        step( solve( !KU( g(~x) ) @ #vk ) )
+          case Setup
+          MIRRORED
+        next
+          case c_g
+          by step( solve( !KU( ~x ) @ #vk.1 ) )
+        qed
+      qed
+    qed
+  qed
+next
+  case Rule_Send
+  backward-search
+    case LHS
+    step( simplify )
+    MIRRORED
+  next
+    case RHS
+    step( simplify )
+    MIRRORED
+  qed
+next
+  case Rule_Setup
+  backward-search
+    case LHS
+    step( simplify )
+    MIRRORED
+  next
+    case RHS
+    step( simplify )
+    MIRRORED
+  qed
+qed
+
+/* All wellformedness checks were successful. */
+
+/*
+Generated from:
+Tamarin version 1.13.0
+Maude version 3.5.1
+Git revision: 255986bd733baaba138941cbc13e093e3bfebd6c (with uncommited changes), branch: develop
+Compiled at: 2026-04-07 05:16:12.507987 UTC
+*/
+
+end
+/* Output
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/diff/issue849-diffG.spthy
+
+  output:          examples/regression/diff/issue849-diffG.spthy.tmp
+  processing time: 0.05s
+  
+  DiffLemma:  Observational_equivalence : verified (44 steps)
+
+==============================================================================
+*/

--- a/case-studies-regression/fast-tests/regression/diff/issue849-diffS_analyzed-diff.spthy
+++ b/case-studies-regression/fast-tests/regression/diff/issue849-diffS_analyzed-diff.spthy
@@ -1,0 +1,159 @@
+theory issue849_diffS
+
+begin
+
+// Function signature and definition of the equational theory E
+
+builtins: multiset
+functions: dec/3, enc/3, fst/1, h/1, k/0, m/0, pair/2, snd/1
+equations:
+    dec(enc(m, k, x), k, h(x)) = m,
+    fst(<x.1, x.2>) = x.1,
+    snd(<x.1, x.2>) = x.2
+
+rule (modulo E) Setup:
+   [ Fr( ~m ), Fr( ~k ), Fr( ~x ) ]
+  --[ Setup( ) ]->
+   [ Out( diff(dec(enc(m, k, ~x), k, h(~x)), m) ), Out( diff(~x, h(~x)) ) ]
+
+diffLemma Observational_equivalence:
+rule-equivalence
+  case Rule_Destrd_union
+  backward-search
+    case LHS
+    step( simplify )
+    step( solve( !KD( (x++y) ) ▶₀ #i ) )
+      case Setup_case_1
+      by step( contradiction /* impossible chain */ )
+    next
+      case Setup_case_2
+      by step( contradiction /* impossible chain */ )
+    qed
+  next
+    case RHS
+    step( simplify )
+    step( solve( !KD( (x++y) ) ▶₀ #i ) )
+      case Setup_case_1
+      by step( contradiction /* impossible chain */ )
+    next
+      case Setup_case_2
+      by step( contradiction /* impossible chain */ )
+    qed
+  qed
+next
+  case Rule_Equality
+  backward-search
+    case LHS
+    step( simplify )
+    step( solve( !KD( x ) ▶₁ #i ) )
+      case Setup_case_1
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case m
+        step( solve( !KU( m ) @ #vk ) )
+          case c_m
+          MIRRORED
+        next
+          case coerce
+          step( solve( !KD( m ) ▶₀ #vk ) )
+            case Setup_case_1
+            by step( contradiction /* impossible chain */ )
+          next
+            case Setup_case_2
+            by step( contradiction /* impossible chain */ )
+          qed
+        qed
+      qed
+    next
+      case Setup_case_2
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case Var_fresh_1_x
+        step( solve( !KU( ~x ) @ #vk ) )
+          case Setup
+          MIRRORED
+        qed
+      qed
+    qed
+  next
+    case RHS
+    step( simplify )
+    step( solve( !KD( x ) ▶₁ #i ) )
+      case Setup_case_1
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case m
+        step( solve( !KU( m ) @ #vk ) )
+          case c_m
+          MIRRORED
+        next
+          case coerce
+          step( solve( !KD( m ) ▶₀ #vk ) )
+            case Setup_case_1
+            by step( contradiction /* impossible chain */ )
+          next
+            case Setup_case_2
+            by step( contradiction /* impossible chain */ )
+          qed
+        qed
+      qed
+    next
+      case Setup_case_2
+      step( solve( (#vl, 0) ~~> (#i, 1) ) )
+        case h
+        step( solve( !KU( h(~x) ) @ #vk ) )
+          case Setup
+          MIRRORED
+        next
+          case c_h
+          by step( solve( !KU( ~x ) @ #vk.1 ) )
+        qed
+      qed
+    qed
+  qed
+next
+  case Rule_Send
+  backward-search
+    case LHS
+    step( simplify )
+    MIRRORED
+  next
+    case RHS
+    step( simplify )
+    MIRRORED
+  qed
+next
+  case Rule_Setup
+  backward-search
+    case LHS
+    step( simplify )
+    MIRRORED
+  next
+    case RHS
+    step( simplify )
+    MIRRORED
+  qed
+qed
+
+/* All wellformedness checks were successful. */
+
+/*
+Generated from:
+Tamarin version 1.13.0
+Maude version 3.5.1
+Git revision: 255986bd733baaba138941cbc13e093e3bfebd6c (with uncommited changes), branch: develop
+Compiled at: 2026-04-07 05:16:12.507987 UTC
+*/
+
+end
+/* Output
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/diff/issue849-diffS.spthy
+
+  output:          examples/regression/diff/issue849-diffS.spthy.tmp
+  processing time: 0.05s
+  
+  DiffLemma:  Observational_equivalence : verified (44 steps)
+
+==============================================================================
+*/

--- a/examples/regression/diff/issue849-diffF.spthy
+++ b/examples/regression/diff/issue849-diffF.spthy
@@ -1,0 +1,14 @@
+theory issue849_diffF begin
+
+builtins: multiset
+functions: f/2, g/1, h/1, c/0
+equations: f(h(g(x)), h(g(x))) = c()
+
+rule Setup:
+  [ Fr(~x) ]
+--[ Setup() ]->
+  [ Out( diff( f(h(g(~x)), h(g(~x))), c() ) )
+  , Out( diff( ~x, g(~x) ) )
+  ]
+
+end

--- a/examples/regression/diff/issue849-diffG.spthy
+++ b/examples/regression/diff/issue849-diffG.spthy
@@ -1,0 +1,14 @@
+theory issue849_diffG begin
+
+builtins: multiset
+functions: f/2, g/1, c/0
+equations: f(g(x), g(x)) = c()
+
+rule Setup:
+  [ Fr(~x) ]
+--[ Setup() ]->
+  [ Out( diff( f(g(~x), g(~x)), c() ) )
+  , Out( diff( ~x, g(~x) ) )
+  ]
+
+end

--- a/examples/regression/diff/issue849-diffS.spthy
+++ b/examples/regression/diff/issue849-diffS.spthy
@@ -1,0 +1,15 @@
+theory issue849_diffS begin
+
+builtins: multiset
+functions: dec/3, enc/3, h/1, k/0, m/0
+
+equations: dec(enc(m, k, x), k, h(x)) = m
+
+rule Setup:
+  [ Fr( ~m ), Fr( ~k ), Fr( ~x ) ]
+--[ Setup() ]->
+  [ Out( diff( dec(enc(m, k, ~x), k, h(~x)), m ) )
+  , Out( diff( ~x, h(~x) ) )
+  ]
+
+end

--- a/lib/theory/src/Theory/Tools/IntruderRules.hs
+++ b/lib/theory/src/Theory/Tools/IntruderRules.hs
@@ -128,13 +128,14 @@ destructionRules :: Bool -> CtxtStRule -> [IntrRuleAC]
 destructionRules bool (CtxtStRule lhs@(viewTerm -> FApp _ _) (StRhs (pos:[]) rhs)) | (bool || (frees rhs /= []) || (containsPrivate rhs)) =
     go [] lhs pos empty []
   where
-    -- In diff mode, avoid creating destruction rules for public constructor subterms
-    -- when the equation itself produces a public constructor result. This prevents
-    -- spurious one-sided derivations in diff mode while preserving destructor rules
-    -- for projection-style equations (where rhs is a variable, not a constructor).
-    isPublicConstrTerm (viewTerm -> FApp (NoEq (_,(_,Public,Constructor))) _) = True
-    isPublicConstrTerm _                                                       = False
-    isPublicConstrRhs = isPublicConstrTerm rhs
+    -- In diff mode, avoid creating destruction rules for public constructor *constants*
+    -- when the equation itself produces a public constructor constant result.
+    -- This prevents spurious one-sided derivations in diff mode for constant public
+    -- terms like `c()` or `true`, while preserving destructor rules for non-constant
+    -- constructors such as `h(x)`.
+    isPublicConstrConstant (viewTerm -> FApp (NoEq (_,(_,Public,Constructor))) as) = null as
+    isPublicConstrConstant _                                                       = False
+    isPublicConstrRhs = isPublicConstrConstant rhs
     go _      _                       []     _ _                     = []
     -- term already in premises, but necessary for constant conclusions
     go _      (viewTerm -> FApp _ _)  (_:[]) _ _ | (frees rhs /= []) = []
@@ -146,7 +147,7 @@ destructionRules bool (CtxtStRule lhs@(viewTerm -> FApp _ _) (StRhs (pos:[]) rhs
         funs    = append (append n (pack "_")) f
         posname = "_" ++ show i ++ pd
         name    = append (pack posname) funs
-        canGenerate = t' /= rhs && rhs `notElem` uprems' && not (bool && isPublicConstrTerm t' && isPublicConstrRhs)
+        canGenerate = t' /= rhs && rhs `notElem` uprems' && not (bool && isPublicConstrConstant t' && isPublicConstrRhs)
         irule = if canGenerate
                 then [Rule (DestrRule name (-1) (rhs == lhs `atPos` pos) (frees rhs == []))
                             ((kdFact t'):(map kuFact uprems'))

--- a/lib/theory/src/Theory/Tools/IntruderRules.hs
+++ b/lib/theory/src/Theory/Tools/IntruderRules.hs
@@ -45,8 +45,6 @@ import           Term.Positions
 
 import           Theory.Model
 
--- import           Debug.Trace
-
 -- Variants of intruder deduction rules
 ----------------------------------------------------------------------
 
@@ -130,6 +128,13 @@ destructionRules :: Bool -> CtxtStRule -> [IntrRuleAC]
 destructionRules bool (CtxtStRule lhs@(viewTerm -> FApp _ _) (StRhs (pos:[]) rhs)) | (bool || (frees rhs /= []) || (containsPrivate rhs)) =
     go [] lhs pos empty []
   where
+    -- In diff mode, avoid creating destruction rules for public constructor subterms
+    -- when the equation itself produces a public constructor result. This prevents
+    -- spurious one-sided derivations in diff mode while preserving destructor rules
+    -- for projection-style equations (where rhs is a variable, not a constructor).
+    isPublicConstrTerm (viewTerm -> FApp (NoEq (_,(_,Public,Constructor))) _) = True
+    isPublicConstrTerm _                                                       = False
+    isPublicConstrRhs = isPublicConstrTerm rhs
     go _      _                       []     _ _                     = []
     -- term already in premises, but necessary for constant conclusions
     go _      (viewTerm -> FApp _ _)  (_:[]) _ _ | (frees rhs /= []) = []
@@ -138,17 +143,18 @@ destructionRules bool (CtxtStRule lhs@(viewTerm -> FApp _ _) (StRhs (pos:[]) rhs
       where
         uprems' = uprems++[ t | (j, t) <- zip [0..] as, i /= j ]
         t'      = as!!i
-        funs = append (append n (pack "_")) f
+        funs    = append (append n (pack "_")) f
         posname = "_" ++ show i ++ pd
         name    = append (pack posname) funs
-        irule = if {-trace (show lhs ++ " " ++ show pos ++ " " ++ show posname ++ " " ++ show rhs ++ " " ++ show (lhs `atPos` pos) ++ " " ++ show (frees rhs == []))-} (t' /= rhs && rhs `notElem` uprems')
-                then [ Rule (DestrRule name (-1) (rhs == lhs `atPos` pos) (frees rhs == []))
-                            ((kdFact  t'):(map kuFact uprems'))
-                            [kdFact rhs] [] [] ]
+        canGenerate = t' /= rhs && rhs `notElem` uprems' && not (bool && isPublicConstrTerm t' && isPublicConstrRhs)
+        irule = if canGenerate
+                then [Rule (DestrRule name (-1) (rhs == lhs `atPos` pos) (frees rhs == []))
+                            ((kdFact t'):(map kuFact uprems'))
+                            [kdFact rhs] [] []]
                 else []
     go _      (viewTerm -> FApp (NoEq (_,(_,Private,_))) _) _     _ _  = []
     go _      (viewTerm -> Lit _)                         (_:_) _ _  =
-        error "IntruderRules.destructionRules: impossible, position invalid"   
+        error "IntruderRules.destructionRules: impossible, position invalid"
      
 destructionRules bool (CtxtStRule lhs (StRhs (pos:posit) rhs)) 
     | (bool || (frees rhs /= []) || (containsPrivate rhs)) = 
@@ -185,8 +191,8 @@ privateConstructorRules rules = map createRule $ derivablePrivateConstants (priv
 
 -- | Simple removal of subsumed rules for auto-generated subterm intruder rules.
 minimizeIntruderRules :: Bool -> [IntrRuleAC] -> [IntrRuleAC]
-minimizeIntruderRules diff rules = 
-    filter (\x -> not $ isDoublePremiseRule x) 
+minimizeIntruderRules diff rules =
+    filter (\x -> not $ isDoublePremiseRule x)
       $ if diff then rules else go [] rules
   where
     go checked [] = reverse checked
@@ -210,7 +216,7 @@ minimizeIntruderRules diff rules =
 subtermIntruderRules :: Bool -> MaudeSig -> [IntrRuleAC]
 subtermIntruderRules diff maudeSig =
    minimizeIntruderRules diff $ concatMap (destructionRules diff) (S.toList $ stRules maudeSig)
-     ++ constructionRules (stFunSyms maudeSig) ++ privateConstructorRules (S.toList $ stRules maudeSig) 
+     ++ constructionRules (stFunSyms maudeSig) ++ privateConstructorRules (S.toList $ stRules maudeSig)
 
 -- | @constructionRules fSig@ returns the construction rules for the given
 -- function signature @fSig@

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -44,8 +44,7 @@ import Data.FileEmbed (embedFile)
 import Data.List (find, intercalate, isPrefixOf)
 import Data.Map (keys)
 import Data.Maybe (fromMaybe, isNothing)
-import Data.Set qualified
-import Debug.Trace
+import Data.Set qualified as S
 import Export qualified
 import Items.LemmaItem (HasLemmaAttributes, HasLemmaName)
 import Items.OptionItem (Option (..))
@@ -56,6 +55,7 @@ import System.Console.CmdArgs.Explicit
 import System.Timeout (timeout)
 import Text.Parsec (ParseError)
 import Text.Read (readEither)
+import Debug.Trace (traceM)
 import Theory hiding (closeTheory, transReport)
 import Theory.Module
 import Theory.Text.Parser (diffTheory, parseIntruderRules, theory)
@@ -469,7 +469,7 @@ checkTranslatedTheory ::
 checkTranslatedTheory thyOpts sign thy = do
   let transReport =
         either
-          (\thy -> checkWellformedness incompleteMSRs thy sign)
+          (\transThy -> checkWellformedness incompleteMSRs transThy sign)
           (`checkWellformednessDiff` sign)
           thy
 
@@ -525,8 +525,8 @@ checkTranslatedTheory thyOpts sign thy = do
           , irreducibleFunSyms = makepublicsym (irreducibleFunSyms s._sigMaudeInfo)
           , reducibleFunSyms = makepublicsym (reducibleFunSyms s._sigMaudeInfo)
           }
-    makepublic = Data.Set.map (\(name, (int, _, construct)) -> (name, (int, Public, construct)))
-    makepublicsym = Data.Set.map $ \case
+    makepublic = S.map (\(name, (int, _, construct)) -> (name, (int, Public, construct)))
+    makepublicsym = S.map $ \case
       NoEq (name, (int, _, constr)) -> NoEq (name, (int, Public, constr))
       x -> x
 
@@ -810,7 +810,9 @@ addMessageDeductionRuleVariantsDiff thy0
         ++ (if enableNat msig then natIntruderRules else [])
         ++ (if enableMSet msig then multisetIntruderRules else [])
         ++ (if enableXor msig then xorIntruderRules else [])
-    thy = addIntrRuleACsDiffBoth (rules False) $ addIntrRuleACsDiffBothDiff (rules True) thy0
+    rulesFalse = rules False
+    rulesTrue = rules True
+    thy = addIntrRuleACsDiffBoth rulesFalse $ addIntrRuleACsDiffBothDiff rulesTrue thy0
     addIntruderVariantsDiff mkRuless =
       addIntrRuleLabels $
         addIntrRuleACsDiffBothDiff


### PR DESCRIPTION
It adds new regression test cases for diff-based observational equivalence and improves the handling of intruder destruction rules in diff mode to prevent spurious one-sided derivations. Additionally, it includes minor code cleanups and refactoring.


**Intruder rule generation improvements:**

* Updated the `destructionRules` function in `Theory/Tools/IntruderRules.hs` to avoid generating destruction rules for public constructor subterms when the equation's right-hand side is also a public constructor in diff mode. This change prevents incorrect one-sided derivations, while still allowing rules for projection-style equations.


ISSUE: #849 