### PR TITLE
Show user-facing error message for missing natural-numbers builtin

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Term.hs
+++ b/lib/theory/src/Theory/Text/Parser/Term.hs
@@ -125,8 +125,12 @@ term plit eqn = asum
     [ pairing       <?> "pairs"
     , parens (msetterm eqn plit)
     , symbol "DH_neutral" *> pure fAppDHNeutral    
-    , symbol "1:nat"      *> pure fAppNatOne
-    , symbol "%1"         *> pure fAppNatOne
+    , symbol "1:nat"
+        *> requireNaturalNumbers "natural-number literal 1:nat"
+        *> pure fAppNatOne
+    , symbol "%1"
+        *> requireNaturalNumbers "natural-number literal %1"
+        *> pure fAppNatOne
     , symbol "1"          *> pure fAppOne
     , application        <?> "function application"
     , nullaryApp

--- a/lib/theory/src/Theory/Text/Parser/Token.hs
+++ b/lib/theory/src/Theory/Text/Parser/Token.hs
@@ -111,6 +111,7 @@ module Theory.Text.Parser.Token (
   , mkMacroStateSig
   , modifyStateSig
   , modifyStateFlag
+  , requireNaturalNumbers
 
     -- * Basic Parsing
   , Parser
@@ -186,6 +187,12 @@ modifyStateFlag ::  Monad m => (S.Set String -> S.Set String) -> ParsecT s Parse
 modifyStateFlag modifier = do
    st <- getState
    setState (st {flags = modifier $ flags st})
+
+requireNaturalNumbers :: String -> Parser ()
+requireNaturalNumbers what = do
+    st <- getState
+    unless (enableNat (sig st)) $
+        fail $ what ++ " requires the natural-numbers builtin"
 
 -- | Add macros to the signature so they're recognized as function symbols
 addMacrosToSignature :: [(B.ByteString, [LVar], Term (Lit Name LVar))] -> MaudeSig -> MaudeSig
@@ -401,12 +408,18 @@ hexColor = T.lexeme spthy (singleQuoted hexCode <|> hexCode)
 -- | Parse a logical variable with the given sorts allowed.
 sortedLVar :: [LSort] -> Parser LVar
 sortedLVar ss =
-    asum $ map (try . mkSuffixParser) ss ++ map mkPrefixParser ss
+    asum $ mkSuffixParser : map mkPrefixParser ss
   where
-    mkSuffixParser s = do
-        (n, i) <- indexedIdentifier <* colon
-        symbol_ (sortSuffix s)
+    mkSuffixParser = do
+        (n, i) <- try (indexedIdentifier <* colon)
+        s <- asum $ map parseSuffix ss
+        when (s == LSortNat) $
+            requireNaturalNumbers "nat-sorted variables"
         return (LVar n s i)
+
+    parseSuffix s = do
+        try $ symbol_ (sortSuffix s)
+        return s
 
     mkPrefixParser s = do
         case s of
@@ -414,7 +427,8 @@ sortedLVar ss =
           LSortPub       -> void $ char '$'
           LSortFresh     -> void $ char '~'
           LSortNode      -> void $ char '#'
-          LSortNat       -> void $ char '%'
+          LSortNat       -> void $
+              char '%' *> requireNaturalNumbers "nat-sorted variables"
         (n, i) <- indexedIdentifier
         return (LVar n s i)
 
@@ -448,7 +462,10 @@ pubName = singleQuotedString
 
 -- | Parse a literal nat name, e.g. @%'n'@.
 natName :: Parser String
-natName = try (symbol "%" *> singleQuotedString)
+natName = do
+    _ <- try (symbol "%" <* lookAhead (char '\''))
+    requireNaturalNumbers "nat names"
+    singleQuotedString
 
 -- | Parse a Sapic Type
 typep :: Parser SapicType
@@ -476,7 +493,8 @@ sortedLVarNoSuffix ss =
           LSortPub       -> void $ char '$'
           LSortFresh     -> void $ char '~'
           LSortNode      -> void $ char '#'
-          LSortNat       -> void $ char '%'
+          LSortNat       -> void $
+              char '%' *> requireNaturalNumbers "nat-sorted variables"
         (n, i) <- indexedIdentifier
         return (LVar n s i)
 


### PR DESCRIPTION
This change displays a user-facing error when natural numbers are used without the required builtin.

**Example:**

```
theory NaturalNumbers

begin

rule A:
  [ ] --> [ A(%1) ]

end
```

**Current:**

```
tamarin-prover: user error (
computeViaMaude:
Parse error: `not enough input'
For Maude Output: `'
For query: `get variants in MSG : list(cons(tamXCtone,nil)) .
')
```

**After:**

```
"example.spthy" (line 6, column 17):
unexpected ")"
natural-number literal %1 requires the natural-numbers builtin
```