### PR TITLE
Optimisation: Switch DisjT from ListT to LogicT

### DIFF
--- a/lib/utils/src/Control/Monad/Trans/Disj.hs
+++ b/lib/utils/src/Control/Monad/Trans/Disj.hs
@@ -20,7 +20,7 @@ module Control.Monad.Trans.Disj (
 import Control.Monad
 import Control.Monad.Disj.Class
 import Control.Monad.Reader
-import ListT
+import Control.Monad.Logic (LogicT, observeAllT)
 
 
 ------------------------------------------------------------------------------
@@ -28,16 +28,16 @@ import ListT
 ------------------------------------------------------------------------------
 
 -- | A disjunction of atoms of type a.
-newtype DisjT m a = DisjT { unDisjT :: ListT m a }
+newtype DisjT m a = DisjT { unDisjT :: LogicT m a }
   deriving (Functor, Applicative, MonadTrans )
 
--- | Construct a 'DisjT' action.
+-- | Construct a 'DisjT' action: a disjunction over the elements of a foldable.
 disjT :: (Monad m, Foldable m) => m a -> DisjT m a
-disjT = DisjT . fromFoldable
+disjT = DisjT . foldr (mplus . return) mzero
 
--- | Run a 'DisjT' action.
+-- | Run a 'DisjT' action, enumerating all atoms in order.
 runDisjT :: Monad m => DisjT m a -> m [a]
-runDisjT = toList . unDisjT
+runDisjT = observeAllT . unDisjT
 
 
 

--- a/lib/utils/tamarin-prover-utils.cabal
+++ b/lib/utils/tamarin-prover-utils.cabal
@@ -47,7 +47,7 @@ library
       , deepseq
       , dlist
       , fclabels
-      , list-t
+      , logict
       , mtl
       , pretty
       , safe


### PR DESCRIPTION
From some profiling, DisjT and it's associated ListT actions make up somewhere north of 30% of the runtime of tamarin on some of the longer running protocols in the examples. We actually don't need the ListT semantics, though; stitching together two sets of answers (with mplus) in a list is a new allocated list. LogicT instead does this as continuations and then it's only actually resolved when calling `observeAllT`, so there's no intermediary allocations (and copying memory around).

The actual semantics of observeAllT over the LogicT should be exactly equivalent to the ListT implementation.

On my machine this results in Tamarin proving examples roughly 30% faster on average, with ~10% ish reduced memory usage. I would appreciate some additional comparisons though!

Examples:

`examples/jcs19-xor/NSLPK3xor.spthy`:
```
OLD:
	0:01.33 real,	4.40 user,	0.76 sys,	0 amem,	216336 mmem

NEW:
	0:00.89 real,	2.81 user,	0.57 sys,	0 amem,	198592 mmem
```

`examples/wireguard/wireguard.spthy`:
```
OLD:
	0:28.93 real,	87.13 user,	16.47 sys,	0 amem,	2495792 mmem
NEW:
	0:23.08 real,	67.63 user,	14.66 sys,	0 amem,	2204656 mmem
```

`examples/eurosp19-eccDAA/ISOIEC_20008_2013_2_ECC_DAA.fixed.spthy`
```
OLD:
	1:57.38 real,	418.30 user,	75.46 sys,	0 amem,	8660336 mmem
NEW:
	1:26.82 real,	323.52 user,	63.84 sys,	0 amem,	7958528 mmem
```