### PR TITLE
Switch to githash to make `--version` more reliable

### DIFF
--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -198,19 +198,22 @@ ensureMaudeAndGetVersion as = do
 
 -- | Git Version
 gitVersion :: String
-gitVersion = case $$tGitInfoCwdTry of
-  -- Built outside a git checkout (e.g. from a source tarball): fall back
-  -- gracefully, as the old gitrev-based code did with "UNKNOWN".
-  Left _err -> "Git revision: UNKNOWN"
-  Right gi  -> concat
-    [ "Git revision: "
-    , giHash gi
-    , if giDirty gi then
-        " (with uncommited changes)"
-      else ""
-    , ", branch: "
-    , giBranch gi
-    ]
+-- We go through 'either' rather than matching the 'Either' directly: the
+-- compile-time splice resolves to a concrete 'Left'/'Right' in any given
+-- build, so a literal @case@ here trips -Woverlapping-patterns on the unused
+-- branch. The 'Left' case handles builds outside a git checkout (e.g. from a
+-- source tarball), falling back to "UNKNOWN" as the old gitrev code did.
+gitVersion = either (const "Git revision: UNKNOWN") fmtGitInfo $$tGitInfoCwdTry
+  where
+    fmtGitInfo gi = concat
+      [ "Git revision: "
+      , giHash gi
+      , if giDirty gi then
+          " (with uncommited changes)"
+        else ""
+      , ", branch: "
+      , giBranch gi
+      ]
 
 -- | Compile Time
 compileTime :: String

--- a/src/Main/Console.hs
+++ b/src/Main/Console.hs
@@ -74,7 +74,7 @@ import Text.PrettyPrint.Class qualified as PP
 import Paths_tamarin_prover (version)
 
 import Language.Haskell.TH
-import Development.GitRev
+import GitHash
 
 ------------------------------------------------------------------------------
 -- Maude version functions - previously in Environment.hs
@@ -198,15 +198,19 @@ ensureMaudeAndGetVersion as = do
 
 -- | Git Version
 gitVersion :: String
-gitVersion = concat
-  [ "Git revision: "
-  , $(gitHash)
-  , if $(gitDirty) then
-      " (with uncommited changes)"
-    else ""
-  , ", branch: "
-  , $(gitBranch)
-  ]
+gitVersion = case $$tGitInfoCwdTry of
+  -- Built outside a git checkout (e.g. from a source tarball): fall back
+  -- gracefully, as the old gitrev-based code did with "UNKNOWN".
+  Left _err -> "Git revision: UNKNOWN"
+  Right gi  -> concat
+    [ "Git revision: "
+    , giHash gi
+    , if giDirty gi then
+        " (with uncommited changes)"
+      else ""
+    , ", branch: "
+    , giBranch gi
+    ]
 
 -- | Compile Time
 compileTime :: String

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -137,7 +137,7 @@ executable tamarin-prover
       , exceptions
       , file-embed
       , filepath
-      , gitrev
+      , githash
       , http-types
       , mtl
       , parsec


### PR DESCRIPTION
I recently ran into some unusual behaviour where recompiling tamarin was not changing the `--version` string so I went digging into this a bit. 

The git revision info is baked in when Console.hs is compiled, and so if you checkout a different git branch and run `make` again then (unless it touches a dependency of `Console.hs`) that cached build is reused. The git information shown in `--version` will still actually be from the last time `Console.hs` was compiled, not the last time `make` was run.

In the process I found out that GitRev isn't maintained anymore https://github.com/acfoltzer/gitrev

Anyway, githash registers some additional build dependencies with GHC
```
  addDependentFile ".../.git/HEAD"                       <hash>
  addDependentFile ".../.git/refs/heads/robust-git-rev"  <hash>
  addDependentFile ".../.git/index"                      <hash>
  addDependentFile ".../.git/packed-refs"                <hash>
```
which *should* force a rebuild of `Console.hs` in most changes of git. 

This still comes with one caveat though, which is that edits that are not staged in git do not get picked up by this. So if you build tamarin, edit a file that isn't a Console.hs dependency, and rebuild, the `--version` string will not show `(with uncommited changes)`. I can't actually think of a nice way to work around that short of having `make` itself construct something like a `Version.hs` that's a dependency, but then tamarin wouldn't compile without `make`. If anyone has better ideas let me know!