### PR TITLE
tree-sitter-spthy: Fix quantifier precedence

### DIFF
--- a/manual/grammar/grammar.ebnf
+++ b/manual/grammar/grammar.ebnf
@@ -1,10 +1,10 @@
 extras  ::=  { multi_comment single_comment /\s|\\\r?\n|\u00A0/ }
 
-conflicts  ::=  { { pub_var } { fresh_var } { msg_var_or_nullary_fun } { temporal_var } { nat_var } { pub_var fresh_var msg_var_or_nullary_fun temporal_var nat_var } { pub_var fresh_var msg_var_or_nullary_fun nat_var } { accountability_lemma diff_lemma } { lemma diff_lemma } { nary_app predicate_ref } { nullary_fun nary_app msg_var_or_nullary_fun } }
+conflicts  ::=  { { pub_var } { fresh_var } { temporal_var } { nat_var } { pub_var fresh_var msg_var_or_nullary_fun temporal_var nat_var } { pub_var fresh_var msg_var_or_nullary_fun nat_var } { nary_app predicate_ref } { nullary_fun nary_app msg_var_or_nullary_fun } }
 
 externals  ::=  { multi_comment single_comment }
 
-precedences  ::=  { { 'NESTED' 'FUNCTION' 'VARIABLE' 'EXPONENTIAL' 'MULTIPLY' 'ADD' 'MUL_SET' 'TUPLE' 'NULLARY_FUN' 'ATOM' 'LOGICAL_NOT' 'EXCLUSIVE_OR' 'LOGICAL_AND' 'LOGICAL_OR' 'LOGICAL_IMPLICATION' 'LOGICAL_IFF' 'CHAIN_GOAL' } { 'NON_DIFF' 'DIFF' } { 'REPLICATION' 'EVENT' 'CHOICE' 'PROCESS_LET' 'LOOKUP' 'CONDITIONAL' } }
+precedences  ::=  { { 'PROCESS' 'NESTED' 'FUNCTION' 'VARIABLE' 'EXPONENTIAL' 'MULTIPLY' 'ADD' 'MUL_SET' 'TUPLE' 'NULLARY_FUN' 'ATOM' 'LOGICAL_NOT' 'EXCLUSIVE_OR' 'LOGICAL_AND' 'LOGICAL_OR' 'LOGICAL_IMPLICATION' 'LOGICAL_IFF' 'QUANTIFIER' 'CHAIN_CONSTRAINT' } { 'NON_DIFF' 'DIFF' } { 'REPLICATION' 'EVENT' 'CHOICE' 'PROCESS_LET' 'LOOKUP' 'CONDITIONAL' } }
 
 word  ::=  ident
 
@@ -16,7 +16,7 @@ rules:
   preprocessor  ::=  ifdef | define | include
   ifdef  ::=  '#ifdef' _ifdef_formula _body_item* ('#else' _body_item*)? '#endif'
   define  ::=  '#define' ident
-  include  ::=  '#include' '"' (param -> path) '"'
+  include  ::=  '#include' '"' path '"'
   _ifdef_formula  ::=  ifdef_nested | ifdef_or | ifdef_and | ifdef_not | ident
   ifdef_nested  ::=  NESTED('(' _ifdef_formula ')')
   ifdef_or  ::=  <LOGICAL_OR(_ifdef_formula '|' _ifdef_formula)
@@ -31,19 +31,19 @@ rules:
   function_attribute  ::=  'private' | 'destructor'
   function_typed  ::=  (ident: function_identifier) '(' arguments? ')' ':' (ident: function_type)
   equations  ::=  >('equations' ('[' 'convergent' ']')? ':' equation (',' equation)* ','?)
-  equation  ::=  (_term: left) '=' (_term: right)
+  equation  ::=  (mset_term: left) '=' (mset_term: right)
   predicates  ::=  ('predicate' | 'predicates') ':' predicate (',' predicate)*
   predicate  ::=  (predicate_def -> '') '<=>' (_formula: formula)
   predicate_def  ::=  (ident: predicate_identifier) '(' arguments? ')'
   options  ::=  'options' ':' option (',' option)* ','?
   option  ::=  'translation-state-optimisation' | 'translation-progress' | 'translation-asynchronous-channels' | 'translation-compress-events' | 'translation-allow-pattern-lookups'
-  global_heuristic  ::=  'heuristic' ':' (_goal_ranking+: goal_ranking)
-  _goal_ranking  ::=  standard_goal_ranking | oracle_goal_ranking | tactic_goal_ranking
-  standard_goal_ranking  ::=  /[CISPcisp][CISPcisp]?[CISPcisp]?[CISPcisp]?/
-  oracle_goal_ranking  ::=  ('O' | 'o') ('"' param '"')?
-  tactic_goal_ranking  ::=  '{' ident '}'
+  global_heuristic  ::=  'heuristic' ':' (_proof_method_ranking+: proof_method_ranking)
+  _proof_method_ranking  ::=  standard_proof_method_ranking | oracle_proof_method_ranking | tactic_proof_method_ranking
+  standard_proof_method_ranking  ::=  /[CISPcisp][CISPcisp]?[CISPcisp]?[CISPcisp]?/
+  oracle_proof_method_ranking  ::=  ('O' | 'o') ('"' param '"')?
+  tactic_proof_method_ranking  ::=  '{' ident '}'
   tactic  ::=  'tactic' ':' ident presort? ((prio+ deprio*) | (prio* deprio+))
-  presort  ::=  'presort' ':' standard_goal_ranking
+  presort  ::=  'presort' ':' standard_proof_method_ranking
   prio  ::=  'prio' ':' ('{' post_ranking '}')? _function+
   deprio  ::=  'deprio' ':' ('{' post_ranking '}')? _function+
   post_ranking  ::=  'smallest' | 'id'
@@ -52,7 +52,7 @@ rules:
   and_function  ::=  <LOGICAL_AND(_function '&' _function)
   not_function  ::=  LOGICAL_NOT('not' _function)
   std_function  ::=  function_name ('"' param '"')*
-  function_name  ::=  'regex' | 'isFactName' | 'isInFactTerms' | 'dhreNoise' | 'defaultNoise' | 'reasonableNoncesNoise' | 'nonAbsurdGoal'
+  function_name  ::=  'regex' | 'isFactName' | 'isInFactTerms' | 'dhreNoise' | 'defaultNoise' | 'reasonableNoncesNoise' | 'nonAbsurdConstraint'
   process  ::=  'process' ':' _process
   _process  ::=  _elementary_process | _extended_process | _stateful_process | inline_msr_process | _nested_process | location_process | predefined_process
   _elementary_process  ::=  binding | output | input | conditional | process_let | deterministic_choice | non_deterministic_choice | null
@@ -61,26 +61,26 @@ rules:
   location_process  ::=  '(' _process ')' '@' ((_literal | tuple_term): location_identifier)
   inline_msr_process  ::=  >(premise ('-->' | action_fact) conclusion (';' _process)?)
   _nested_process  ::=  '(' _process ')'
-  predefined_process  ::=  <-1(_term)
+  predefined_process  ::=  <PROCESS(mset_term)
   binding  ::=  >('new' _literal (';' _process)?)
-  output  ::=  >(('out' '(' _term ',' _term ')' (';' _process)?) | ('out' '(' _term ')' (';' _process)?))
-  input  ::=  >(('in' '(' _term ',' _term ')' (';' _process)?) | ('in' '(' _term ')' (';' _process)?))
+  output  ::=  >(('out' '(' mset_term ',' mset_term ')' (';' _process)?) | ('out' '(' mset_term ')' (';' _process)?))
+  input  ::=  >(('in' '(' mset_term ',' mset_term ')' (';' _process)?) | ('in' '(' mset_term ')' (';' _process)?))
   conditional  ::=  >CONDITIONAL('if' (_condition: condition) 'then' (_process: then) ('else' (_process: else))?)
   process_let  ::=  >PROCESS_LET('let' term_eq+ 'in' (_process: in) ('else' (_process: else))?)
   deterministic_choice  ::=  <CHOICE(_process ('|' | '||') _process)
-  non_deterministic_choice  ::=  <CHOICE(_process ('+') _process)
+  non_deterministic_choice  ::=  <CHOICE(_process '+' _process)
   null  ::=  '0'
   event  ::=  >EVENT('event' _fact (';' _process)?)
   replication  ::=  >REPLICATION('!' _process (';' _process)?)
-  set_state  ::=  >('insert' (_term: from) ',' (_term: to) (';' _process)?)
-  delete_state  ::=  >('delete' _term (';' _process)?)
-  read_state  ::=  >LOOKUP('lookup' (_term: from) 'as' (_lvar: to) 'in' (_process: in) ('else' (_process: else))? (';' _process)?)
-  set_lock  ::=  >('lock' _term (';' _process)?)
-  remove_lock  ::=  >('unlock' _term (';' _process)?)
+  set_state  ::=  >('insert' (mset_term: from) ',' (mset_term: to) (';' _process)?)
+  delete_state  ::=  >('delete' mset_term (';' _process)?)
+  read_state  ::=  >LOOKUP('lookup' (mset_term: from) 'as' (_lvar: to) 'in' (_process: in) ('else' (_process: else))? (';' _process)?)
+  set_lock  ::=  >('lock' mset_term (';' _process)?)
+  remove_lock  ::=  >('unlock' mset_term (';' _process)?)
   _condition  ::=  equality_check | lesser_check | predicate_ref
-  equality_check  ::=  (_term | _formula) @(1('=')) (_term | _formula)
-  lesser_check  ::=  _term ('(<)' | '<<') _term
-  let  ::=  'let' (_term: let_identifier) '=' _process
+  equality_check  ::=  (mset_term | _formula) @(1('=')) (mset_term | _formula)
+  lesser_check  ::=  mset_term ('(<)' | '<<') mset_term
+  let  ::=  'let' (mset_term: let_identifier) '=' _process
   export  ::=  'export' (ident: export_identifier) ':' '"' export_query '"'
   _rule  ::=  rule | diff_rule
   rule  ::=  simple_rule variants?
@@ -92,14 +92,22 @@ rules:
   variants  ::=  'variants' simple_rule (',' simple_rule)*
   modulo  ::=  '(' 'modulo' ('E' | 'AC') ')'
   rule_attrs  ::=  '[' rule_attr (',' rule_attr)* ','? ']'
-  rule_attr  ::=  rule_attr_color | 'no_derivcheck' | 'issapicrule' | rule_process | rule_role
+  rule_attr  ::=  rule_attr_color | 'no_derivcheck' | 'issapicrule' | rule_process | rule_role | rule_extended_attribute
   rule_attr_color  ::=  ('color=' | 'colour=') hexcolor
-  rule_role  ::=  'role' '=' '"' (ident: role_identifier) '"'
-  rule_process  ::=  'process' '=' '"' ident '"'
+  rule_role  ::=  'role' '=' ''' (ident: role_identifier) '''
+  rule_process  ::=  'process' '=' ''' ident '''
+  rule_extended_attribute  ::=  (xattribute_ident: extended_attribute_name) ('=' (('[' (no_square_brackets: extended_attribute_value) ']') | ('(' (no_round_brackets: extended_attribute_value) ')') | ('{' (no_curly_brackets: extended_attribute_value) '}') | ('"' (no_double_quotes: extended_attribute_value) '"') | (''' (no_single_quotes: extended_attribute_value) ''') | ('|' (no_pipe: extended_attribute_value) '|')))?
+  xattribute_ident  ::=  @(-1(/x-[a-zA-Z_]+/))
+  no_square_brackets  ::=  @(-1(/[^\[\]]*/))
+  no_round_brackets  ::=  @(-1(/[^\(\)]*/))
+  no_curly_brackets  ::=  @(-1(/[^\{\}]*/))
+  no_double_quotes  ::=  @(-1(/[^"]*/))
+  no_single_quotes  ::=  @(-1(/[^']*/))
+  no_pipe  ::=  @(-1(/[^|]*/))
   rule_let_block  ::=  'let' rule_let_term+ 'in'
-  rule_let_term  ::=  ((msg_var_or_nullary_fun | nat_var): left) '=' (_term: right)
+  rule_let_term  ::=  ((msg_var_or_nullary_fun | nat_var): left) '=' (mset_term: right)
   macros  ::=  'macros' ':' macro (',' macro)*
-  macro  ::=  (ident: macro_identifier) '(' (_non_temporal_var (',' _non_temporal_var)*)? ')' '=' (_term: term)
+  macro  ::=  (ident: macro_identifier) '(' (_non_temporal_var (',' _non_temporal_var)*)? ')' '=' (mset_term: term)
   embedded_restriction  ::=  '_restrict' '(' (_formula: formula) ')'
   _facts_restrictions  ::=  <((_fact | embedded_restriction) (',' (_fact | embedded_restriction))*)
   _facts  ::=  <(_fact (',' _fact)*)
@@ -112,7 +120,7 @@ rules:
   case_test  ::=  'test' (ident: test_identifier) ':' '"' (_formula: formula) '"'
   _lemma  ::=  lemma | diff_lemma | accountability_lemma | equiv_lemma | diff_equiv_lemma
   lemma  ::=  'lemma' modulo? (ident: lemma_identifier) diff_lemma_attrs? ':' trace_quantifier? '"' (_formula: formula) '"' (_proof_skeleton: proof_skeleton)?
-  lemma_attr  ::=  'sources' | 'reuse' | 'use_induction' | ('output=' '[' language (',' language)* ']') | ('hide_lemma=' ident) | ('heuristic=' (_goal_ranking+: goal_ranking))
+  lemma_attr  ::=  'sources' | 'reuse' | 'use_induction' | ('output=' '[' language (',' language)* ']') | ('hide_lemma=' ident) | ('heuristic=' (_proof_method_ranking+: proof_method_ranking))
   language  ::=  'spthy' | 'spthytyped' | 'msr' | 'proverif' | 'deepsec'
   diff_lemma  ::=  'diffLemma' modulo? (ident: lemma_identifier) diff_lemma_attrs? ':' (_proof_skeleton: proof_skeleton)?
   diff_lemma_attrs  ::=  '[' (diff_lemma_attr | lemma_attr) (',' (diff_lemma_attr | lemma_attr))* ','? ']'
@@ -129,26 +137,26 @@ rules:
   cases  ::=  case ('next' case)* 'qed'
   case  ::=  'case' (ident: case_identifier) (_proof_skeleton: proof_skeleton)
   _proof_methods  ::=  >(proof_method | step+)
-  proof_method  ::=  'sorry' | 'simplify' | ('solve' '(' goal ')') | 'contradiction' | 'induction' | 'rule-equivalence' | 'backward-search' | 'ATTACK'
+  proof_method  ::=  'sorry' | 'simplify' | ('solve' '(' constraint ')') | 'contradiction' | 'induction' | 'rule-equivalence' | 'backward-search' | 'ATTACK'
   step  ::=  'step' '(' proof_method ')'
-  goal  ::=  premise_goal | action_goal | chain_goal | disjunction_split_goal | eq_split_goal
-  premise_goal  ::=  _fact '▶' natural_subscript temporal_var
-  action_goal  ::=  _fact '@' temporal_var
-  chain_goal  ::=  '(' temporal_var ',' natural ')' '~~>' '(' temporal_var ',' natural ')'
-  disjunction_split_goal  ::=  CHAIN_GOAL((_formula: formula) (('||' | '∥') (_formula: formula))+)
-  eq_split_goal  ::=  'splitEqs' '(' natural ')'
-  _term  ::=  tuple_term | mset_term | nested_term | nullary_fun | binary_app | nary_app | _literal
-  tuple_term  ::=  TUPLE('<' ((mset_term): term) (',' (mset_term: term))* '>')
-  mset_term  ::=  <MUL_SET((nat_term: left) ('++' | '+') (nat_term: right))
-  nat_term  ::=  <ADD((xor_term: left) '%+' (xor_term: right))
-  xor_term  ::=  <EXCLUSIVE_OR((mult_term: left) ('XOR' | '⊕') (mult_term: right))
-  mult_term  ::=  <MULTIPLY((exp_term: left) '*' (exp_term: right))
-  exp_term  ::=  >EXPONENTIAL((_term: base) '^' (_term: exponent))
+  constraint  ::=  premise_constraint | action_constraint | chain_constraint | disjunction_split_constraint | eq_split_constraint
+  premise_constraint  ::=  _fact '▶' natural_subscript temporal_var
+  action_constraint  ::=  ATOM((_fact: fact) '@' ((temporal_var_optional_prefix -> temporal_var): variable))
+  chain_constraint  ::=  '(' temporal_var ',' natural ')' '~~>' '(' temporal_var ',' natural ')'
+  disjunction_split_constraint  ::=  CHAIN_CONSTRAINT((_formula: formula) (('||' | '∥') (_formula: formula))+)
+  eq_split_constraint  ::=  'splitEqs' '(' natural ')'
+  _term  ::=  tuple_term | nested_term | nullary_fun | binary_app | nary_app | _literal
+  tuple_term  ::=  TUPLE('<' (mset_term: left) (',' (mset_term: right))* '>')
+  mset_term  ::=  <MUL_SET((nat_term: left) (('++' | '+') (nat_term: right))*)
+  nat_term  ::=  <ADD((xor_term: left) ('%+' (xor_term: right))*)
+  xor_term  ::=  <EXCLUSIVE_OR((mul_term: left) (('XOR' | '⊕') (mul_term: right))*)
+  mul_term  ::=  <MULTIPLY((exp_term: left) ('*' (exp_term: right))*)
+  exp_term  ::=  >EXPONENTIAL((_term: base) ('^' (_term: exponent))*)
   nested_term  ::=  NESTED('(' mset_term ')')
   nullary_fun  ::=  NULLARY_FUN((ident: function_identifier) | ((ident: function_identifier) '(' ')'))
-  binary_app  ::=  FUNCTION((ident: function_identifier) '{' (_term: argument) (',' (_term: argument))*? '}' (_term: argument))
+  binary_app  ::=  FUNCTION((ident: function_identifier) '{' (arguments: argument) '}' (mset_term: argument))
   nary_app  ::=  FUNCTION((ident: function_identifier) '(' arguments ')')
-  arguments  ::=  ((_term | temporal_var): argument) (',' (_term: argument))*
+  arguments  ::=  ((mset_term | temporal_var): argument) (',' (mset_term: argument))*
   _literal  ::=  pub_name | fresh_name | _non_temporal_var | comp_var | _custom_type_var
   _non_temporal_var  ::=  pub_var | fresh_var | msg_var_or_nullary_fun | nat_var
   pub_var  ::=  VARIABLE(('$' (ident: variable_identifier) ('.' natural)?) | ((ident: variable_identifier) ('.' natural)? ':' 'pub'))
@@ -174,17 +182,17 @@ rules:
   temp_var_induction  ::=  ATOM('last' '(' temporal_var ')')
   temp_var_order  ::=  ATOM(((temporal_var_optional_prefix -> temporal_var): left) '<' ((temporal_var_optional_prefix -> temporal_var): right))
   temp_var_eq  ::=  ATOM(((temporal_var_optional_prefix -> temporal_var): left) '=' ((temporal_var_optional_prefix -> temporal_var): right))
-  action_constraint  ::=  ATOM((_fact: fact) '@' ((temporal_var_optional_prefix -> temporal_var): variable))
-  term_eq  ::=  ATOM((_term: left) '=' (_term: right))
-  subterm_rel  ::=  ATOM((_term: left) ('<<' | '⊏') (_term: right))
-  quantified_formula  ::=  ATOM(('Ex' | '∃' | 'All' | '∀') (_lvar+: variable) '.' (_formula: formula))
+  term_eq  ::=  ATOM((mset_term: left) '=' (mset_term: right))
+  subterm_rel  ::=  ATOM((mset_term: left) ('<<' | '⊏') (mset_term: right))
+  quantified_formula  ::=  QUANTIFIER(('Ex' | '∃' | 'All' | '∀') (_lvar+: variable) '.' (_formula: formula))
   atom  ::=  ATOM('⊥' | 'F' | '⊤' | 'T')
   _lvar  ::=  temporal_var | _non_temporal_var
   predicate_ref  ::=  FUNCTION((ident: predicate_identifier) '(' arguments? ')')
   pre_defined  ::=  NULLARY_FUN(ident)
   hexcolor  ::=  (''' @('#')? @(/[0-9a-fA-F]{1,6}/) ''') | (@('#')? @(/[0-9a-fA-F]{1,6}/))
-  ident  ::=  /[A-Za-z0-9][a-zA-Z0-9_*]*/
+  ident  ::=  /[A-Za-z0-9]\w*/
   param  ::=  /[^"]*/
+  path  ::=  /[A-Za-z0-9-\_]*/
   export_query  ::=  /(\\"|[^"])*/
   natural  ::=  /[0-9]+/
   natural_subscript  ::=  ('₀' | '₁' | '₂' | '₃' | '₄' | '₅' | '₆' | '₇' | '₈' | '₉')+

--- a/tree-sitter/tree-sitter-spthy/grammar.js
+++ b/tree-sitter/tree-sitter-spthy/grammar.js
@@ -56,6 +56,7 @@ module.exports = grammar({
           'LOGICAL_OR',
           'LOGICAL_IMPLICATION',
           'LOGICAL_IFF',
+          'QUANTIFIER',
           'CHAIN_CONSTRAINT',
       ],
       // Diff
@@ -1414,7 +1415,7 @@ module.exports = grammar({
           field('right', $.mset_term)
       )),
 
-      quantified_formula: $ => prec('ATOM', seq(
+      quantified_formula: $ => prec('QUANTIFIER', seq(
           choice('Ex', '∃', 'All', '∀'),
           field('variable', repeat1($._lvar)),
           '.',

--- a/tree-sitter/tree-sitter-spthy/src/grammar.json
+++ b/tree-sitter/tree-sitter-spthy/src/grammar.json
@@ -6237,7 +6237,7 @@
     },
     "quantified_formula": {
       "type": "PREC",
-      "value": "ATOM",
+      "value": "QUANTIFIER",
       "content": {
         "type": "SEQ",
         "members": [
@@ -6659,6 +6659,10 @@
       {
         "type": "STRING",
         "value": "LOGICAL_IFF"
+      },
+      {
+        "type": "STRING",
+        "value": "QUANTIFIER"
       },
       {
         "type": "STRING",


### PR DESCRIPTION
The precedence of quantifiers should be lower than the precedence of logical operators in order to agree with the Tamarin parser.

For example, currently, the tree-sitter parser incorrectly parses 
```spthy
All x #t . P(x)@t ==> Q(x)@t
```
equivalently to
```spthy
(All x #t. P(x)@t) ==> Q(x)@t
```
instead of
```spthy
All x #t. (P(x)@t ==> Q(x)@t).
```

Fixes #854. (This PR also updates the EBNF file (generated by `generate-ebnf.js`) which thus reflects some previous changes to the grammar, too.)
