### PR TITLE
Optimisation: Inlining and specialising functions

### DIFF
--- a/lib/term/src/Term/LTerm.hs
+++ b/lib/term/src/Term/LTerm.hs
@@ -296,6 +296,7 @@ freshLVar :: MonadFresh m => String -> LSort -> m LVar
 freshLVar n s = LVar n s <$> freshIdent n
 
 -- | Returns the most precise sort of an 'LTerm'.
+{-# INLINABLE sortOfLTerm #-}
 sortOfLTerm :: Show c => (c -> LSort) -> LTerm c -> LSort
 sortOfLTerm sortOfConst t = case viewTerm2 t of
     Lit2 (Con c)  -> sortOfConst c
@@ -568,19 +569,23 @@ class HasFrees t where
     mapFrees   :: Applicative f => MonotoneFunction f -> t -> f t
 
 -- | @v `occurs` t@ iff variable @v@ occurs as a free variable in @t@.
+{-# INLINABLE occurs #-}
 occurs :: HasFrees t => LVar -> t -> Bool
 occurs x = getAny . foldFrees (Any . (x ==))
 
 -- | @freesDList t@ is the difference list of all free variables of @t@.
+{-# INLINABLE freesDList #-}
 freesDList :: HasFrees t => t -> D.DList LVar
 freesDList = foldFrees pure
 
 -- | @freesList t@ is the list of all free variables of @t@.
+{-# INLINABLE freesList #-}
 freesList :: HasFrees t => t -> [LVar]
 freesList = D.toList . freesDList
 
 -- | @frees t@ is the sorted and duplicate-free list of all free variables in
 -- @t@.
+{-# INLINABLE frees #-}
 frees :: HasFrees t => t -> [LVar]
 frees = sortednub . freesList
 
@@ -598,12 +603,14 @@ varOccurences =
 -- | @someInst t@ returns an instance of @t@ where all free variables whose
 -- binding is not yet determined by the caller are replaced with fresh
 -- variables.
+{-# INLINABLE someInst #-}
 someInst :: (MonadFresh m, MonadBind LVar LVar m, HasFrees t) => t -> m t
 someInst = mapFrees (Arbitrary $ \x -> importBinding (`LVar` lvarSort x) x (lvarName x))
 
 -- | @rename t@ replaces all variables in @t@ with fresh variables.
 --   Note that the result is not guaranteed to be equal for terms that are
 --   equal modulo changing the indices of variables.
+{-# INLINABLE rename #-}
 rename :: (MonadFresh m, HasFrees a) => a -> m a
 rename x = case boundsVarIdx x of
     Nothing                     -> return x
@@ -639,11 +646,13 @@ eqModuloFreshnessNoAC t1 =
                   mapFrees (Arbitrary $ \x -> importBinding (`LVar` lvarSort x) x "")
 
 -- | The mininum and maximum index of all free variables.
+{-# INLINABLE boundsVarIdx #-}
 boundsVarIdx :: HasFrees t => t -> Maybe (Integer, Integer)
 boundsVarIdx = getMinMax . foldFrees (minMaxSingleton . lvarIdx)
 
 -- | @avoid t@ computes a 'FreshState' that avoids generating
 -- variables occurring in @t@.
+{-# INLINABLE avoid #-}
 avoid :: HasFrees t => t -> FreshState
 avoid = maybe 0 (succ . snd) . boundsVarIdx
 
@@ -676,6 +685,7 @@ avoidPreciseVars = foldl' ins M.empty
 
 -- | @avoidPrecise t@ computes a 'Precise.FreshState' that avoids generating
 -- variables occurring in @t@.
+{-# INLINABLE avoidPrecise #-}
 avoidPrecise :: HasFrees t => t -> Precise.FreshState
 avoidPrecise = avoidPreciseVars . frees
 
@@ -683,6 +693,7 @@ avoidPrecise = avoidPreciseVars . frees
 --   If 'Control.Monad.PreciseFresh' is used with non-AC terms and identical
 --   fresh state, the same result is returned for two terms that only differ
 --   in the indices of variables.
+{-# INLINABLE renamePrecise #-}
 renamePrecise :: (MonadFresh m, HasFrees a) => a -> m a
 renamePrecise x = evalBindT (someInst x) noBindings
 
@@ -696,32 +707,39 @@ renameDropNamehint =
 ------------
 
 instance HasFrees LVar where
+    {-# INLINABLE foldFrees #-}
     foldFrees = id
     foldFreesOcc f c v = f c v
+    {-# INLINABLE mapFrees #-}
     mapFrees (Arbitrary f) = f
     mapFrees (Monotone f)  = f
 
 instance HasFrees v => HasFrees (Lit c v) where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (Var x) = foldFrees f x
     foldFrees _ _       = mempty
 
     foldFreesOcc f c (Var x) = foldFreesOcc f c x
     foldFreesOcc _ _ _       = mempty
 
+    {-# INLINABLE mapFrees #-}
     mapFrees f (Var x) = Var <$> mapFrees f x
     mapFrees _ l       = pure l
 
 instance HasFrees v => HasFrees (BVar v) where
+    {-# INLINABLE foldFrees #-}
     foldFrees _ (Bound _) = mempty
     foldFrees f (Free v)  = foldFrees f v
 
     foldFreesOcc _ _ (Bound _) = mempty
     foldFreesOcc f c (Free v)  = foldFreesOcc f c v
 
+    {-# INLINABLE mapFrees #-}
     mapFrees _ b@(Bound _) = pure b
     mapFrees f   (Free v)  = Free <$> mapFrees f v
 
 instance (HasFrees l, Ord l) => HasFrees (Term l) where
+    {-# INLINABLE foldFrees #-}
     foldFrees f = foldMap (foldFrees f)
 
     foldFreesOcc f c t = case viewTerm t of
@@ -730,24 +748,31 @@ instance (HasFrees l, Ord l) => HasFrees (Term l) where
         FApp o        as -> mconcat $ map (foldFreesOcc f (show o:c)) as
           -- AC or C symbols
 
+    {-# INLINABLE mapFrees #-}
     mapFrees f (viewTerm -> Lit l)                  = lit <$> mapFrees f l
     mapFrees f@(Arbitrary _) (viewTerm -> FApp o l) = fApp o <$> mapFrees f l
     mapFrees f@(Monotone _)  (viewTerm -> FApp o l) = unsafefApp o <$> mapFrees f l
 
 instance HasFrees a => HasFrees (Equal a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f               = foldMap (foldFrees f)
     foldFreesOcc f p (Equal a b) = foldFreesOcc f p (a,b)
+    {-# INLINABLE mapFrees #-}
     mapFrees     f               = traverse (mapFrees f)
 
 instance HasFrees a => HasFrees (Match a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f                       = foldMap (foldFrees f)
     foldFreesOcc _ _ NoMatch             = mempty
     foldFreesOcc f p (DelayedMatches ms) = foldFreesOcc f p ms
+    {-# INLINABLE mapFrees #-}
     mapFrees     f                       = traverse (mapFrees f)
 
 instance HasFrees a => HasFrees (RRule a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f               = foldMap (foldFrees f)
     foldFreesOcc f p (RRule a b) = foldFreesOcc f p (a,b)
+    {-# INLINABLE mapFrees #-}
     mapFrees     f               = traverse (mapFrees f)
 
 instance HasFrees () where
@@ -776,19 +801,25 @@ instance HasFrees Char where
     mapFrees     _   = pure
 
 instance HasFrees a => HasFrees (Maybe a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f            = foldMap (foldFrees f)
     foldFreesOcc _ _ Nothing  = mempty
     foldFreesOcc f p (Just x) = foldFreesOcc f p x
+    {-# INLINABLE mapFrees #-}
     mapFrees     f            = traverse (mapFrees f)
 
 instance (HasFrees a, HasFrees b) => HasFrees (Either a b) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f   = either (foldFrees f) (foldFrees f)
     foldFreesOcc f p = either (foldFreesOcc f ("0":p)) (foldFreesOcc f ("1":p))
+    {-# INLINABLE mapFrees #-}
     mapFrees     f   = either (fmap Left . mapFrees   f) (fmap Right . mapFrees   f)
 
 instance (HasFrees a, HasFrees b) => HasFrees (a, b) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f   (x, y) = foldFrees f x `mappend` foldFrees f y
     foldFreesOcc f p (x, y) = foldFreesOcc f ("0":p) x `mappend` foldFreesOcc f ("1":p) y
+    {-# INLINABLE mapFrees #-}
     mapFrees     f   (x, y) = (,) <$> mapFrees   f x <*> mapFrees   f y
 
 instance (HasFrees a, HasFrees b, HasFrees c) => HasFrees (a, b, c) where
@@ -807,32 +838,42 @@ instance (HasFrees a, HasFrees b, HasFrees c, HasFrees d) => HasFrees (a, b, c, 
         (\(x, (y, (z, a))) -> (x, y, z, a)) <$> mapFrees f (x0, (y0, (z0, a0)))
 
 instance HasFrees a => HasFrees [a] where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f      = foldMap  (foldFrees f)
     foldFreesOcc f c xs = mconcat $ (map (\(i,x) -> foldFreesOcc f (show i:c) x)) $ zip [(0::Int)..] xs
+    {-# INLINABLE mapFrees #-}
     mapFrees     f      = traverse (mapFrees f)
 
 instance HasFrees a => HasFrees (Disj a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f     = foldMap  (foldFrees f)
     foldFreesOcc f p d = foldFreesOcc f p (getDisj d)
+    {-# INLINABLE mapFrees #-}
     mapFrees     f     = traverse (mapFrees f)
 
 instance HasFrees a => HasFrees (Conj a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f     = foldMap  (foldFrees f)
     foldFreesOcc f p c = foldFreesOcc f p (getConj c)
+    {-# INLINABLE mapFrees #-}
     mapFrees     f     = traverse (mapFrees f)
 
 instance (Ord a, HasFrees a) => HasFrees (S.Set a) where
+    {-# INLINABLE foldFrees #-}
     foldFrees   f    = foldMap  (foldFrees f)
     foldFreesOcc f p = foldMap (foldFreesOcc f ("0":p))
+    {-# INLINABLE mapFrees #-}
     mapFrees     f   = fmap S.fromList . mapFrees f . S.toList
 
 instance (Ord k, HasFrees k, HasFrees v) => HasFrees (M.Map k v) where
+    {-# INLINABLE foldFrees #-}
     foldFrees f = M.foldrWithKey combine mempty
       where
         combine k v m = foldFrees f k `mappend` (foldFrees f v `mappend` m)
     foldFreesOcc f p = M.foldrWithKey combine mempty
       where
         combine k v m = foldFreesOcc f p (k,v) `mappend` m
+    {-# INLINABLE mapFrees #-}
     mapFrees f = fmap M.fromList . mapFrees f . M.toList
 
 

--- a/lib/term/src/Term/Maude/Types.hs
+++ b/lib/term/src/Term/Maude/Types.hs
@@ -61,6 +61,16 @@ lTermToMTerm' = lTermToMTerm sortOfName
 
 
 -- | Convert an @LNTerm@ with arbitrary names to an @MTerm@.
+--
+-- Almost always called at the concrete @Name@/@BindT (Lit Name LVar) MaudeLit
+-- Fresh@ type from the @theory@ package, once per Maude query. Without an
+-- exposed unfolding GHC compiled the @mapM@/@<$>@/@importBinding@ plumbing once
+-- with dictionary passing, so we make it INLINABLE and hint the common
+-- specialisation.
+{-# INLINABLE lTermToMTerm #-}
+{-# SPECIALIZE lTermToMTerm
+      :: (Name -> LSort) -> VTerm Name LVar
+      -> BindT (Lit Name LVar) MaudeLit Fresh MTerm #-}
 lTermToMTerm :: (MonadBind (Lit c LVar) MaudeLit m, MonadFresh m, Ord c)
              => (c -> LSort) -- ^ A function that returns the sort of a constant.
              -> VTerm c LVar -- ^ The term to translate.
@@ -77,6 +87,10 @@ lTermToMTerm sortOf =
 
 -- | Convert an 'MTerm' to an 'LNTerm' under the assumption that the bindings
 -- for the constants are already available.
+{-# INLINABLE mTermToLNTerm #-}
+{-# SPECIALIZE mTermToLNTerm
+      :: String -> MTerm
+      -> BindT MaudeLit (Lit Name LVar) Fresh (VTerm Name LVar) #-}
 mTermToLNTerm :: (MonadBind MaudeLit (Lit c LVar) m, MonadFresh m, Ord c, Show c)
              => String -- ^ Name hint for freshly generated variables.
              -> MTerm  -- ^ The maude term to convert.

--- a/lib/term/src/Term/Substitution/SubstVFree.hs
+++ b/lib/term/src/Term/Substitution/SubstVFree.hs
@@ -101,10 +101,18 @@ applyLit subst v@(Var i)  = fromMaybe (lit v) $ M.lookup i (sMap subst)
 applyLit _     c@(Con _)  = lit c
 
 -- | @applyVTerm subst t@ applies the substitution @subst@ to the term @t@.
+--
+-- This is one of the hottest functions in the constraint solver and is called
+-- almost exclusively at the concrete 'LNTerm' type from a different package
+-- (@theory@), so GHC seems to miss the change to specialise that case without
+-- an added hint here.
+{-# INLINABLE applyVTerm #-}
+{-# SPECIALIZE applyVTerm :: LNSubst -> LNTerm -> LNTerm #-}
 applyVTerm :: (IsConst c, IsVar v) => Subst c v -> VTerm c v -> VTerm c v
 applyVTerm = applyVTermProj applyLit
 
 -- | Variant of @applyVTerm@ with custom function to apply literals
+{-# INLINABLE applyVTermProj #-}
 applyVTermProj :: Ord a => (t1 -> t2 -> Term a) -> t1 -> Term t2 -> Term a
 applyVTermProj f subst t = case viewTerm t of
     Lit l            -> f subst l
@@ -118,6 +126,7 @@ applyVTermProj f subst t = case viewTerm t of
 ----------------------------------------------------------------------
 
 -- | Convert a list to a substitution. The @x/x@ mappings are removed.
+{-# INLINABLE substFromList #-}
 substFromList :: IsVar v => [(v, VTerm c v)] -> Subst c v
 substFromList xs  =
     Subst (M.fromList [ (v,t) | (v,t) <- xs, not (equalToVar t v) ])
@@ -129,6 +138,7 @@ equalToVar _                          _ = False
 
 -- | Convert a map to a substitution. The @x/x@ mappings are removed.
 -- FIXME: implement directly, use substFromMap for substFromList.
+{-# INLINABLE substFromMap #-}
 substFromMap :: IsVar v => Map v (VTerm c v) -> Subst c v
 substFromMap = Subst . M.filterWithKey (\v t -> not $ equalToVar t v)
 
@@ -219,8 +229,10 @@ instance Sized (Subst c v) where
 ------------
 
 instance Ord c => HasFrees (LSubst c) where
+    {-# INLINABLE foldFrees #-}
     foldFrees  f = foldFrees f . sMap
     foldFreesOcc = mempty -- we ignore occurences in substitutions for now
+    {-# INLINABLE mapFrees #-}
     mapFrees   f = (substFromList <$>) . mapFrees   f . substToList
 
 -- | Types that support the application of some type

--- a/lib/term/src/Term/Term.hs
+++ b/lib/term/src/Term/Term.hs
@@ -245,6 +245,10 @@ allProtSubterms _                                     = []
 
 -- | Is term @inner@ in term @outer@ and not below a reducible function symbol?
 -- This is used for the Subterm relation
+-- INLINABLE so the call site (the subterm store, at the concrete 'LNTerm'
+-- type in another package) can specialise away the @Eq@/@Ord FunSym@
+-- dictionaries and the per-level @any@ closure.
+{-# INLINABLE elemNotBelowReducible #-}
 elemNotBelowReducible :: Eq a => FunSig -> Term a -> Term a -> Bool
 elemNotBelowReducible _ inner outer
                       | inner == outer = True

--- a/lib/term/src/Term/Term/Raw.hs
+++ b/lib/term/src/Term/Term/Raw.hs
@@ -114,6 +114,7 @@ fApp List        ts = FAPP List ts
 fApp s@(NoEq _)  ts = FAPP s ts
 
 -- | Smart constructor for AC terms.
+{-# INLINABLE fAppAC #-}
 fAppAC :: Ord a => ACSym -> [Term a] -> Term a
 fAppAC _     []  = error "Term.fAppAC: empty argument list"
 fAppAC _     [a] = a
@@ -127,6 +128,7 @@ fAppAC acsym as  =
     o_as              = [ a | FAPP _ ts <- o_as0, a <- ts ]
 
 -- | Smart constructor for C terms.
+{-# INLINABLE fAppC #-}
 fAppC :: Ord a => CSym -> [Term a] -> Term a
 fAppC nacsym as = FAPP (C nacsym) (sort as)
 

--- a/lib/term/src/Term/Unification.hs
+++ b/lib/term/src/Term/Unification.hs
@@ -104,6 +104,14 @@ import           Debug.Trace.Ignore
 ----------------------------------------------------------------------
 
 -- | @unifyLTerm sortOf eqs@ returns a complete set of unifiers for @eqs@ modulo AC.
+-- Almost always called at the concrete 'LNTerm' type from the @theory@ package;
+-- without an exposed unfolding GHC compiles the RWST plumbing of @unif@
+-- (sequence/execRWST/the writer monoid) once with dictionary passing, so we
+-- hint the 'Name' specialisation here.
+{-# INLINABLE unifyLTermFactored #-}
+{-# SPECIALIZE unifyLTermFactored
+      :: (Name -> LSort) -> [Equal LNTerm]
+      -> WithMaude (LNSubst, [SubstVFresh Name LVar]) #-}
 unifyLTermFactored :: (IsConst c)
                    => (c -> LSort)
                    -> [Equal (LTerm c)]

--- a/lib/term/src/Term/Unification.hs
+++ b/lib/term/src/Term/Unification.hs
@@ -227,6 +227,12 @@ solveMatchLNTerm = solveMatchLTerm sortOfName
 type UnifyRaw c = RWST (c -> LSort) [Equal (LTerm c)] (Map LVar (VTerm c LVar)) Maybe
 
 -- | Unify two 'LTerm's with delayed AC-unification.
+--
+-- This is the innermost loop of free unification and is called only at the
+-- concrete 'Name' constant type. Exposing the unfolding (INLINABLE) and forcing
+-- a 'Name'-specialised copy seems to help GHC optimise.
+{-# INLINABLE unifyRaw #-}
+{-# SPECIALIZE unifyRaw :: LNTerm -> LNTerm -> UnifyRaw Name () #-}
 unifyRaw :: IsConst c => LTerm c -> LTerm c -> UnifyRaw c ()
 unifyRaw l0 r0 = do
     mappings <- get
@@ -290,6 +296,9 @@ instance Monoid MatchFailure where
 
 -- | Ensure that the computed substitution @sigma@ satisfies
 -- @t ==_AC apply sigma p@ after the delayed equations are solved.
+{-# INLINABLE matchRaw #-}
+{-# SPECIALIZE matchRaw :: (Name -> LSort) -> LNTerm -> LNTerm
+                        -> ExceptT MatchFailure (State (Map LVar LNTerm)) () #-}
 matchRaw :: IsConst c
          => (c -> LSort)
          -> LTerm c -- ^ Term @t@
@@ -324,6 +333,7 @@ matchRaw sortOf t p = do
 
 -- | @sortGreaterEq v t@ returns @True@ if the sort ensures that the sort of @v@ is greater or equal to
 --   the sort of @t@.
+{-# INLINABLE sortGeqLTerm #-}
 sortGeqLTerm :: IsConst c => (c -> LSort) -> LVar -> LTerm c -> Bool
 sortGeqLTerm st v t = do
     case (lvarSort v, sortOfLTerm st t) of

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -1831,6 +1831,7 @@ instance HasFrees GoalStatus where
     mapFrees  = const pure
 
 instance HasFrees System where
+    {-# INLINABLE foldFrees #-}
     foldFrees fun (System a b c d e f g h i j k l m) =
         foldFrees fun a `mappend`
         foldFrees fun b `mappend`
@@ -1860,6 +1861,7 @@ instance HasFrees System where
         foldFreesCtx fun ("k":ctx') k -}
       where ctx' = "system":ctx
 
+    {-# INLINABLE mapFrees #-}
     mapFrees fun (System a b c d e f g h i j k l m) =
         System <$> mapFrees fun a
                <*> mapFrees fun b
@@ -1876,12 +1878,14 @@ instance HasFrees System where
                <*> mapFrees fun m
 
 instance HasFrees Source where
+    {-# INLINABLE foldFrees #-}
     foldFrees f th =
         foldFrees f (L.get cdGoal th)   `mappend`
         foldFrees f (L.get cdCases th)
 
     foldFreesOcc  _ _ = const mempty
 
+    {-# INLINABLE mapFrees #-}
     mapFrees f th = Source <$> mapFrees f (L.get cdGoal th)
                                     <*> mapFrees f (L.get cdCases th)
 

--- a/lib/theory/src/Theory/Constraint/System/Constraints.hs
+++ b/lib/theory/src/Theory/Constraint/System/Constraints.hs
@@ -108,8 +108,10 @@ instance Apply LNSubst Edge where
     apply subst (Edge from to) = Edge (apply subst from) (apply subst to)
 
 instance HasFrees Edge where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (Edge x y) = foldFrees f x `mappend` foldFrees f y
     foldFreesOcc  f c (Edge x y) = foldFreesOcc f ("edge":c) (x, y)
+    {-# INLINABLE mapFrees #-}
     mapFrees  f (Edge x y) = Edge <$> mapFrees f x <*> mapFrees f y
 
 -- | A *⋖* constraint between 'NodeId's.
@@ -141,8 +143,10 @@ instance Apply LNSubst LessAtom where
     apply subst (LessAtom smaller larger r) = LessAtom (apply subst smaller) (apply subst larger) r
 
 instance HasFrees LessAtom where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (LessAtom s l _) = foldFrees f s <> foldFrees f l
     foldFreesOcc f c (LessAtom s l _) = foldFreesOcc f ("lessAtom":c) (s, l)
+    {-# INLINABLE mapFrees #-}
     mapFrees f (LessAtom s l r) = LessAtom <$> mapFrees f s <*> mapFrees f l <*> pure r
 
 ------------------------------------------------------------------------------
@@ -204,6 +208,7 @@ isSubtermGoal _         = False
 ------------
 
 instance HasFrees Goal where
+    {-# INLINABLE foldFrees #-}
     foldFrees f goal = case goal of
         ActionG i fa  -> foldFrees f i <> foldFrees f fa
         PremiseG p fa -> foldFrees f p <> foldFrees f fa
@@ -217,6 +222,7 @@ instance HasFrees Goal where
         ChainG co p  -> foldFreesOcc f ("ChainG":c)  (co, p)
         _            -> mempty
 
+    {-# INLINABLE mapFrees #-}
     mapFrees f goal = case goal of
         ActionG i fa  -> ActionG  <$> mapFrees f i <*> mapFrees f fa
         PremiseG p fa -> PremiseG <$> mapFrees f p <*> mapFrees f fa

--- a/lib/theory/src/Theory/Constraint/System/Guarded.hs
+++ b/lib/theory/src/Theory/Constraint/System/Guarded.hs
@@ -270,8 +270,10 @@ traverseGuarded f = foldGuarded (fmap GAto . traverse (traverseTerm (traverse (t
                                 (\qua ss as gf -> GGuarded qua ss <$> traverse (traverse (traverseTerm (traverse (traverse f)))) as <*> gf)
 
 instance Ord c => HasFrees (Guarded (String, LSort) c LVar) where
+    {-# INLINABLE foldFrees #-}
     foldFrees    f   = foldMap  (foldFrees f)
     foldFreesOcc _ _ = const mempty
+    {-# INLINABLE mapFrees #-}
     mapFrees     f   = traverseGuarded (mapFrees f)
 
 

--- a/lib/theory/src/Theory/Model/Atom.hs
+++ b/lib/theory/src/Theory/Model/Atom.hs
@@ -154,8 +154,10 @@ instance (Apply s t) => Apply s (SyntacticSugar t)
     apply subst (Pred fa) = Pred $ apply subst fa
 
 instance HasFrees t => HasFrees (Atom t) where
+    {-# INLINABLE foldFrees #-}
     foldFrees f = foldMap (foldFrees f)
     foldFreesOcc _ _ = const mempty -- we ignore occurences in atoms for now
+    {-# INLINABLE mapFrees #-}
     mapFrees  f = traverse (mapFrees f)
 
 instance (Apply s t, Apply s (syn t)) => Apply s (ProtoAtom syn t) where

--- a/lib/theory/src/Theory/Model/Fact.hs
+++ b/lib/theory/src/Theory/Model/Fact.hs
@@ -182,8 +182,10 @@ instance Sized t => Sized (Fact t) where
   size (Fact _ _ args) = size args
 
 instance HasFrees t => HasFrees (Fact t) where
+    {-# INLINABLE foldFrees #-}
     foldFrees  f = foldMap  (foldFrees f)
     foldFreesOcc f c fa = foldFreesOcc f (show (factTag fa):c) (factTerms fa)
+    {-# INLINABLE mapFrees #-}
     mapFrees   f = traverse (mapFrees f)
 
 instance Apply s t => Apply s (Fact t) where

--- a/lib/theory/src/Theory/Model/Formula.hs
+++ b/lib/theory/src/Theory/Model/Formula.hs
@@ -316,13 +316,17 @@ applyMacroInFormula macros fm = mapAtoms (const (fmap (applyMacros (lnMacrosToBN
 ------------
 
 instance HasFrees LNFormula where
+    {-# INLINABLE foldFrees #-}
     foldFrees  f = foldMap  (foldFrees  f)
     foldFreesOcc _ _ = const mempty -- we ignore occurences in Formulas for now
+    {-# INLINABLE mapFrees #-}
     mapFrees   f = traverseFormula (mapFrees   f)
 
 instance HasFrees SyntacticLNFormula where
+    {-# INLINABLE foldFrees #-}
     foldFrees  f = foldMap  (foldFrees  f)
     foldFreesOcc _ _ = const mempty -- we ignore occurences in Formulas for now
+    {-# INLINABLE mapFrees #-}
     mapFrees   f = traverseFormula (mapFrees   f)
 
 instance Apply LNSubst LNFormula where

--- a/lib/theory/src/Theory/Model/Rule.hs
+++ b/lib/theory/src/Theory/Model/Rule.hs
@@ -277,6 +277,7 @@ instance Functor Rule where
     fmap f (Rule i ps cs as nvs) = Rule (f i) ps cs as nvs
 
 instance (Show i, HasFrees i) => HasFrees (Rule i) where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (Rule i ps cs as nvs) =
         (foldFrees f i  `mappend`) $
         (foldFrees f ps `mappend`) $
@@ -286,6 +287,7 @@ instance (Show i, HasFrees i) => HasFrees (Rule i) where
     -- We do not include the new variables in the occurrences
     foldFreesOcc f c (Rule i ps cs as _) =
         foldFreesOcc f ((show i):c) (ps, cs, as)
+    {-# INLINABLE mapFrees #-}
     mapFrees f (Rule i ps cs as nvs) =
         Rule <$> mapFrees f i
              <*> mapFrees f ps <*> mapFrees f cs <*> mapFrees f as
@@ -334,8 +336,10 @@ ruleInfo _     intr (IntrInfo  x) = intr x
 ------------
 
 instance (HasFrees p, HasFrees i) => HasFrees (RuleInfo p i) where
+    {-# INLINABLE foldFrees #-}
     foldFrees  f = ruleInfo (foldFrees f) (foldFrees f)
     foldFreesOcc _ _ = const mempty
+    {-# INLINABLE mapFrees #-}
     mapFrees   f = ruleInfo (fmap ProtoInfo . mapFrees   f)
                             (fmap IntrInfo . mapFrees   f)
 
@@ -473,9 +477,11 @@ instance HasFrees ConcIdx where
     mapFrees   _ = pure
 
 instance HasFrees ProtoRuleEInfo where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (ProtoRuleEInfo na attr rstr) =
         foldFrees f na `mappend` foldFrees f attr `mappend` foldFrees f rstr
     foldFreesOcc  _ _ = const mempty
+    {-# INLINABLE mapFrees #-}
     mapFrees f (ProtoRuleEInfo na attr rstr) =
         ProtoRuleEInfo na <$> mapFrees f attr <*> mapFrees f rstr
 
@@ -483,12 +489,14 @@ instance Apply s ProtoRuleEInfo where
     apply _ = id
 
 instance HasFrees ProtoRuleACInfo where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (ProtoRuleACInfo na attr vari breakers) =
         foldFrees f na `mappend` foldFrees f attr
                        `mappend` foldFrees f vari
                        `mappend` foldFrees f breakers
     foldFreesOcc  _ _ = const mempty
 
+    {-# INLINABLE mapFrees #-}
     mapFrees f (ProtoRuleACInfo na attr vari breakers) =
         ProtoRuleACInfo na <$> mapFrees f attr
                            <*> mapFrees f vari
@@ -499,12 +507,14 @@ instance Apply s ProtoRuleACInstInfo where
         ProtoRuleACInstInfo (apply subst na) attr breakers
 
 instance HasFrees ProtoRuleACInstInfo where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (ProtoRuleACInstInfo na attr breakers) =
         foldFrees f na `mappend` foldFrees f attr
                        `mappend` foldFrees f breakers
 
     foldFreesOcc  _ _ = const mempty
 
+    {-# INLINABLE mapFrees #-}
     mapFrees f (ProtoRuleACInstInfo na attr breakers) =
         ProtoRuleACInstInfo na <$> mapFrees f attr <*> mapFrees f breakers
 

--- a/lib/theory/src/Theory/Tools/EquationStore.hs
+++ b/lib/theory/src/Theory/Tools/EquationStore.hs
@@ -153,9 +153,11 @@ instance Apply LNSubst SplitId where
     apply _ = id
 
 instance HasFrees EqStore where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (EqStore subst substs nextSplitId) =
         foldFrees f subst <> foldFrees f substs <> foldFrees f nextSplitId
     foldFreesOcc  _ _ = const mempty
+    {-# INLINABLE mapFrees #-}
     mapFrees f (EqStore subst substs nextSplitId) =
         EqStore <$> mapFrees f subst
                 <*> mapFrees f substs

--- a/lib/theory/src/Theory/Tools/SubtermStore.hs
+++ b/lib/theory/src/Theory/Tools/SubtermStore.hs
@@ -544,9 +544,11 @@ natSubtermEqualities relation = {-trace (show (("natSubtermEqualities"
 
 
 instance HasFrees SubtermStore where
+    {-# INLINABLE foldFrees #-}
     foldFrees f (SubtermStore negSt st solvedSt _ _) =
         foldFrees f negSt <> foldFrees f st <> foldFrees f solvedSt
     foldFreesOcc  _ _ = const mempty
+    {-# INLINABLE mapFrees #-}
     mapFrees f (SubtermStore negSt st solvedSt contr oldNegSt) =
         SubtermStore <$> mapFrees f negSt
                 <*> mapFrees f st


### PR DESCRIPTION
This adds a bunch of compiler hints about inlining certain hot functions that came up in profiling. Roughly 10% speedup, and some minorly improved memory usage. Note this is just hints to the compiler, so it does not influence semantics in any way and so is trivially safe (assuming GHC is correct, of course).

Results (built on top of https://github.com/tamarin-prover/tamarin-prover/pull/864 and https://github.com/tamarin-prover/tamarin-prover/pull/863). The combined effect of these three PRs improves `ISOIEC_20008_2013_2_ECC_DAA.fixed.spthy` from 1m57s on my machine to ~59 seconds, or roughly doubled performance, and around 40% less memory.

`examples/jcs19-xor/NSLPK3xor.spthy`:
```
OLD:
	0:00.81 real,	2.46 user,	0.52 sys,	0 amem,	199680 mmem
NEW:
	0:00.67 real,	1.96 user,	0.40 sys,	0 amem,	181664 mmem
```

`examples/wireguard/wireguard.spthy`:
```
OLD:
	0:18.28 real,	51.92 user,	10.47 sys,	0 amem,	1973344 mmem
NEW:
	0:17.27 real,	47.01 user,	9.92 sys,	0 amem,	1683952 mmem
```

`examples/eurosp19-eccDAA/ISOIEC_20008_2013_2_ECC_DAA.fixed.spthy`:
```
OLD:
	1:05.33 real,	241.55 user,	37.42 sys,	0 amem,	6439088 mmem
NEW:
	0:58.70 real,	214.97 user,	33.79 sys,	0 amem,	6170128 mmem
```