### PR TITLE
Reduce peak memory and repeated work during proof search

### DIFF
--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -304,9 +304,8 @@ execProofMethod ctxt method sys =
       let cases =   removeRedundantCases ctxt [] snd
                   . map (fmap cleanup . fst)
                   . getDisj $ runReduction (m <* simplifySystem) ctxt sys (avoid sys)
-          casesMap = M.fromListWith (error "case names not unique")
-                   $ uniqueListBy (comparing fst) id distinguish cases
-      in casesMap `deepseq` casesMap
+      in force $ M.fromListWith (error "case names not unique")
+               $ uniqueListBy (comparing fst) id distinguish cases
 
     cleanup :: System -> System
     cleanup s = L.set sSubst emptySubst (Precise.evalFresh (renamePrecise s) Precise.nothingUsed)

--- a/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/ProofMethod.hs
@@ -304,8 +304,9 @@ execProofMethod ctxt method sys =
       let cases =   removeRedundantCases ctxt [] snd
                   . map (fmap cleanup . fst)
                   . getDisj $ runReduction (m <* simplifySystem) ctxt sys (avoid sys)
-      in  M.fromListWith (error "case names not unique")
-            $ uniqueListBy (comparing fst) id distinguish cases
+          casesMap = M.fromListWith (error "case names not unique")
+                   $ uniqueListBy (comparing fst) id distinguish cases
+      in casesMap `deepseq` casesMap
 
     cleanup :: System -> System
     cleanup s = L.set sSubst emptySubst (Precise.evalFresh (renamePrecise s) Precise.nothingUsed)
@@ -1199,4 +1200,3 @@ prettyDiffProofMethod method = case method of
     DiffRuleEquivalence      -> keyword_ "rule-equivalence"
     DiffBackwardSearch       -> keyword_ "backward-search"  
     DiffBackwardSearchStep s -> keyword_ "step(" <-> prettyProofMethod s <-> keyword_ ")"
-

--- a/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Reduction.hs
@@ -599,14 +599,19 @@ substNextGoalNr     = return ()
 -- sequent. This is an internal function.
 substPart :: Apply LNSubst a => (System :-> a) -> Reduction ()
 substPart l = do subst <- getM sSubst
-                 modM l (apply subst)
+                 unless (null $ substToList subst) $
+                   modM l (apply subst)
 
 -- | Apply the current substitution of the equation store the nodes of the
 -- constraint system. Indicates whether additional equalities were added to
 -- the equations store.
 substNodes :: Reduction ChangeIndicator
-substNodes =
-    substNodeIds <* ((modM sNodes . M.map . apply) =<< getM sSubst)
+substNodes = do
+    c <- substNodeIds
+    subst <- getM sSubst
+    unless (null $ substToList subst) $
+      modM sNodes (M.map $ apply subst)
+    return c
 
 -- | @setNodes nodes@ normalizes the @nodes@ such that node ids are unique and
 -- then updates the @sNodes@ field of the proof state to the corresponding map.
@@ -637,18 +642,21 @@ substNodeIds =
 substGoals :: Reduction ChangeIndicator
 substGoals = do
     subst <- getM sSubst
-    goals <- M.toList <$> getM sGoals
-    sGoals =: M.empty
-    changes <- forM goals $ \(goal, status) -> case goal of
-        -- Look out for KU-actions that might need to be solved again.
-        ActionG i fa@(kFactView -> Just (UpK, m))
-          | (isMsgVar m || isProduct m || isUnion m {--|| isXor m-}) && (apply subst m /= m) ->
-              insertAction i (apply subst fa)
-        _ -> do modM sGoals $
-                  M'.insertWith combineGoalStatus (apply subst goal) status
-                return Unchanged
+    if null $ substToList subst
+      then return Unchanged
+      else do
+        goals <- M.toList <$> getM sGoals
+        sGoals =: M.empty
+        changes <- forM goals $ \(goal, status) -> case goal of
+            -- Look out for KU-actions that might need to be solved again.
+            ActionG i fa@(kFactView -> Just (UpK, m))
+              | (isMsgVar m || isProduct m || isUnion m {--|| isXor m-}) && (apply subst m /= m) ->
+                  insertAction i (apply subst fa)
+            _ -> do modM sGoals $
+                      M'.insertWith combineGoalStatus (apply subst goal) status
+                    return Unchanged
 
-    return (mconcat changes)
+        return (mconcat changes)
 
 
 -- Conjoining two constraint systems

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -348,7 +348,12 @@ partialAtomValuation ctxt sys =
     runMaude   = (`runReader` get pcMaudeHandle ctxt)
     before     = alwaysBefore sys
     lessRel    = rawLessRel sys
-    nodesAfter = \i -> filter (i /=) $ S.toList $ D.reachableSet [i] lessRel
+    reachable  = M.fromList
+        [ (i, D.reachableSet [i] lessRel)
+        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) lessRel
+        ]
+    nodesAfter = \i -> filter (i /=) $ S.toList $
+        M.findWithDefault S.empty i reachable
     reducible  = reducibleFunSyms $ mhMaudeSig $ get pcMaudeHandle ctxt
     sst        = get sSubtermStore sys
 
@@ -679,19 +684,19 @@ nonInjectiveFactInstances ctxt se = do
 --    j <- S.toList $ D.reachableSet [i] less
     (j, _) <- M.toList $ get sNodes se
     -- check that j<k
-    guard  (k `S.member` D.reachableSet [j] less)
+    guard  (j `isBefore` k)
     let isCounterExample checkRule = (j /= i) && (j /= k) &&
                            maybe False checkRule (M.lookup j $ get sNodes se)
         checkRuleJK jRu    = (
                            -- check that f(t,...) occurs at j in prems and j<k
                            any conflictingFact (get rPrems jRu ++ get rConcs jRu) &&
-                           (k `S.member` D.reachableSet [j] less) &&
+                           (j `isBefore` k) &&
                             nonUnifiableNodes j i
                            )
         checkRuleIJ jRu    = (
                            -- check that f(t,...) occurs at j in concs and i<j
                            any conflictingFact (get rPrems jRu ++  get rConcs jRu) &&
-                           (j `S.member` D.reachableSet [i] less) &&
+                           (i `isBefore` j) &&
                             nonUnifiableNodes k j
                            )
     if (isCounterExample checkRuleJK) then return (j,i)
@@ -704,6 +709,11 @@ nonInjectiveFactInstances ctxt se = do
 --    return (i, j, k) -- counter-example to unique fact instances
   where
     less      = rawLessRel se
+    reachable = M.fromList
+        [ (i, D.reachableSet [i] less)
+        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) less
+        ]
+    isBefore i j = j `S.member` M.findWithDefault S.empty i reachable
     firstTerm = headMay . factTerms
     runMaude   = (`runReader` get pcMaudeHandle ctxt)
     nonUnifiableNodes :: NodeId -> NodeId -> Bool

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -348,12 +348,8 @@ partialAtomValuation ctxt sys =
     runMaude   = (`runReader` get pcMaudeHandle ctxt)
     before     = alwaysBefore sys
     lessRel    = rawLessRel sys
-    reachable  = M.fromList
-        [ (i, D.reachableSet [i] lessRel)
-        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) lessRel
-        ]
     nodesAfter = \i -> filter (i /=) $ S.toList $
-        M.findWithDefault S.empty i reachable
+        D.reachableFrom lessRel i
     reducible  = reducibleFunSyms $ mhMaudeSig $ get pcMaudeHandle ctxt
     sst        = get sSubtermStore sys
 
@@ -709,11 +705,8 @@ nonInjectiveFactInstances ctxt se = do
 --    return (i, j, k) -- counter-example to unique fact instances
   where
     less      = rawLessRel se
-    reachable = M.fromList
-        [ (i, D.reachableSet [i] less)
-        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) less
-        ]
-    isBefore i j = j `S.member` M.findWithDefault S.empty i reachable
+    reachableFrom = D.reachableFrom less
+    isBefore i j = j `S.member` reachableFrom i
     firstTerm = headMay . factTerms
     runMaude   = (`runReader` get pcMaudeHandle ctxt)
     nonUnifiableNodes :: NodeId -> NodeId -> Bool

--- a/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
+++ b/lib/theory/src/Theory/Constraint/Solver/Simplify.hs
@@ -408,10 +408,14 @@ insertImpliedFormulas :: Reduction ChangeIndicator
 insertImpliedFormulas = do
     sys <- gets id
     hnd <- getMaudeHandle
+    let actionsByTag =
+            M.fromListWith (++) $ do
+                (i, fa) <- allActions sys
+                return (factTag fa, [(skolemizeTerm (varTerm i), skolemizeFact fa)])
     applyChangeList $ do
         clause  <- (S.toList $ get sFormulas sys) ++
                    (S.toList $ get sLemmas sys)
-        implied <- impliedFormulas hnd sys clause
+        implied <- impliedFormulasWithSkActions hnd actionsByTag clause
         if ( implied `S.notMember` get sFormulas sys &&
              implied `S.notMember` get sSolvedFormulas sys )
           then return (insertFormula implied)

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -1056,7 +1056,12 @@ safePartialAtomValuation ctxt sys =
     runMaude   = (`runReader` L.get pcMaudeHandle ctxt)
     before     = alwaysBefore sys
     lessRel    = rawLessRel sys
-    nodesAfter = \i -> filter (i /=) $ S.toList $ D.reachableSet [i] lessRel
+    reachable  = M.fromList
+        [ (i, D.reachableSet [i] lessRel)
+        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) lessRel
+        ]
+    nodesAfter = \i -> filter (i /=) $ S.toList $
+        M.findWithDefault S.empty i reachable
     reducible  = reducibleFunSyms $ mhMaudeSig $ L.get pcMaudeHandle ctxt
     sst        = L.get sSubtermStore sys
 
@@ -1645,10 +1650,14 @@ alwaysBefore sys =
     check -- lessRel is cached for partial applications
   where
     lessRel   = rawLessRel sys
+    reachable = M.fromList
+        [ (i, D.reachableSet [i] lessRel)
+        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) lessRel
+        ]
     check i j =
          -- speed-up check by first checking less-atoms
          ((i, j) `S.member` getLessAtoms sys)
-      || (j `S.member` D.reachableSet [i] lessRel)
+      || (j `S.member` M.findWithDefault S.empty i reachable)
 
 -- | 'True' iff the given node id is guaranteed to be instantiated to an
 -- index in the trace.

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -238,7 +238,6 @@ module Theory.Constraint.System (
 
   -- * Formula simplification
   , impliedFormulas
-  , impliedFormulasWithActions
   , impliedFormulasWithSkActions
 
   -- * Pretty-printing
@@ -1056,12 +1055,8 @@ safePartialAtomValuation ctxt sys =
     runMaude   = (`runReader` L.get pcMaudeHandle ctxt)
     before     = alwaysBefore sys
     lessRel    = rawLessRel sys
-    reachable  = M.fromList
-        [ (i, D.reachableSet [i] lessRel)
-        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) lessRel
-        ]
     nodesAfter = \i -> filter (i /=) $ S.toList $
-        M.findWithDefault S.empty i reachable
+        D.reachableFrom lessRel i
     reducible  = reducibleFunSyms $ mhMaudeSig $ L.get pcMaudeHandle ctxt
     sst        = L.get sSubtermStore sys
 
@@ -1116,18 +1111,11 @@ safePartialAtomValuation ctxt sys =
 -- | @impliedFormulas se imp@ returns the list of guarded formulas that are
 -- implied by @se@.
 impliedFormulas :: MaudeHandle -> System -> LNGuarded -> [LNGuarded]
-impliedFormulas hnd sys = impliedFormulasWithActions hnd actionsByTag
+impliedFormulas hnd sys = impliedFormulasWithSkActions hnd skActionsByTag
   where
-    actionsByTag =
-        M.fromListWith (++) $ do
-            action@(_, fa) <- allActions sys
-            return (factTag fa, [action])
-
-impliedFormulasWithActions :: MaudeHandle -> M.Map FactTag [(NodeId, LNFact)] -> LNGuarded -> [LNGuarded]
-impliedFormulasWithActions hnd sysActionsByTag =
-    impliedFormulasWithSkActions hnd (fmap (map skolemizeAction) sysActionsByTag)
-  where
-    skolemizeAction (i, fa) = (skolemizeTerm (varTerm i), skolemizeFact fa)
+    skActionsByTag = M.fromListWith (++)
+        [ (factTag fa, [(skolemizeTerm (varTerm i), skolemizeFact fa)])
+        | (i, fa) <- allActions sys ]
 
 impliedFormulasWithSkActions :: MaudeHandle -> M.Map FactTag [(SkTerm, SkFact)] -> LNGuarded -> [LNGuarded]
 impliedFormulasWithSkActions hnd sysActionsByTag gf0 = res
@@ -1649,15 +1637,12 @@ alwaysBefore :: System -> (NodeId -> NodeId -> Bool)
 alwaysBefore sys =
     check -- lessRel is cached for partial applications
   where
-    lessRel   = rawLessRel sys
-    reachable = M.fromList
-        [ (i, D.reachableSet [i] lessRel)
-        | i <- S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) lessRel
-        ]
+    lessRel       = rawLessRel sys
+    reachableFrom = D.reachableFrom lessRel
     check i j =
          -- speed-up check by first checking less-atoms
          ((i, j) `S.member` getLessAtoms sys)
-      || (j `S.member` M.findWithDefault S.empty i reachable)
+      || (j `S.member` reachableFrom i)
 
 -- | 'True' iff the given node id is guaranteed to be instantiated to an
 -- index in the trace.

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -238,6 +238,8 @@ module Theory.Constraint.System (
 
   -- * Formula simplification
   , impliedFormulas
+  , impliedFormulasWithActions
+  , impliedFormulasWithSkActions
 
   -- * Pretty-printing
   , prettySystem
@@ -1109,7 +1111,21 @@ safePartialAtomValuation ctxt sys =
 -- | @impliedFormulas se imp@ returns the list of guarded formulas that are
 -- implied by @se@.
 impliedFormulas :: MaudeHandle -> System -> LNGuarded -> [LNGuarded]
-impliedFormulas hnd sys gf0 = res
+impliedFormulas hnd sys = impliedFormulasWithActions hnd actionsByTag
+  where
+    actionsByTag =
+        M.fromListWith (++) $ do
+            action@(_, fa) <- allActions sys
+            return (factTag fa, [action])
+
+impliedFormulasWithActions :: MaudeHandle -> M.Map FactTag [(NodeId, LNFact)] -> LNGuarded -> [LNGuarded]
+impliedFormulasWithActions hnd sysActionsByTag =
+    impliedFormulasWithSkActions hnd (fmap (map skolemizeAction) sysActionsByTag)
+  where
+    skolemizeAction (i, fa) = (skolemizeTerm (varTerm i), skolemizeFact fa)
+
+impliedFormulasWithSkActions :: MaudeHandle -> M.Map FactTag [(SkTerm, SkFact)] -> LNGuarded -> [LNGuarded]
+impliedFormulasWithSkActions hnd sysActionsByTag gf0 = res
   where
     res = case (openGuarded gf `evalFresh` avoid gf) of
       Just (All, _vs, antecedent, succedent) -> do
@@ -1125,13 +1141,11 @@ impliedFormulas hnd sys gf0 = res
     prepare (EqE s t)     = Left  (GEqE s t)
     prepare ato           = Right (fmap (fmapTerm (fmap Free)) ato)
 
-    sysActions = do (i, fa) <- allActions sys
-                    return (skolemizeTerm (varTerm i), skolemizeFact fa)
-
     candidateSubsts subst []               = return subst
     candidateSubsts subst ((GAction a fa):as) = do
-        sysAct <- sysActions
-        subst' <- (`runReader` hnd) $ matchAction sysAct (applySkAction subst (a, fa))
+        let action@(_, fa') = applySkAction subst (a, fa)
+        sysAct <- M.findWithDefault [] (factTag fa') sysActionsByTag
+        subst' <- (`runReader` hnd) $ matchAction sysAct action
         candidateSubsts (compose subst' subst) as
     candidateSubsts subst ((GEqE s' t'):as)   = do
         let s = applySkTerm subst s'

--- a/lib/theory/src/Theory/Constraint/System/Guarded.hs
+++ b/lib/theory/src/Theory/Constraint/System/Guarded.hs
@@ -73,6 +73,8 @@ module Theory.Constraint.System.Guarded (
   , unskolemizeLNGuarded
   , applySkGuarded
   , skolemizeGuarded
+  , SkTerm
+  , SkFact
   , skolemizeTerm
   , skolemizeFact
   , matchAction

--- a/lib/utils/src/Data/DAG/Simple.hs
+++ b/lib/utils/src/Data/DAG/Simple.hs
@@ -13,6 +13,7 @@ module Data.DAG.Simple (
   , inverse
   , image
   , reachableSet
+  , reachableFrom
   , restrict
 
   -- ** Cycles
@@ -29,6 +30,7 @@ import           Control.Monad.RWS
 
 import           Data.List
 import qualified Data.DList as D
+import qualified Data.Map   as M
 import qualified Data.Set   as S
 import           Data.Maybe
 
@@ -77,6 +79,13 @@ reachableSet start dag =
       | x `S.member` visited = visited
       | otherwise            =
           foldl' visit (S.insert x visited) (x `image` dag)
+
+-- | Produce a function for querying the nodes reachable from a given node.
+reachableFrom :: Ord a => [(a, a)] -> a -> S.Set a
+reachableFrom dag = \i -> M.findWithDefault (S.singleton i) i memo
+  where
+    memo  = M.fromList [ (i, reachableSet [i] dag) | i <- nodes ]
+    nodes = S.toList $ S.fromList $ concatMap (\(x, y) -> [x, y]) dag
 
 -- | Is the relation cyclic.
 cyclic :: Ord a => [(a,a)] -> Bool


### PR DESCRIPTION
Disclaimer: I am by far not an expert with Haskell, so this PR was developed with assistance from OpenAI Codex (chatGPT 5.5). 

This PR reduces allocation and peak residency in proof search by avoiding repeated normalization and reachability work in hot paths.

Changes:
- Skip substitution passes over system parts, nodes, and goals when the current substitution is empty.
- Cache reachability sets inside valuation/simplification paths instead of recomputing `reachableSet` repeatedly.
- Index system actions by fact tag before matching implied formulas, so candidate action matching does not scan every action for every guarded action.
- Force proof-method case maps before returning them, avoiding retained lazy intermediate structures.
- Export `SkTerm` and `SkFact` so the optimized implied-formula path can reuse pre-skolemized actions.

Validation:
- `stack build`
- `stack exec -- tamarin-prover test`
  - 55 cases
  - 0 errors
  - 0 failures

Benchmark sample against current `develop` showed the branch still improves the representative proof-search cases:

| Case | Threads | Elapsed Improvement | Max Residency Improvement | Total Memory Improvement |
| --- | ---: | ---: | ---: | ---: |
| `counter-injectivity` | N1 | 26.1% faster | 30.5% lower | 30.1% lower |
| `counter-injectivity` | N4 | 22.6% faster | 27.7% lower | 25.3% lower |
| `counter-unmatching` | N1 | 20.2% faster | 62.9% lower | 61.3% lower |
| `counter-unmatching` | N4 | 12.7% faster | 62.0% lower | 59.7% lower |
| `commitment-later` | N1 | 33.3% faster | 55.5% lower | 54.3% lower |
| `commitment-later` | N4 | 33.2% faster | 54.9% lower | 53.4% lower |


The benchmark cases are in these files:
- counter-injectivity: examples/csf17/counter-protocol.spthy
- counter-unmatching: examples/csf17/counter-protocol.spthy
- commitment-later: examples/csf17/commitment-protocol.spthy