### PR TITLE
Parse nullary macro applications

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Term.hs
+++ b/lib/theory/src/Theory/Text/Parser/Term.hs
@@ -140,7 +140,8 @@ term plit eqn = asum
       maudeSig <- sig <$> getState
       -- FIXME: This try should not be necessary.
       asum [ try (symbol (BC.unpack sym)) $> fApp fs []
-           | fs@(NoEq (sym,(0,_,_))) <- S.toList $ funSyms maudeSig ]
+           | fs@(NoEq (sym,(0,_,_))) <- S.toList $
+               funSyms maudeSig `S.union` S.map NoEq (macroNames maudeSig) ]
 
 -- | A left-associative sequence of exponentations.
 expterm :: Ord l => Bool -> Parser (Term l) -> Parser (Term l)


### PR DESCRIPTION
Prior to this change nullary macros where considered as variables instead of macro applications causing Tamarin not being able to parse its own output.

**Example:**

```
theory NullaryMacro

begin

macros:
  init() = 'x'

rule A:
  [ ] --> [ A(init()) ]

end
```

**Tamarin Output:**

```
theory NullaryMacro

begin

// Function signature and definition of the equational theory E

functions: fst/1, pair/2, snd/1
equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2

macros: init( ) =  'x'

rule (modulo E) A:
   [ ] --> [ A( init ) ]

  /*
  rule (modulo AC) A:
     [ ] --> [ A( 'x' ) ]
  */

/* All wellformedness checks were successful. */

/*
Generated from:
Tamarin version 1.13.0
Maude version 3.4
Git revision: 255986bd733baaba138941cbc13e093e3bfebd6c (with uncommited changes), branch: develop
Compiled at: 2026-05-05 17:01:45.562031 UTC
*/

end
```