### PR TITLE
export: Extend Tamarin-to-ProVerif property translation

### DIFF
--- a/case-studies-regression/fast-tests/loops/JCS12_Typing_Example_analyzed.spthy
+++ b/case-studies-regression/fast-tests/loops/JCS12_Typing_Example_analyzed.spthy
@@ -39,54 +39,61 @@ rule (modulo E) Client_2:
 
   /* has exactly the trivial AC variant */
 
+restriction Restr_Serv_1_1:
+  "∀ x #NOW x.1. (Restr_Serv_1_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  // safety formula
+
+  /*
+  expanded formula:
+  "∀ x #NOW x.1. (Restr_Serv_1_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  */
+
 rule (modulo E) Serv_1:
-   [
-   !Ltk( $S, ~ltkS ), In( request ),
-   !Pk( fst(snd(adec(request, ~ltkS))), pkC )
-   ]
+   [ !Ltk( $S, ~ltkS ), In( request ), !Pk( C, pkC ) ]
   --[
   Eq( fst(adec(request, ~ltkS)), '1' ),
-  ReceivedKey( fst(snd(adec(request, ~ltkS))), $S,
-               snd(snd(adec(request, ~ltkS)))
-  ),
-  In_Serv_1( request, snd(snd(adec(request, ~ltkS))) )
+  ReceivedKey( C, $S, snd(snd(adec(request, ~ltkS))) ),
+  In_Serv_1( request, snd(snd(adec(request, ~ltkS))) ),
+  Restr_Serv_1_1( C, fst(snd(adec(request, ~ltkS))) )
   ]->
    [ Out( aenc(<'2', snd(snd(adec(request, ~ltkS)))>, pkC) ) ]
 
   /*
   rule (modulo AC) Serv_1:
-     [ !Ltk( $S, ~ltkS ), In( request ), !Pk( z, pkC ) ]
-    --[ Eq( z.2, '1' ), ReceivedKey( z, $S, z.1 ), In_Serv_1( request, z.1 )
+     [ !Ltk( $S, ~ltkS ), In( request ), !Pk( C, pkC ) ]
+    --[
+    Eq( z.1, '1' ), ReceivedKey( C, $S, z ), In_Serv_1( request, z ),
+    Restr_Serv_1_1( C, z.2 )
     ]->
-     [ Out( aenc(<'2', z.1>, pkC) ) ]
+     [ Out( aenc(<'2', z>, pkC) ) ]
     variants (modulo AC)
-    1. ~ltkS = ~ltkS.12
+    1. ~ltkS = ~ltkS.15
        request
-             = request.14
-       z     = fst(snd(adec(request.14, ~ltkS.12)))
-       z.1   = snd(snd(adec(request.14, ~ltkS.12)))
-       z.2   = fst(adec(request.14, ~ltkS.12))
+             = request.18
+       z     = snd(snd(adec(request.18, ~ltkS.15)))
+       z.1   = fst(adec(request.18, ~ltkS.15))
+       z.2   = fst(snd(adec(request.18, ~ltkS.15)))
     
-    2. ~ltkS = ~ltkS.16
+    2. ~ltkS = ~ltkS.20
        request
-             = aenc(<z.22, z.19, z.21>, pk(~ltkS.16))
-       z     = z.19
-       z.1   = z.21
-       z.2   = z.22
+             = aenc(<z.26, z.28, z.25>, pk(~ltkS.20))
+       z     = z.25
+       z.1   = z.26
+       z.2   = z.28
     
-    3. ~ltkS = ~ltkS.20
+    3. ~ltkS = ~ltkS.24
        request
-             = aenc(x.37, pk(~ltkS.20))
-       z     = fst(snd(x.37))
-       z.1   = snd(snd(x.37))
-       z.2   = fst(x.37)
+             = aenc(x.45, pk(~ltkS.24))
+       z     = snd(snd(x.45))
+       z.1   = fst(x.45)
+       z.2   = fst(snd(x.45))
     
-    4. ~ltkS = ~ltkS.21
+    4. ~ltkS = ~ltkS.25
        request
-             = aenc(<z.27, x.39>, pk(~ltkS.21))
-       z     = fst(x.39)
-       z.1   = snd(x.39)
-       z.2   = z.27
+             = aenc(<z.31, x.47>, pk(~ltkS.25))
+       z     = snd(x.47)
+       z.1   = z.31
+       z.2   = fst(x.47)
   */
 
 lemma typing_assertion [sources]:
@@ -113,7 +120,7 @@ next
     case case_1
     solve( !Ltk( $S, ~ltkS ) ▶₀ #i )
       case Register_pk
-      solve( !Pk( z, pkC ) ▶₂ #i )
+      solve( !Pk( C, pkC ) ▶₂ #i )
         case Register_pk
         solve( !KU( aenc(<z, $A, v>, pk(~ltkS)) ) @ #vk )
           case Client_1
@@ -272,8 +279,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -285,7 +292,7 @@ summary of summaries:
 analyzed: examples/loops/JCS12_Typing_Example.spthy
 
   output:          examples/loops/JCS12_Typing_Example.spthy.tmp
-  processing time: 0.09s
+  processing time: 0.07s
   
   typing_assertion (all-traces): verified (15 steps)
   Client_session_key_secrecy_raw (all-traces): verified (8 steps)

--- a/case-studies-regression/fast-tests/post17/foo_eligibility_analyzed.spthy
+++ b/case-studies-regression/fast-tests/post17/foo_eligibility_analyzed.spthy
@@ -35,7 +35,7 @@ rule (modulo E) V_1:
   Created_commit_V_1( blind(commit($vote, ~r), ~b) )
   ]->
    [
-   Out( <blind(commit($vote, ~r), ~b),
+   Out( <blind(commit($vote, ~r), ~b), 
          sign(blind(commit($vote, ~r), ~b), ~ltkV)>
    ),
    St_V_1( V, $vote, ~r, ~b )
@@ -52,7 +52,7 @@ rule (modulo E) A_1:
 
 rule (modulo E) V_2:
    [
-   In( <blind(commit(vote, ~r), ~b),
+   In( <blind(commit(vote, ~r), ~b), 
         sign(blind(commit(vote, ~r), ~b), ~ltkA)>
    ),
    St_V_1( V, vote, ~r, ~b ), !AdminLtk( A, ~ltkA )
@@ -103,7 +103,7 @@ rule (modulo E) C_2:
     1. r     = r.5
        x     = x.5
        z     = open(x.5, r.5)
-
+    
     2. r     = x.5
        x     = commit(x.6, x.5)
        z     = x.6
@@ -350,8 +350,8 @@ summary of summaries:
 analyzed: examples/post17/foo_eligibility.spthy
 
   output:          examples/post17/foo_eligibility.spthy.tmp
-  processing time: 0.22s
-
+  processing time: 0.24s
+  
   types (all-traces): verified (43 steps)
   exec (exists-trace): verified (9 steps)
   eligibility (all-traces): verified (11 steps)

--- a/case-studies-regression/fast-tests/post17/foo_eligibility_analyzed.spthy
+++ b/case-studies-regression/fast-tests/post17/foo_eligibility_analyzed.spthy
@@ -35,7 +35,7 @@ rule (modulo E) V_1:
   Created_commit_V_1( blind(commit($vote, ~r), ~b) )
   ]->
    [
-   Out( <blind(commit($vote, ~r), ~b), 
+   Out( <blind(commit($vote, ~r), ~b),
          sign(blind(commit($vote, ~r), ~b), ~ltkV)>
    ),
    St_V_1( V, $vote, ~r, ~b )
@@ -52,7 +52,7 @@ rule (modulo E) A_1:
 
 rule (modulo E) V_2:
    [
-   In( <blind(commit(vote, ~r), ~b), 
+   In( <blind(commit(vote, ~r), ~b),
         sign(blind(commit(vote, ~r), ~b), ~ltkA)>
    ),
    St_V_1( V, vote, ~r, ~b ), !AdminLtk( A, ~ltkA )
@@ -77,16 +77,36 @@ rule (modulo E) V_3:
 
   /* has exactly the trivial AC variant */
 
+restriction Restr_C_2_1:
+  "∀ x #NOW x.1. (Restr_C_2_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  // safety formula
+
+  /*
+  expanded formula:
+  "∀ x #NOW x.1. (Restr_C_2_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  */
+
 rule (modulo E) C_2:
-   [ In( r ), St_C_1( A, commit(open(x, r), r) ) ]
-  --[ VotePublished( open(x, r) ), Out_C_2( commit(open(x, r), r) ) ]->
+   [ In( r ), St_C_1( A, x ) ]
+  --[
+  VotePublished( open(x, r) ), Out_C_2( x ),
+  Restr_C_2_1( x, commit(open(x, r), r) )
+  ]->
    [ Out( open(x, r) ) ]
 
   /*
   rule (modulo AC) C_2:
-     [ In( r ), St_C_1( A, commit(z, r) ) ]
-    --[ VotePublished( z ), Out_C_2( commit(z, r) ) ]->
+     [ In( r ), St_C_1( A, x ) ]
+    --[ VotePublished( z ), Out_C_2( x ), Restr_C_2_1( x, commit(z, r) ) ]->
      [ Out( z ) ]
+    variants (modulo AC)
+    1. r     = r.5
+       x     = x.5
+       z     = open(x.5, r.5)
+
+    2. r     = x.5
+       x     = commit(x.6, x.5)
+       z     = x.6
   */
 
 lemma types [sources]:
@@ -317,8 +337,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -330,8 +350,8 @@ summary of summaries:
 analyzed: examples/post17/foo_eligibility.spthy
 
   output:          examples/post17/foo_eligibility.spthy.tmp
-  processing time: 0.38s
-  
+  processing time: 0.22s
+
   types (all-traces): verified (43 steps)
   exec (exists-trace): verified (9 steps)
   eligibility (all-traces): verified (11 steps)

--- a/case-studies-regression/features/auto-sources/spore/SpliceAS_2_analyzed-auto-sources.spthy
+++ b/case-studies-regression/features/auto-sources/spore/SpliceAS_2_analyzed-auto-sources.spthy
@@ -119,14 +119,12 @@ rule (modulo E) C_from_S:
   /* has exactly the trivial AC variant */
 
 restriction OnlyOnce:
-  "∀ A B #i #j.
-    (((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( B ) @ #j)) ∧ (A = B)) ⇒ (#i = #j)"
+  "∀ A #i #j. ((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( A ) @ #j)) ⇒ (#i = #j)"
   // safety formula
 
   /*
   expanded formula:
-  "∀ A B #i #j.
-    (((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( B ) @ #j)) ∧ (A = B)) ⇒ (#i = #j)"
+  "∀ A #i #j. ((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( A ) @ #j)) ⇒ (#i = #j)"
   */
 
 lemma executability:
@@ -778,8 +776,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -791,7 +789,7 @@ summary of summaries:
 analyzed: examples/features/auto-sources/spore/SpliceAS_2.spthy
 
   output:          examples/features/auto-sources/spore/SpliceAS_2.spthy.tmp
-  processing time: 2.91s
+  processing time: 1.72s
   
   executability (exists-trace): verified (21 steps)
   Secrecy (all-traces): falsified - found trace (16 steps)

--- a/case-studies-regression/features/auto-sources/spore/SpliceAS_3_analyzed-auto-sources.spthy
+++ b/case-studies-regression/features/auto-sources/spore/SpliceAS_3_analyzed-auto-sources.spthy
@@ -122,14 +122,12 @@ rule (modulo E) C_from_S:
   /* has exactly the trivial AC variant */
 
 restriction OnlyOnce:
-  "∀ A B #i #j.
-    (((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( B ) @ #j)) ∧ (A = B)) ⇒ (#i = #j)"
+  "∀ A #i #j. ((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( A ) @ #j)) ⇒ (#i = #j)"
   // safety formula
 
   /*
   expanded formula:
-  "∀ A B #i #j.
-    (((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( B ) @ #j)) ∧ (A = B)) ⇒ (#i = #j)"
+  "∀ A #i #j. ((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( A ) @ #j)) ⇒ (#i = #j)"
   */
 
 lemma executability:
@@ -1119,8 +1117,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -1132,7 +1130,7 @@ summary of summaries:
 analyzed: examples/features/auto-sources/spore/SpliceAS_3.spthy
 
   output:          examples/features/auto-sources/spore/SpliceAS_3.spthy.tmp
-  processing time: 3.27s
+  processing time: 1.75s
   
   executability (exists-trace): verified (21 steps)
   Secrecy (all-traces): verified (39 steps)

--- a/case-studies-regression/features/auto-sources/spore/SpliceAS_analyzed-auto-sources.spthy
+++ b/case-studies-regression/features/auto-sources/spore/SpliceAS_analyzed-auto-sources.spthy
@@ -116,14 +116,12 @@ rule (modulo E) C_from_S:
   /* has exactly the trivial AC variant */
 
 restriction OnlyOnce:
-  "∀ A B #i #j.
-    (((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( B ) @ #j)) ∧ (A = B)) ⇒ (#i = #j)"
+  "∀ A #i #j. ((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( A ) @ #j)) ⇒ (#i = #j)"
   // safety formula
 
   /*
   expanded formula:
-  "∀ A B #i #j.
-    (((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( B ) @ #j)) ∧ (A = B)) ⇒ (#i = #j)"
+  "∀ A #i #j. ((OnlyOnce( A ) @ #i) ∧ (OnlyOnce( A ) @ #j)) ⇒ (#i = #j)"
   */
 
 lemma executability:
@@ -731,8 +729,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -744,7 +742,7 @@ summary of summaries:
 analyzed: examples/features/auto-sources/spore/SpliceAS.spthy
 
   output:          examples/features/auto-sources/spore/SpliceAS.spthy.tmp
-  processing time: 2.33s
+  processing time: 1.21s
   
   executability (exists-trace): verified (21 steps)
   Secrecy (all-traces): falsified - found trace (11 steps)

--- a/case-studies-regression/loops/JCS12_Typing_Example_analyzed.spthy
+++ b/case-studies-regression/loops/JCS12_Typing_Example_analyzed.spthy
@@ -39,54 +39,61 @@ rule (modulo E) Client_2:
 
   /* has exactly the trivial AC variant */
 
+restriction Restr_Serv_1_1:
+  "∀ x #NOW x.1. (Restr_Serv_1_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  // safety formula
+
+  /*
+  expanded formula:
+  "∀ x #NOW x.1. (Restr_Serv_1_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  */
+
 rule (modulo E) Serv_1:
-   [
-   !Ltk( $S, ~ltkS ), In( request ),
-   !Pk( fst(snd(adec(request, ~ltkS))), pkC )
-   ]
+   [ !Ltk( $S, ~ltkS ), In( request ), !Pk( C, pkC ) ]
   --[
   Eq( fst(adec(request, ~ltkS)), '1' ),
-  ReceivedKey( fst(snd(adec(request, ~ltkS))), $S,
-               snd(snd(adec(request, ~ltkS)))
-  ),
-  In_Serv_1( request, snd(snd(adec(request, ~ltkS))) )
+  ReceivedKey( C, $S, snd(snd(adec(request, ~ltkS))) ),
+  In_Serv_1( request, snd(snd(adec(request, ~ltkS))) ),
+  Restr_Serv_1_1( C, fst(snd(adec(request, ~ltkS))) )
   ]->
    [ Out( aenc(<'2', snd(snd(adec(request, ~ltkS)))>, pkC) ) ]
 
   /*
   rule (modulo AC) Serv_1:
-     [ !Ltk( $S, ~ltkS ), In( request ), !Pk( z, pkC ) ]
-    --[ Eq( z.2, '1' ), ReceivedKey( z, $S, z.1 ), In_Serv_1( request, z.1 )
+     [ !Ltk( $S, ~ltkS ), In( request ), !Pk( C, pkC ) ]
+    --[
+    Eq( z.1, '1' ), ReceivedKey( C, $S, z ), In_Serv_1( request, z ),
+    Restr_Serv_1_1( C, z.2 )
     ]->
-     [ Out( aenc(<'2', z.1>, pkC) ) ]
+     [ Out( aenc(<'2', z>, pkC) ) ]
     variants (modulo AC)
-    1. ~ltkS = ~ltkS.12
+    1. ~ltkS = ~ltkS.15
        request
-             = request.14
-       z     = fst(snd(adec(request.14, ~ltkS.12)))
-       z.1   = snd(snd(adec(request.14, ~ltkS.12)))
-       z.2   = fst(adec(request.14, ~ltkS.12))
+             = request.18
+       z     = snd(snd(adec(request.18, ~ltkS.15)))
+       z.1   = fst(adec(request.18, ~ltkS.15))
+       z.2   = fst(snd(adec(request.18, ~ltkS.15)))
     
-    2. ~ltkS = ~ltkS.16
+    2. ~ltkS = ~ltkS.20
        request
-             = aenc(<z.22, z.19, z.21>, pk(~ltkS.16))
-       z     = z.19
-       z.1   = z.21
-       z.2   = z.22
+             = aenc(<z.26, z.28, z.25>, pk(~ltkS.20))
+       z     = z.25
+       z.1   = z.26
+       z.2   = z.28
     
-    3. ~ltkS = ~ltkS.20
+    3. ~ltkS = ~ltkS.24
        request
-             = aenc(x.37, pk(~ltkS.20))
-       z     = fst(snd(x.37))
-       z.1   = snd(snd(x.37))
-       z.2   = fst(x.37)
+             = aenc(x.45, pk(~ltkS.24))
+       z     = snd(snd(x.45))
+       z.1   = fst(x.45)
+       z.2   = fst(snd(x.45))
     
-    4. ~ltkS = ~ltkS.21
+    4. ~ltkS = ~ltkS.25
        request
-             = aenc(<z.27, x.39>, pk(~ltkS.21))
-       z     = fst(x.39)
-       z.1   = snd(x.39)
-       z.2   = z.27
+             = aenc(<z.31, x.47>, pk(~ltkS.25))
+       z     = snd(x.47)
+       z.1   = z.31
+       z.2   = fst(x.47)
   */
 
 lemma typing_assertion [sources]:
@@ -113,7 +120,7 @@ next
     case case_1
     solve( !Ltk( $S, ~ltkS ) ▶₀ #i )
       case Register_pk
-      solve( !Pk( z, pkC ) ▶₂ #i )
+      solve( !Pk( C, pkC ) ▶₂ #i )
         case Register_pk
         solve( !KU( aenc(<z, $A, v>, pk(~ltkS)) ) @ #vk )
           case Client_1
@@ -272,8 +279,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -285,7 +292,7 @@ summary of summaries:
 analyzed: examples/loops/JCS12_Typing_Example.spthy
 
   output:          examples/loops/JCS12_Typing_Example.spthy.tmp
-  processing time: 0.09s
+  processing time: 0.08s
   
   typing_assertion (all-traces): verified (15 steps)
   Client_session_key_secrecy_raw (all-traces): verified (8 steps)

--- a/case-studies-regression/post17/foo_eligibility_analyzed.spthy
+++ b/case-studies-regression/post17/foo_eligibility_analyzed.spthy
@@ -35,7 +35,7 @@ rule (modulo E) V_1:
   Created_commit_V_1( blind(commit($vote, ~r), ~b) )
   ]->
    [
-   Out( <blind(commit($vote, ~r), ~b),
+   Out( <blind(commit($vote, ~r), ~b), 
          sign(blind(commit($vote, ~r), ~b), ~ltkV)>
    ),
    St_V_1( V, $vote, ~r, ~b )
@@ -52,7 +52,7 @@ rule (modulo E) A_1:
 
 rule (modulo E) V_2:
    [
-   In( <blind(commit(vote, ~r), ~b),
+   In( <blind(commit(vote, ~r), ~b), 
         sign(blind(commit(vote, ~r), ~b), ~ltkA)>
    ),
    St_V_1( V, vote, ~r, ~b ), !AdminLtk( A, ~ltkA )
@@ -103,7 +103,7 @@ rule (modulo E) C_2:
     1. r     = r.5
        x     = x.5
        z     = open(x.5, r.5)
-
+    
     2. r     = x.5
        x     = commit(x.6, x.5)
        z     = x.6
@@ -351,7 +351,7 @@ analyzed: examples/post17/foo_eligibility.spthy
 
   output:          examples/post17/foo_eligibility.spthy.tmp
   processing time: 0.22s
-
+  
   types (all-traces): verified (43 steps)
   exec (exists-trace): verified (9 steps)
   eligibility (all-traces): verified (11 steps)

--- a/case-studies-regression/post17/foo_eligibility_analyzed.spthy
+++ b/case-studies-regression/post17/foo_eligibility_analyzed.spthy
@@ -35,7 +35,7 @@ rule (modulo E) V_1:
   Created_commit_V_1( blind(commit($vote, ~r), ~b) )
   ]->
    [
-   Out( <blind(commit($vote, ~r), ~b), 
+   Out( <blind(commit($vote, ~r), ~b),
          sign(blind(commit($vote, ~r), ~b), ~ltkV)>
    ),
    St_V_1( V, $vote, ~r, ~b )
@@ -52,7 +52,7 @@ rule (modulo E) A_1:
 
 rule (modulo E) V_2:
    [
-   In( <blind(commit(vote, ~r), ~b), 
+   In( <blind(commit(vote, ~r), ~b),
         sign(blind(commit(vote, ~r), ~b), ~ltkA)>
    ),
    St_V_1( V, vote, ~r, ~b ), !AdminLtk( A, ~ltkA )
@@ -77,16 +77,36 @@ rule (modulo E) V_3:
 
   /* has exactly the trivial AC variant */
 
+restriction Restr_C_2_1:
+  "∀ x #NOW x.1. (Restr_C_2_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  // safety formula
+
+  /*
+  expanded formula:
+  "∀ x #NOW x.1. (Restr_C_2_1( x, x.1 ) @ #NOW) ⇒ (x = x.1)"
+  */
+
 rule (modulo E) C_2:
-   [ In( r ), St_C_1( A, commit(open(x, r), r) ) ]
-  --[ VotePublished( open(x, r) ), Out_C_2( commit(open(x, r), r) ) ]->
+   [ In( r ), St_C_1( A, x ) ]
+  --[
+  VotePublished( open(x, r) ), Out_C_2( x ),
+  Restr_C_2_1( x, commit(open(x, r), r) )
+  ]->
    [ Out( open(x, r) ) ]
 
   /*
   rule (modulo AC) C_2:
-     [ In( r ), St_C_1( A, commit(z, r) ) ]
-    --[ VotePublished( z ), Out_C_2( commit(z, r) ) ]->
+     [ In( r ), St_C_1( A, x ) ]
+    --[ VotePublished( z ), Out_C_2( x ), Restr_C_2_1( x, commit(z, r) ) ]->
      [ Out( z ) ]
+    variants (modulo AC)
+    1. r     = r.5
+       x     = x.5
+       z     = open(x.5, r.5)
+
+    2. r     = x.5
+       x     = commit(x.6, x.5)
+       z     = x.6
   */
 
 lemma types [sources]:
@@ -317,8 +337,8 @@ qed
 Generated from:
 Tamarin version 1.13.0
 Maude version 3.4
-Git revision: 1deff12bd69c96308abb2463d4de5f2c7610c191 (with uncommited changes), branch: develop
-Compiled at: 2026-03-09 07:36:56.194364 UTC
+Git revision: a31226029a4774beefcb53c81296ea289c8d91d0 (with uncommited changes), branch: feat/tamarin-to-pv-pr
+Compiled at: 2026-06-25 11:10:06.043274 UTC
 */
 
 end
@@ -330,8 +350,8 @@ summary of summaries:
 analyzed: examples/post17/foo_eligibility.spthy
 
   output:          examples/post17/foo_eligibility.spthy.tmp
-  processing time: 0.43s
-  
+  processing time: 0.22s
+
   types (all-traces): verified (43 steps)
   exec (exists-trace): verified (9 steps)
   eligibility (all-traces): verified (11 steps)

--- a/examples/features/auto-sources/spore/SpliceAS.spthy
+++ b/examples/features/auto-sources/spore/SpliceAS.spthy
@@ -216,9 +216,8 @@ rule C_from_S:
  // here to ensure a single key per user
  restriction OnlyOnce:
    "
-     All A B #i #j.
-       OnlyOnce(A)@#i & OnlyOnce(B)@#j
-       & A=B
+     All A #i #j.
+       OnlyOnce(A)@#i & OnlyOnce(A)@#j
      ==>
        #i = #j
    "

--- a/examples/features/auto-sources/spore/SpliceAS_2.spthy
+++ b/examples/features/auto-sources/spore/SpliceAS_2.spthy
@@ -205,9 +205,8 @@ rule C_from_S:
  // here to ensure a single key per user
  restriction OnlyOnce:
    "
-     All A B #i #j.
-       OnlyOnce(A)@#i & OnlyOnce(B)@#j
-       & A=B
+     All A #i #j.
+       OnlyOnce(A)@#i & OnlyOnce(A)@#j
      ==>
        #i = #j
    "

--- a/examples/features/auto-sources/spore/SpliceAS_3.spthy
+++ b/examples/features/auto-sources/spore/SpliceAS_3.spthy
@@ -217,9 +217,8 @@ rule C_from_S:
  // here to ensure a single key per user
  restriction OnlyOnce:
    "
-     All A B #i #j.
-       OnlyOnce(A)@#i & OnlyOnce(B)@#j
-       & A=B
+     All A #i #j.
+       OnlyOnce(A)@#i & OnlyOnce(A)@#j
      ==>
        #i = #j
    "

--- a/examples/features/auto-sources/tamarin-repo/loops/JCS12_Typing_Example.spthy
+++ b/examples/features/auto-sources/tamarin-repo/loops/JCS12_Typing_Example.spthy
@@ -58,11 +58,8 @@ rule Client_2:
 // A server thread answering in one-step to a session-key setup request from
 // some client.
 rule Serv_1:
-  let msg = adec(request, ~ltkS)
-      tag = fst(msg)
-      C   = fst(snd(msg))
-      k   = snd(snd(msg))
-  in
+  let tag = fst(adec(request, ~ltkS))
+      k   = snd(snd(adec(request, ~ltkS)))  in
     [ !Ltk($S, ~ltkS)
     , In( request )
     , !Pk(C, pkC)
@@ -74,6 +71,7 @@ rule Serv_1:
                     // the proof depth and use the GUI, then you can see that
                     // there is the option that, without this check, servers
                     // just forward messages to further servers.)
+    , _restrict( C   = fst(snd(adec(request, ~ltkS))) )
     , ReceivedKey(C, $S, k)
     , In_Serv_1(request, k)
     ]->

--- a/examples/loops/JCS12_Typing_Example.spthy
+++ b/examples/loops/JCS12_Typing_Example.spthy
@@ -60,7 +60,6 @@ rule Client_2:
 rule Serv_1:
   let msg = adec(request, ~ltkS)
       tag = fst(msg)
-      C   = fst(snd(msg))
       k   = snd(snd(msg))
   in
     [ !Ltk($S, ~ltkS)
@@ -76,6 +75,7 @@ rule Serv_1:
                     // just forward messages to further servers.)
     , ReceivedKey(C, $S, k)
     , In_Serv_1(request, k)
+    , _restrict(C   = fst(snd(msg)))
     ]->
     [ Out( aenc{'2',k}pkC ) ]
 

--- a/examples/post17/foo_eligibility.spthy
+++ b/examples/post17/foo_eligibility.spthy
@@ -85,12 +85,10 @@ rule V_3:
 
 rule C_2:
   let v = open(x, r)
-      x = commit(open(x,r),r)
   in
     [ In( r ), St_C_1( A, x ) ]
-  --[ VotePublished( v ), Out_C_2(x) ]->
+  --[ VotePublished( v ), Out_C_2(x), _restrict(x = commit(open(x,r),r)) ]->
     [ Out( v ) ]
-
 
 
 // sources lemma

--- a/examples/usenix23-ens/robert.spthy
+++ b/examples/usenix23-ens/robert.spthy
@@ -432,7 +432,6 @@ rule PhoneExposureStatusRequest:
  rule ServerExposureStatusRequest:
     let
         epochp = fst(sdec(~KS, ebid))
-        id = snd(sdec(~KS, ebid))
         m = <ebid, epoch, $t>
         esr_req = <m, mac(KauthP, m)>
     in
@@ -443,6 +442,7 @@ rule PhoneExposureStatusRequest:
     , !LEE($CC, id, epoch) ]
   --[ Time($t)
     , _restrict(epochp = epoch)
+    , _restrict(id = snd(sdec(~KS, ebid)))
     // This check is assumed to be implicit in the spec and only an artifect of our model.
     , _restrict(idS = id)
     , IsTrue(sdecSuc(~KS, ebid))
@@ -512,8 +512,6 @@ rule PhoneUploadHello:
 rule Backend:
     let
         epochp = fst(sdec(~KS, ebid))
-        id = snd(sdec(~KS, ebid))
-        CC2 = sdecIV(~KG, ebid, ecc)
         m = <ecc, ebid, time16>
         hello = <m, mac(KauthP, m)>
     in
@@ -525,6 +523,8 @@ rule Backend:
     , ValidToken($CC1, qr) ]
   --[  EpochAtTime(CC2, epochp, $time)
     , _restrict(time16 = trunc16($time))
+    , _restrict(CC2 = sdecIV(~KG, ebid, ecc))
+    , _restrict(id = snd(sdec(~KS, ebid)))
     , MarkPositive(idI, $time)
     , BackendForward($CC1, CC2)
     , IsTrue(sdecSuc(~KS, ebid))

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -28,7 +28,7 @@ import Data.List as List
 import Data.Map qualified as M
 import Data.Maybe
 import Data.Set qualified as S
-import Debug.Trace (trace)
+import Extension.Data.Label qualified as L
 import ProVerifHeader
 import RuleTranslation
 import Sapic.Annotation
@@ -46,6 +46,10 @@ import Theory.Sapic
 import Theory.Text.Pretty
 import Theory.Tools.Wellformedness (formulaFacts)
 
+-- ===========================================================================
+-- SECTION 1: Module Header & Types
+-- ===========================================================================
+
 -- | Types of translation the export module covers (others are covered by sapic module).
 data Translation
   = ProVerif
@@ -57,6 +61,13 @@ exportModule :: Translation -> ModuleType
 exportModule ProVerif = ModuleProVerif
 exportModule DeepSec = ModuleDeepSec
 
+-- | Classification for how a lemma should be translated
+data LemmaTranslationMode
+  = AsQuery       -- ^ Regular lemma, translate as query
+  | AsAxiom       -- ^ Reuse/source lemma, translate as axiom
+  | ExcludeLemma  -- ^ Don't translate at all
+  deriving (Eq, Ord, Show)
+
 -- | Information needed during translation.
 data TranslationContext = TranslationContext
   { trans :: Translation,
@@ -65,8 +76,10 @@ data TranslationContext = TranslationContext
     hasUnboundStates :: Bool,
     predicates :: [Predicate],
     replicationBound :: Int,
-    skipReuseOrSrc :: Bool,
-    skipRestrictions :: Bool
+    skipReuseLemmas :: Bool,
+    skipSourceLemmas :: Bool,
+    skipRestrictions :: Bool,
+    skipPrecise :: Bool
   }
   deriving (Eq, Ord)
 
@@ -80,9 +93,111 @@ emptyTC =
       hasUnboundStates = False,
       predicates = [],
       replicationBound = 3, -- TODO: allow modifying this parameter
-      skipReuseOrSrc = False,
-      skipRestrictions = False
+      skipReuseLemmas = False,
+      skipSourceLemmas = False,
+      skipRestrictions = False,
+      skipPrecise = False
     }
+
+-- ===========================================================================
+-- Helper Functions for Formula Construction
+-- ===========================================================================
+
+-- | Build a conjunction from a list of formulas.
+-- Returns True for empty list, single formula unchanged, otherwise folds with .&&.
+buildConjunction :: [LNFormula] -> LNFormula
+buildConjunction [] = TF True
+buildConjunction [f] = f
+buildConjunction fs = foldr1 (.&&.) fs
+
+-- | Build a disjunction from a list of formulas.
+-- Returns False for empty list, single formula unchanged, otherwise folds with .||.
+buildDisjunction :: [LNFormula] -> LNFormula
+buildDisjunction [] = TF False
+buildDisjunction [f] = f
+buildDisjunction fs = foldr1 (.||.) fs
+
+-- | Wrap a formula with quantifiers of the given type.
+-- Applies quantifiers from outer to inner (first element becomes outermost quantifier).
+wrapWithQuantifiers :: Quantifier -> [(String, LSort)] -> LNFormula -> LNFormula
+wrapWithQuantifiers _ [] body = body
+wrapWithQuantifiers q (v:vs) body = Qua q v (wrapWithQuantifiers q vs body)
+
+-- | Check if a formula represents a valid existential disjunction pattern.
+-- Valid patterns include:
+-- - An existential formula with quantifier-free body
+-- - A disjunction of existential formulas
+-- - A temporal/equality constraint: #i < #j, x = y
+-- - A bare action atom (from moved negated actions)
+-- - A nested implication: All x. P => Q (where Q is valid conclusion)
+isExistentialDisjunction :: MonadFresh m => LNFormula -> m Bool
+isExistentialDisjunction fm@(Qua Ex _ _) = do
+  (_, _, fm') <- openFormulaPrefix fm
+  -- Accept either quantifier-free bodies or nested existential/disjunctive structure.
+  if isQuantifierFree fm'
+    then pure True
+    else isExistentialDisjunction fm'
+-- Handle universals (nested implications): All x. P => Q
+isExistentialDisjunction fm@(Qua All _ _) = do
+  (_, _, fm') <- openFormulaPrefix fm
+  isExistentialDisjunction fm'
+-- Handle implications: P => Q (nested implication body)
+isExistentialDisjunction (Conn Imp p q) | isQuantifierFree p = do
+  -- The premise must be quantifier-free, conclusion can be:
+  -- quantifier-free, existential, or another nested implication
+  if isQuantifierFree q
+    then pure True
+    else isExistentialDisjunction q
+-- Handle disjunctions: (Ex...) | (Ex...) | ...
+isExistentialDisjunction (Conn Or fm1 fm2) = do
+  b1 <- isExistentialDisjunction fm1
+  b2 <- isExistentialDisjunction fm2
+  pure $ b1 && b2
+-- Handle conjunctions: (Ex...) & (Ex...) & ... or (All...) & (Ex...)
+-- This allows patterns like: ((Ex #j. A@j) & (Ex #k. B@k)) | ((Ex #r. C@r) & (Ex #t. D@t))
+-- Also allows: (All #j. B@j => C) & (Ex #k. D@k)
+isExistentialDisjunction (Conn And fm1 fm2) = do
+  b1 <- isExistentialDisjunction fm1
+  b2 <- isExistentialDisjunction fm2
+  pure $ b1 && b2
+isExistentialDisjunction fm | isConstraintAtom fm = pure True
+isExistentialDisjunction fm | isBareActionAtom fm = pure True
+isExistentialDisjunction _ = pure False
+
+-- | Check if a formula is a temporal or equality constraint
+isConstraintAtom :: LNFormula -> Bool
+isConstraintAtom (Ato (Less _ _)) = True
+isConstraintAtom (Ato (EqE _ _)) = True
+isConstraintAtom (Not (Ato (EqE _ _))) = True
+isConstraintAtom (Conn Or f1 f2) = isConstraintAtom f1 && isConstraintAtom f2
+isConstraintAtom _ = False
+
+-- | Check if a formula is a bare action atom
+isBareActionAtom :: LNFormula -> Bool
+isBareActionAtom (Ato (Action _ _)) = True
+isBareActionAtom _ = False
+
+-- | Check if a formula is a nested implication that can be flattened.
+-- Pattern: All x. Q => R  where Q is quantifier-free and R is quantifier-free or existential disjunction
+-- This is equivalent to adding Q to the premise.
+isNestedImplicationOk :: MonadFresh m => LNFormula -> m Bool
+isNestedImplicationOk fm@(Qua All _ _) = do
+  (_, _, fm') <- openFormulaPrefix fm
+  isNestedImplicationOk fm'
+isNestedImplicationOk (Conn Imp q r) | isQuantifierFree q = do
+  -- The nested premise q must be quantifier-free
+  -- The nested conclusion r can be:
+  -- 1. Quantifier-free (like #i < #j)
+  -- 2. An existential disjunction
+  -- 3. Another nested implication
+  if isQuantifierFree r
+    then pure True
+    else do
+      isExDisj <- isExistentialDisjunction r
+      if isExDisj
+        then pure True
+        else isNestedImplicationOk r
+isNestedImplicationOk _ = pure False
 
 -- | Failure function performing an unsafe IO failure
 translationFail :: String -> a
@@ -100,59 +215,76 @@ translationWarning s cont = unsafePerformIO printWarning
 -- Core ProVerif Export
 ------------------------------------------------------------------------------
 
-proverifTemplate :: (Document d) => [d] -> [d] -> d -> [d] -> [d] -> [d] -> [d] -> [d] -> d
-proverifTemplate headers queries process macroproc ruleproc restrictions lemmas comments =
-  vcat headers
+proverifTemplate :: (Document d) => Bool -> [d] -> [d] -> d -> [d] -> [d] -> [d] -> [d] -> [d] -> [d] -> d
+proverifTemplate skipPrecise headers queries process macroproc ruleproc restrictions axioms lemmas comments =
+  (if skipPrecise then text "" else text "set preciseActions = true.")
+    $$ vcat headers
     $$ vcat queries
-    $$ vcat lemmas
-    $$ vcat restrictions
+    $$ (if null restrictions then text "" else text "" $$ text "(* Restrictions *)" $$ text "" $$ vcat restrictions)
+    $$ (if null axioms then text "" else text "" $$ text "(* Axioms from reuse/source lemmas *)" $$ text "" $$ vcat axioms)
+    $$ (if null lemmas then text "" else text "" $$ text "(* Lemmas (queries) *)" $$ text "" $$ vcat lemmas)
     $$ vcat macroproc
     $$ vcat ruleproc
+    $$ text "" $$ text "(* Process *)" $$ text ""
     $$ text "process"
     $$ nest 4 process
     $--$ vcat (intersperse (text "") comments)
 
 prettyProVerifTheory ::
   ModuleType ->
-  Bool -> -- noReuse
+  Bool -> -- noReuseLemmas
+  Bool -> -- noSourceLemmas
   Bool -> -- noRestrictions
+  Bool -> -- noMultiset
+  Bool -> -- noPrecise
+  Bool -> -- hasSpecificLemmas
   (ProtoLemma LNFormula ProofSkeleton -> Bool) ->
   (OpenTheory, TypingEnvironment) ->
   IO Doc
-prettyProVerifTheory m noReuse noRestrictions lemSel (thy, typEnv) = do
-  headersTheory <- loadHeaders tc thy typEnv -- load headers from theory
+prettyProVerifTheory m noReuseLemmas noSourceLemmas noRestrictions noMultiset noPrecise hasSpecificLemmas lemSel (thy', typEnv) = do
+  headersTheory <- loadHeaders sharedEventTags tc thy typEnv -- load headers from theory
   let headersTranslation =
         [ baseHeaders, -- base headers for translation
           prochd, -- headers from the process
           macroprochd, -- headers from the macroprocess
-          ruleHeaders -- headers from the rules
+          ruleHeaders, -- headers from the rules
+          lemmaHeaders, -- headers from the lemmas
+          restrictionHeaders -- headers from the restrictions
         ]
   headers <- checkDuplicates' $ filterHeaders $ S.unions $ headersTheory : headersTranslation
   let hd = attribHeaders tc headers
-  pure $ proverifTemplate hd queries proc' macroproc ruleproc restrictions lemmas comments
+  pure $ proverifTemplate (skipPrecise tc) hd queries proc' macroproc ruleproc restrictions axioms lemmas comments
   where
+    thy = if noMultiset then thy' else multisetTheory thy'
+
     tc =
       emptyTC
         { predicates = theoryPredicates thy,
-          skipReuseOrSrc = noReuse,
-          skipRestrictions = noRestrictions
+          skipReuseLemmas = noReuseLemmas,
+          skipSourceLemmas = noSourceLemmas,
+          skipRestrictions = noRestrictions,
+          skipPrecise = noPrecise
         }
     (proc, prochd, hasBoundState, hasUnboundState) = loadProc tc thy
-    (ruleproc, ruleComb, ruleHeaders) = loadRules thy m
     proc'
       | null (theoryProcesses thy) = ruleComb
       | null (theoryRules thy) = proc
       | otherwise = proc <-> text "|" <-> ruleComb
     baseHeaders = if hasUnboundState then stateHeaders else S.empty
-    restrictions =
+    -- Compute shared events from both lemmas and restrictions
+    lemmaSharedEvents = detectSharedTimepointEvents (filter lemSel (theoryLemmas thy))
+    restrictionSharedEvents = detectSharedTimepointEventsRestrictions (theoryRestrictions thy)
+    sharedEventTags = lemmaSharedEvents `S.union` restrictionSharedEvents
+    (restrictions, restrictionHeaders) =
       if skipRestrictions tc
-        then []
-        else loadRestrictions tc typEnv thy
+        then ([], S.empty)
+        else loadRestrictions sharedEventTags tc typEnv thy
     queries = loadQueries thy
-    lemmas = loadLemmas lemSel tc typEnv thy
+    (axioms, lemmas, lemmaHeaders) = loadLemmas sharedEventTags hasSpecificLemmas lemSel tc typEnv thy
+    (ruleproc, ruleComb, ruleHeaders) = loadRules sharedEventTags thy m
     (macroproc, macroprochd) =
       -- if stateM is not empty, we have inlined the process calls, so we don't reoutput them
-      if hasBoundState then ([], S.empty) else loadMacroProc tc thy
+      if hasBoundState then ([text ""], S.empty) else loadMacroProc tc thy
     comments = [text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy]
 
 stateHeaders :: S.Set ProVerifHeader
@@ -173,6 +305,10 @@ builtins "diffie-hellman" =
     [ Sym "const" "g" ":bitstring" [],
       Fun "fun" "exp" 2 "(bitstring,bitstring):bitstring" [],
       Eq "equation" "forall a:bitstring,b:bitstring;" "exp( exp(g,a),b) = exp(exp(g,b),a)" ""
+      -- Note: The following commented out functions and equations are not supported by ProVerif.
+      -- Fun "fun" "inv" 1 "(bitstring):bitstring" [],
+      -- Eq "equation" "forall a:bitstring,b:bitstring;" "exp( exp(a,b), inv(b)) = a" "",
+      -- Eq "equation" "forall a:bitstring;" "inv( inv(a)) = a" ""
     ]
 builtins "locations-report" =
   AccurateBuiltin
@@ -229,34 +365,37 @@ filterHeaders = S.filter (not . isForbidden)
 
 -- | Extract the “name” of any header that should be unique.
 getProVerifHeaderIdentifier :: ProVerifHeader -> Maybe String
-getProVerifHeaderIdentifier (Fun _ n _ _ _)   = Just n
-getProVerifHeaderIdentifier (Sym _ n _ _)     = Just n
-getProVerifHeaderIdentifier (HEvent n _)      = Just n
-getProVerifHeaderIdentifier (Table n _)       = Just n
-getProVerifHeaderIdentifier _                 = Nothing
+getProVerifHeaderIdentifier (Fun _ n _ _ _) = Just n
+getProVerifHeaderIdentifier (Sym _ n _ _) = Just n
+getProVerifHeaderIdentifier (HEvent n _) = Just n
+getProVerifHeaderIdentifier (Table n _) = Just n
+getProVerifHeaderIdentifier _ = Nothing
 
 -- | Fail if any identifier occurs more than once; otherwise return all headers
-checkDuplicates :: MonadFail m => [ProVerifHeader] -> m [ProVerifHeader]
+checkDuplicates :: (MonadFail m) => [ProVerifHeader] -> m [ProVerifHeader]
 checkDuplicates headers = do
-    let identMap :: M.Map String [ProVerifHeader]
-        identMap = M.fromListWith (<>)
-                  [ (n, [h])
-                  | h <- headers
-                  , Just n <- [getProVerifHeaderIdentifier h]
-                  ]
-        conflicts = filter ((>1) . length) (M.toList identMap)
+  let identMap :: M.Map String [ProVerifHeader]
+      identMap =
+        M.fromListWith
+          (<>)
+          [ (n, [h])
+            | h <- headers,
+              Just n <- [getProVerifHeaderIdentifier h]
+          ]
+      conflicts = M.toList $ M.filter ((> 1) . length) identMap
 
-    -- if there are conflicts, bail; otherwise return the whole input
-    unless (null conflicts) $
-      fail $ unlines
+  -- if there are conflicts, bail; otherwise return the whole input
+  unless (null conflicts) $
+    fail $
+      unlines
         ( "ProVerif constructs (functions, constants, events, tables) must be distinct.\
           \ Please rename these duplicates:"
-        : [ intercalate ", " (map show defs)
-          | (_, defs) <- conflicts
-          ]
+            : [ intercalate ", " (map show defs)
+                | (_, defs) <- conflicts
+              ]
         )
 
-    return headers
+  return headers
 
 checkDuplicates' :: S.Set ProVerifHeader -> IO [ProVerifHeader]
 checkDuplicates' = checkDuplicates . S.toList
@@ -266,7 +405,7 @@ ppPubName (NameId n) = text $ case n of
   "zero" -> "0"
   "one" -> "1"
   "g" -> "g"
-  _ -> "s" ++ n
+  _ -> "v" ++ n
 
 -- Loader of the export functions
 ------------------------------------------------------------------------------
@@ -288,7 +427,7 @@ proverifEquivTemplate headers queries equivlemmas macroproc comments =
 
 prettyProVerifEquivTheory :: (OpenTheory, TypingEnvironment) -> IO Doc
 prettyProVerifEquivTheory (thy, typEnv) = do
-  headersTheory <- loadHeaders tc thy typEnv
+  headersTheory <- loadHeaders S.empty tc thy typEnv
   let headersTranslation =
         [ baseHeaders,
           equivhd,
@@ -311,7 +450,7 @@ prettyProVerifEquivTheory (thy, typEnv) = do
     queries = loadQueries thy
     (macroproc, macroprochd) =
       -- if stateM is not empty, we have inlined the process calls, so we don't reoutput them
-      if hasBoundState then ([], S.empty) else loadMacroProc tc thy
+      if hasBoundState then ([text ""], S.empty) else loadMacroProc tc thy
     comments = [text "(*" $$ text bd $$ text "*)" | (_, bd) <- theoryFormalComments thy]
 
 ------------------------------------------------------------------------------
@@ -331,7 +470,7 @@ emptyTypeEnv = TypingEnvironment {vars = M.empty, events = M.empty, funs = M.emp
 
 prettyDeepSecTheory :: Int -> OpenTheory -> IO Doc
 prettyDeepSecTheory repBound thy = do
-  headers <- loadHeaders tc thy emptyTypeEnv
+  headers <- loadHeaders S.empty tc thy emptyTypeEnv
   let hd = attribHeaders tc $ S.toList (S.unions [headers, macroprochd, equivhd])
   pure $ deepsecTemplate hd macroproc requests equivlemmas comments
   where
@@ -351,6 +490,11 @@ loadRequests thy =
 -- Term Printers
 ------------------------------------------------------------------------------
 
+-- | Print a variable name. For timepoint (node) variables, we need to ensure
+-- they don't collide with term variables of the same name. In Tamarin, #t and t
+-- are different variables, but in ProVerif they would both become 't'.
+-- We handle this by checking the sort and NOT adding a prefix here - instead,
+-- we use a separate function for timepoint variables in query declarations.
 ppLVar :: LVar -> Doc
 ppLVar (LVar n _ 0) = text $ sanitizeSymbol 'a' n
 ppLVar (LVar n _ i) = text . sanitizeSymbol 'a' $ n <> "_" <> show i
@@ -371,8 +515,11 @@ ppTypeLit :: (Show c) => TranslationContext -> Lit c SapicLVar -> Doc
 ppTypeLit tc (Var v) = ppTypeVar tc v
 ppTypeLit _ (Con c) = text . sanitizeSymbol 'a' $ show c
 
-auxppTerm :: (Show v) => (Lit Name v -> Doc) -> VTerm Name v -> (Doc, S.Set ProVerifHeader)
-auxppTerm ppLit t = (ppTerm t, getHdTerm t)
+-- | Render a term and collect required ProVerif header declarations.
+-- Takes a literal rendering function and a term, returns the rendered
+-- Doc and the set of headers needed for declarations (e.g., free constants).
+renderTermWithHeaders :: (Show v) => (Lit Name v -> Doc) -> VTerm Name v -> (Doc, S.Set ProVerifHeader)
+renderTermWithHeaders ppLit t = (ppTerm t, getHdTerm t)
   where
     ppTerm tm = case viewTerm tm of
       Lit v -> ppLit v
@@ -419,11 +566,11 @@ auxppTerm ppLit t = (ppTerm t, getHdTerm t)
       Lit _ -> S.empty
       FApp _ ts -> foldl (\x y -> x `S.union` getHdTerm y) S.empty ts
 
--- | pretty print a SapicTerm, collecting the constants that need to be declared
--- matchVars is the set of vars that correspond to pattern matching
--- isPattern enables the pattern match printing, which adds types to variables, and = to constants.
-auxppSapicTerm :: TranslationContext -> S.Set LVar -> Bool -> SapicTerm -> (Doc, S.Set ProVerifHeader)
-auxppSapicTerm tc mVars isPattern = auxppTerm ppLit
+-- | Render a SapicTerm, collecting the constants that need to be declared.
+-- matchVars is the set of vars that correspond to pattern matching.
+-- isPattern enables pattern match printing, which adds types to variables and = to constants.
+renderSapicTermWithPattern :: TranslationContext -> S.Set LVar -> Bool -> SapicTerm -> (Doc, S.Set ProVerifHeader)
+renderSapicTermWithPattern tc mVars isPattern = renderTermWithHeaders ppLit
   where
     ppLit v = case v of
       Con (Name FreshName n) -> text . sanitizeSymbol 'a' $ show n
@@ -438,7 +585,9 @@ auxppSapicTerm tc mVars isPattern = auxppTerm ppLit
                   ++ show lsort
                   ++ ". Used in pattern matching, this may produces different behaviour in Tamarin and ProVerif.  Used elsewhere, we simply ignore the sort and translate to to ProVerif's default: bitstring"
               )
-              $ text "=" <> ppLVar lvar
+              $ if isPattern || S.member lvar mVars
+                  then text "=" <> ppLVar lvar
+                  else ppLVar lvar
       Var (SapicLVar lvar _)
         | S.member lvar mVars -> text "=" <> ppLVar lvar
       l | isPattern -> ppTypeLit tc l
@@ -446,30 +595,30 @@ auxppSapicTerm tc mVars isPattern = auxppTerm ppLit
       l -> text . sanitizeSymbol 'a' $ show l
 
 ppSapicTerm :: TranslationContext -> SapicTerm -> (Doc, S.Set ProVerifHeader)
-ppSapicTerm tc = auxppSapicTerm tc S.empty False
+ppSapicTerm tc = renderSapicTermWithPattern tc S.empty False
 
--- pretty print an LNTerm, collecting the constant that need to be declared
--- the boolean b enables types printout
-pppLNTerm :: TranslationContext -> Bool -> LNTerm -> (Doc, S.Set ProVerifHeader)
-pppLNTerm _ b = auxppTerm ppLit
+-- | Render an LNTerm, collecting the constants that need to be declared.
+-- The boolean parameter enables type annotations in the output.
+renderLNTermTyped :: TranslationContext -> Bool -> LNTerm -> (Doc, S.Set ProVerifHeader)
+renderLNTermTyped _ includeTypes = renderTermWithHeaders ppLit
   where
     ppLit v = case v of
       Con (Name FreshName n) -> text . sanitizeSymbol 'a' $ show n
       Con (Name PubName n) -> ppPubName n
-      tm2 | b -> text $ sanitizeSymbol 'a' (show tm2) <> ":bitstring"
+      tm2 | includeTypes -> text $ sanitizeSymbol 'a' (show tm2) <> ":bitstring"
       Var lvar -> ppLVar lvar
       tm2 -> text . sanitizeSymbol 'a' $ show tm2
 
 ppLNTerm :: TranslationContext -> LNTerm -> (Doc, S.Set ProVerifHeader)
-ppLNTerm tc = pppLNTerm tc False
+ppLNTerm tc = renderLNTermTyped tc False
 
--- pretty print a Fact, collecting the constant that need to be declared
+-- | Render a Fact, collecting the constants that need to be declared.
 ppFact :: TranslationContext -> Fact SapicTerm -> (Doc, S.Set ProVerifHeader)
 ppFact tc (Fact tag _ ts)
-  | factTagArity tag /= length ts = sppFact ("MALFORMED-" ++ show tag) ts
-  | otherwise = sppFact ('e' : factTagName tag) ts
+  | factTagArity tag /= length ts = renderFactWithName ("MALFORMED-" ++ show tag) ts
+  | otherwise = renderFactWithName ('e' : factTagName tag) ts
   where
-    sppFact name ts2 =
+    renderFactWithName name ts2 =
       (nestShort' (name ++ "(") ")" . fsep . punctuate comma $ pts, sh)
       where
         (pts, shs) = unzip $ map (ppSapicTerm tc) ts2
@@ -523,7 +672,7 @@ ppAction ProcessAnnotation {pureState = True, isStateChannel = Just _} tc (New v
     True
   )
 ppAction _ TranslationContext {trans} Rep | trans == ProVerif = (text "!", S.empty, False)
-ppAction _ TranslationContext {trans = DeepSec} Rep = (emptyDoc, S.empty, False)
+ppAction _ TranslationContext {trans = DeepSec} Rep = (text "", S.empty, False)
 ppAction _ tc@TranslationContext {trans = ProVerif} (ChIn t1 t2 mvars) =
   ( text "in(" <> pt1 <> text "," <> pt2 <> text ")",
     sh1 `S.union` sh2,
@@ -531,7 +680,7 @@ ppAction _ tc@TranslationContext {trans = ProVerif} (ChIn t1 t2 mvars) =
   )
   where
     (pt1, sh1) = getAttackerChannel tc t1
-    (pt2, sh2) = auxppSapicTerm tc (S.map toLVar mvars) True t2
+    (pt2, sh2) = renderSapicTermWithPattern tc (S.map toLVar mvars) True t2
 ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2@(LIT (Var (SapicLVar _ _))) mvars) =
   ( text "in(" <> pt1 <> text "," <> pt2 <> text ")",
     sh1 `S.union` sh2,
@@ -539,7 +688,7 @@ ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2@(LIT (Var (SapicL
   )
   where
     (pt1, sh1) = getAttackerChannel tc t1
-    (pt2, sh2) = auxppSapicTerm tc (S.map toLVar mvars) True t2
+    (pt2, sh2) = renderSapicTermWithPattern tc (S.map toLVar mvars) True t2
 
 -- pattern matching on input for deepsec is not supported
 ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2 mvars) =
@@ -558,7 +707,7 @@ ppAction _ tc@TranslationContext {trans = DeepSec} (ChIn t1 t2 mvars) =
   )
   where
     (pt1, sh1) = getAttackerChannel tc t1
-    (pt2, sh2) = auxppSapicTerm tc (S.map toLVar mvars) True t2
+    (pt2, sh2) = renderSapicTermWithPattern tc (S.map toLVar mvars) True t2
     pt2var = "fresh" ++ stripNonAlphanumerical (render pt2)
 ppAction _ tc (ChOut t1 t2) = (text "out(" <> pt1 <> text "," <> pt2 <> text ")", sh1 `S.union` sh2, True)
   where
@@ -567,11 +716,11 @@ ppAction _ tc (ChOut t1 t2) = (text "out(" <> pt1 <> text "," <> pt2 <> text ")"
 ppAction _ tc@TranslationContext {trans} (Event (Fact tag m ts)) | trans == ProVerif = (text "event " <> pa, sh, True) -- event Headers are definde globally inside loadHeaders
   where
     (pa, sh) = ppFact tc (Fact tag m ts)
-ppAction _ TranslationContext {trans = DeepSec} (Event _) = (emptyDoc, S.empty, False)
+ppAction _ TranslationContext {trans = DeepSec} (Event _) = (text "", S.empty, False)
 -- For pure states, we do not put locks and unlocks
 ppAction ProcessAnnotation {pureState = True} TranslationContext {trans} (Lock _)
   | trans == ProVerif =
-      (emptyDoc, S.empty, False)
+      (text "", S.empty, False)
 -- If there is a state channel, we simply use it
 ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} TranslationContext {trans} (Lock _)
   | trans == ProVerif =
@@ -597,11 +746,11 @@ ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@Transl
       )
   where
     freevars = S.fromList $ map (\(SapicLVar lvar _) -> lvar) $ freesSapicTerm t
-    (pt, sh) = auxppSapicTerm tc freevars True t
+    (pt, sh) = renderSapicTermWithPattern tc freevars True t
     ptvar = "lock_" ++ stripNonAlphanumerical (render pt)
 ppAction ProcessAnnotation {pureState = True} TranslationContext {trans} (Unlock _)
   | trans == ProVerif =
-      (emptyDoc, S.empty, False)
+      (text "", S.empty, False)
 ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = False} TranslationContext {trans} (Unlock _)
   | trans == ProVerif =
       ( text "out(lock_" <> ppLVar lvar <> text "," <> text "counterlock" <> ppLVar lvar <> text "+1" <> text ") | ",
@@ -627,14 +776,6 @@ ppAction ProcessAnnotation {stateChannel = Just (AnVar lvar), pureState = _} tc@
 ppAction ProcessAnnotation {stateChannel = Nothing, pureState = True} TranslationContext {trans} (Insert _ _)
   | trans == ProVerif =
       (text "TRANSLATIONERROR", S.empty, True)
--- ppAction ProcessAnnotation{stateChannel = Just (AnVar lvar), pureState=False} tc@TranslationContext{trans=ProVerif} (Insert _ c) =
---       (text "in(" <> pt <> text ", " <> pt <> text "_dump:bitstring);"
---        $$ text "out(" <> pt <> text ", " <> pc <> text ") |"
---       , shc, False)
---   where
---     pt = ppLVar lvar
---     (pc, shc) = ppSapicTerm tc c
-
 -- must rely on the table
 ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@TranslationContext {trans} (Insert t t2)
   | trans == ProVerif =
@@ -657,6 +798,17 @@ ppAction ProcessAnnotation {stateChannel = Nothing, pureState = False} tc@Transl
     ptvar = "stateChannel" ++ stripNonAlphanumerical (render pt)
     dumpvar = "dumpvar" ++ stripNonAlphanumerical (render pt)
     hd = Sym "free" ptvar ":channel" []
+ppAction _ TranslationContext {trans = ProVerif} (MSR prems acts concs rests matchVars)
+  | not (null rests) =
+      translationFail "Embedded MSR constraints are currently not supported for ProVerif export."
+  | otherwise =
+      (msrDoc, msrHeaders, hasTailDocs)
+  where
+    lnPrems = map toLNFact prems
+    lnActs = map toLNFact acts
+    lnConcs = map toLNFact concs
+    matched = S.map (show . toLVar) matchVars
+    (msrDoc, msrHeaders, hasTailDocs) = translateEmbeddedRuleAction matched lnPrems lnActs lnConcs
 ppAction _ _ _ = translationFail "Action not supported for translation"
 
 ppSapic :: TranslationContext -> LProcess (ProcessAnnotation LVar) -> (Doc, S.Set ProVerifHeader)
@@ -680,7 +832,7 @@ ppSapic tc (ProcessComb (Let t1 t2 mvars) _ pl (ProcessNull _)) =
   )
   where
     (ppl, pshl) = ppSapic tc pl
-    (pt1, sh1) = auxppSapicTerm tc (S.map toLVar mvars) True t1
+    (pt1, sh1) = renderSapicTermWithPattern tc (S.map toLVar mvars) True t1
     (pt2, sh2) = ppSapicTerm tc t2
 ppSapic tc (ProcessComb (Let t1 t2 mvars) _ pl pr) =
   ( text "let "
@@ -696,7 +848,7 @@ ppSapic tc (ProcessComb (Let t1 t2 mvars) _ pl pr) =
   where
     (ppl, pshl) = ppSapic tc pl
     (ppr, pshr) = ppSapic tc pr
-    (pt1, sh1) = auxppSapicTerm tc (S.map toLVar mvars) True t1
+    (pt1, sh1) = renderSapicTermWithPattern tc (S.map toLVar mvars) True t1
     (pt2, sh2) = ppSapicTerm tc t2
 
 -- if the process call does not have any argument, we just inline
@@ -728,7 +880,7 @@ ppSapic tc (ProcessComb (Cond a) _ pl pr) =
     ppFact' p =
       case expandFormula (predicates tc) (toLFormula p) of
         Left _ -> translationFail "Export does not support tamarin predicates in conditionnals."
-        Right form -> (fst . snd $ Precise.evalFresh (ppLFormula emptyTypeEnv ppNAtom form) (avoidPrecise form), S.empty)
+        Right form -> (fst . snd $ Precise.evalFresh (ppLFormula emptyTypeEnv (ppNAtom S.empty) form) (avoidPrecise form), S.empty)
     addElseBranch (d, s) = case pr of
       ProcessNull _ -> (d, s)
       _ ->
@@ -805,7 +957,7 @@ ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, 
     pc = ppTypeVar tc c
     pc2 = ppUnTypeVar c
     freevars = S.fromList $ map (\(SapicLVar lvar _) -> lvar) $ freesSapicTerm t
-    (pt, sh) = auxppSapicTerm tc freevars True t
+    (pt, sh) = renderSapicTermWithPattern tc freevars True t
     ptvar = "stateChannel" ++ stripNonAlphanumerical (render pt)
     (ppl, pshl) = ppSapic tc pl
 ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, pureState = False} pl pr) =
@@ -854,7 +1006,7 @@ ppSapic tc (ProcessComb (Lookup t c) ProcessAnnotation {stateChannel = Nothing, 
     pc = ppTypeVar tc c
     pc2 = ppUnTypeVar c
     freevars = S.fromList $ map (\(SapicLVar lvar _) -> lvar) $ freesSapicTerm t
-    (pt, sh) = auxppSapicTerm tc freevars True t
+    (pt, sh) = renderSapicTermWithPattern tc freevars True t
     (pt', _) = ppSapicTerm tc t
     ptvar = "stateChannel" ++ stripNonAlphanumerical (render pt)
     (ppl, pshl) = ppSapic tc pl
@@ -894,7 +1046,7 @@ addAttackerReportProc tc thy p =
         theoryPredicates thy
     (_, (formula, _)) = case reportPreds of
       Nothing -> translationFail "Translation Error, the Report predicate must be defined."
-      Just (Predicate _ form) -> Precise.evalFresh (ppLFormula emptyTypeEnv ppNAtom form) (avoidPrecise form)
+      Just (Predicate _ form) -> Precise.evalFresh (ppLFormula emptyTypeEnv (ppNAtom S.empty) form) (avoidPrecise form)
 
 ------------------------------------------------------------------------------
 -- Main printer for processes
@@ -902,7 +1054,7 @@ addAttackerReportProc tc thy p =
 
 loadProc :: TranslationContext -> OpenTheory -> (Doc, S.Set ProVerifHeader, Bool, Bool)
 loadProc tc thy = case theoryProcesses thy of
-  [] -> (emptyDoc, S.empty, False, False)
+  [] -> (text "", S.empty, False, False)
   [pr] ->
     let (d, headers) = ppSapic tc2 p
         finald =
@@ -920,7 +1072,7 @@ loadMacroProc :: TranslationContext -> OpenTheory -> ([Doc], S.Set ProVerifHeade
 loadMacroProc tc thy = loadMacroProcs tc thy (theoryProcessDefs thy)
 
 loadMacroProcs :: TranslationContext -> OpenTheory -> [ProcessDef] -> ([Doc], S.Set ProVerifHeader)
-loadMacroProcs _ _ [] = ([], S.empty)
+loadMacroProcs _ _ [] = ([text ""], S.empty)
 loadMacroProcs tc thy (p : q) =
   let (docs, heads) = loadMacroProcs tc3 thy q
    in case p._pVars of
@@ -1031,40 +1183,50 @@ typeVarsEvent TypingEnvironment {events = ev} tag ts =
 
 ppProtoAtom ::
   (HighlightDocument d, Ord k, Show k, Show c) =>
+  S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
   Bool ->
   (s (Term (Lit c k)) -> d) ->
   (Term (Lit c k) -> d) ->
   ProtoAtom s (Term (Lit c k)) ->
   (d, M.Map k SapicType)
-ppProtoAtom te _ _ ppT (Action v f@(Fact tag _ ts))
+ppProtoAtom ruleIdEvents te _ _ ppT (Action v f@(Fact tag _ ts))
   | factTagArity tag /= length ts = translationFail $ "MALFORMED function" ++ show tag
   | (tag == KUFact) || isKLogFact f -- treat KU() and K() facts the same
     =
       (ppFactL "attacker" ts <> opAction <> ppT v, M.empty)
   | otherwise =
-      ( text "event(" <> ppFactL ('e' : factTagName tag) ts <> text ")" <> opAction <> ppT v,
+      ( text "event("
+          <> eventArgs ('e' : factTagName tag) ts
+          <> text ")"
+          <> opAction
+          <> ppT v,
         typeVarsEvent te tag ts
       )
   where
+    factName = factTagName tag
+    useRuleId = factName `S.member` ruleIdEvents
     ppFactL n t = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ map ppT t
-ppProtoAtom _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
-ppProtoAtom _ False _ ppT (EqE l r) =
+    eventArgs n t
+      | useRuleId = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ (text "rid" : map ppT t)
+      | otherwise = ppFactL n t
+ppProtoAtom _ _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
+ppProtoAtom _ _ False _ ppT (EqE l r) =
   (sep [ppT l <-> opEqual, ppT r], M.empty)
-ppProtoAtom _ True _ ppT (EqE l r) =
+ppProtoAtom _ _ True _ ppT (EqE l r) =
   (sep [ppT l <-> text "<>", ppT r], M.empty)
 -- sep [ppNTerm l <-> text "≈", ppNTerm r]
-ppProtoAtom _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
-ppProtoAtom _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
-ppProtoAtom _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
+ppProtoAtom _ _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
+ppProtoAtom _ _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
+ppProtoAtom _ _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
 
-ppAtom :: TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
-ppAtom te b = ppProtoAtom te b (const emptyDoc)
+ppAtom :: S.Set String -> TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppAtom ruleIdEvents te b = ppProtoAtom ruleIdEvents te b (const emptyDoc)
 
 -- only used for ProVerif queries display
 -- the Bool is set to False when we must negate the atom
-ppNAtom :: TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
-ppNAtom te b = ppAtom te b (fst . ppLNTerm emptyTC)
+ppNAtom :: S.Set String -> TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppNAtom ruleIdEvents te b = ppAtom ruleIdEvents te b (fst . ppLNTerm emptyTC)
 
 mapLits :: (Ord a, Ord b) => (a -> b) -> Term a -> Term b
 mapLits f t = case viewTerm t of
@@ -1085,54 +1247,103 @@ ppLFormula ::
   ProtoFormula syn (String, LSort) c LVar ->
   m ([LVar], (b, M.Map LVar SapicType))
 ppLFormula te ppAt =
-  pp
+  printFormula
   where
-    pp (Ato a) = pure ([], ppAt te False (toLAt a))
-    pp (TF True) = pure ([], (operator_ "true", M.empty)) -- "T"
-    pp (TF False) = pure ([], (operator_ "false", M.empty)) -- "F"
-    pp (Not (Ato a@(EqE _ _))) = pure ([], ppAt te True (toLAt a))
-    pp (Not p) = do
-      (vs, (p', envp)) <- pp p
-      pure (vs, (operator_ "not" <> opParens p', envp)) -- text "¬" <> parens (pp a)
-      -- pure $ operator_ "not" <> opParens p' -- text "¬" <> parens (pp a)
-    pp (Conn op p q) = do
-      (vsp, (p', envp)) <- pp p
-      (vsq, (q', envq)) <- pp q
+    printFormula (Ato a) = pure ([], ppAt te False (toLAt a))
+    printFormula (TF True) = pure ([], (operator_ "true", M.empty)) -- "T"
+    printFormula (TF False) = pure ([], (operator_ "false", M.empty)) -- "F"
+    printFormula (Not (Ato a@(EqE _ _))) = pure ([], ppAt te True (toLAt a))
+    printFormula (Not p) = do
+      (vs, (p', envp)) <- printFormula p
+      pure (vs, (operator_ "not" <> opParens p', envp)) -- text "¬" <> parens (printFormula a)
+      -- pure $ operator_ "not" <> opParens p' -- text "¬" <> parens (printFormula a)
+    printFormula (Conn op p q) = do
+      (vsp, (p', envp)) <- printFormula p
+      (vsq, (q', envq)) <- printFormula q
       pure (vsp ++ vsq, (sep [opParens p' <-> ppOp op, opParens q'], mergeEnv envp envq))
       where
         ppOp And = text "&&"
         ppOp Or = text "||"
         ppOp Imp = text "==>"
         ppOp Iff = opIff
-    pp fm@(Qua {}) =
+    printFormula fm@(Qua {}) =
       scopeFreshness $ do
         (vs, _, fm') <- openFormulaPrefix fm
-        (vsp, d') <- pp fm'
+        (vsp, d') <- printFormula fm'
         pure (vs ++ vsp, d')
 
 -- | Check if a formula is quantifier-free.
-isPropFormula :: LNFormula -> Bool
-isPropFormula (Qua {}) = False
-isPropFormula (Ato _) = True
-isPropFormula (TF _) = True
-isPropFormula (Not (Ato (EqE _ _))) = True
-isPropFormula (Not _) = True
-isPropFormula (Conn _ p q) = isPropFormula p && isPropFormula q
+isQuantifierFree :: LNFormula -> Bool
+isQuantifierFree (Qua {}) = False
+isQuantifierFree (Ato _) = True
+isQuantifierFree (TF _) = True
+isQuantifierFree (Not (Ato (EqE _ _))) = True
+isQuantifierFree (Not _) = True
+isQuantifierFree (Conn _ p q) = isQuantifierFree p && isQuantifierFree q
+
+-- | Count the number of quantifier alternations in a formula.
+-- An alternation occurs when we switch from All to Ex or vice versa.
+-- For example:
+--   All x. P(x)                     -> 0 alternations (All only)
+--   All x. Ex y. P(x,y)             -> 1 alternation  (All -> Ex)
+--   All x. Ex y. not(Ex z. Q)       -> 2 alternations (All -> Ex -> All, since not(Ex) = All)
+--   All x. (P(x) => Ex y. Q(y))     -> 1 alternation  (All -> Ex)
+-- The supported fragment has at most 1 alternation: All* (premise => Ex* conclusion)
+countQuantifierAlternations :: LNFormula -> Int
+countQuantifierAlternations = go Nothing
+  where
+    -- go tracks the current quantifier context (Nothing = none yet, Just All/Ex = last seen)
+    go :: Maybe Quantifier -> LNFormula -> Int
+    go _ (Ato _) = 0
+    go _ (TF _) = 0
+    go ctx (Not (Qua Ex v body)) = go ctx (Qua All v body)  -- not(Ex) = All
+    go ctx (Not (Qua All v body)) = go ctx (Qua Ex v body)  -- not(All) = Ex
+    go ctx (Not body) = go ctx body
+    go ctx (Qua q _ body) =
+      let alternation = case ctx of
+            Nothing -> 0  -- First quantifier, no alternation
+            Just q' -> if q == q' then 0 else 1  -- Same quantifier = 0, different = 1
+          bodyAlternations = go (Just q) body
+      in alternation + bodyAlternations
+    go ctx (Conn _ p q) = max (go ctx p) (go ctx q)
 
 ppQueryFormula ::
   (MonadFresh m, Functor s) =>
+  S.Set String ->
   TypingEnvironment ->
   ProtoFormula s (String, LSort) Name LVar ->
   [LVar] ->
+  String ->
   m Doc
-ppQueryFormula te fm extravs = do
-  (vs, (p, typeVars)) <- ppLFormula te ppNAtom fm
-  pure $
-    sep
-      [ text "query " <> fsep (punctuate comma (map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs))) <> text ";",
-        nest 1 p,
-        text "."
-      ]
+ppQueryFormula ruleIdEvents te fm extravs attrs = do
+  (vs, (p, typeVars)) <- ppLFormula te (ppNAtom ruleIdEvents) fm
+  let includeRuleId = formulaUsesRuleIdEvents ruleIdEvents fm
+  let ruleIdVar = text "rid:bitstring"
+  let allVarsList = S.toList . S.fromList $ extravs ++ vs
+  -- Check for name collisions between term and timepoint variables
+  -- In Tamarin, t and #t are different, but in ProVerif they'd both be 't'
+  let termVarNames = S.fromList [n | LVar n s _ <- allVarsList, s /= LSortNode]
+  let timepointVarsWithCollision = [n | LVar n LSortNode _ <- allVarsList, S.member n termVarNames]
+  -- If there's a collision, we can't translate this query
+  if not (null timepointVarsWithCollision)
+    then pure $ text "(* Variable name collision: '" <> text (head timepointVarsWithCollision) <>
+                text "' is used both as term and timepoint. Please rename one in the Tamarin source. *)"
+    else do
+      let allVars = map (ppTimeTypeVar typeVars) allVarsList
+      let quantifiedVars =
+            if includeRuleId
+              then ruleIdVar : allVars
+              else allVars
+      let queryLine =
+            case quantifiedVars of
+              [] -> text "query;"
+              _ -> text "query " <> fsep (punctuate comma quantifiedVars) <> text ";"
+      let attrsDoc = if null attrs then text "" else text attrs
+      pure $
+        sep
+          [ queryLine,
+            nest 1 p <> attrsDoc <> text "."
+          ]
 
 ppTimeTypeVar :: M.Map LVar SapicType -> LVar -> Doc
 ppTimeTypeVar _ lvar@(LVar _ LSortNode _) = ppLVar lvar <> text ":time"
@@ -1141,204 +1352,1130 @@ ppTimeTypeVar te lvar =
     Nothing -> ppLVar lvar <> text ":bitstring"
     Just t -> ppLVar lvar <> text ":" <> text (ppType t)
 
-ppQueryFormulaEx :: TypingEnvironment -> LNFormula -> [LVar] -> Doc
-ppQueryFormulaEx te fm vs =
-  Precise.evalFresh (ppQueryFormula te fm vs) (avoidPrecise fm)
+ppQueryFormulaEx :: S.Set String -> TypingEnvironment -> LNFormula -> [LVar] -> String -> Doc
+ppQueryFormulaEx ruleIdEvents te fm vs attrs =
+  Precise.evalFresh (ppQueryFormula ruleIdEvents te fm vs attrs) (avoidPrecise fm)
 
 ppRestrictFormula ::
+  S.Set String ->
   TypingEnvironment ->
   ProtoFormula Unit2 (String, LSort) Name LVar ->
-  Precise.FreshT Data.Functor.Identity.Identity Doc
-ppRestrictFormula te frm =
+  String ->
+  Precise.FreshT Data.Functor.Identity.Identity (Doc, Bool)
+ppRestrictFormula ruleIdEvents te frm attrs =
   if any (\(Fact tag _ _) -> factTagName tag == "KU") $ formulaFacts frm
     then -- todo: Add all translation warnings to the wellformedness report.
-      pure $ translationWarning "formula with KU facts is not supported\n" (ppFail frm)
-    else pp $ frm -- don't allow KU facts, nothing corresponding in PV
+      pure (ppFail (Just "lemma contains KU fact") frm, False)
+    else renderFormula frm
   where
-    pp (Not fm@(Qua Ex _ _)) = do
+    -- attrs contains lemma attributes like "[induction]" but these don't affect
+    -- ProVerif translation - they are Tamarin-specific proving hints
+    _attrs = attrs  -- suppress unused warning
+
+    renderFormula (Not fm@(Qua Ex _ _)) = do
       (vs, _, fm') <- openFormulaPrefix fm
       pure
-        ( if isPropFormula fm'
-            then ppOk fm' vs
-            else ppFail fm
+        ( if isQuantifierFree fm'
+            then (ppOk fm' vs, True)
+            else (ppFail (Just "lemma is not quantifier-free") fm, False)
         )
-    pp fm@(Qua Ex _ _) = do
+    -- Handle Not(All...) - translate the inner All formula and mark as having leading negation
+    renderFormula (Not fm@(Qua All _ _)) = do
+      (_, _, fm') <- openFormulaPrefix fm
+      (doc, succeeded) <- handleUniversalFormula fm fm'
+      pure (doc, succeeded)  -- The caller will add the leading negation comment
+    renderFormula fm@(Qua Ex _ _) = do
       (vs, _, fm') <- openFormulaPrefix fm
       pure
-        ( if isPropFormula fm'
-            then ppOk fm' vs
-            else ppFail fm
+        ( if isQuantifierFree fm'
+            then (ppOk fm' vs, True)
+            else (ppFail (Just "lemma is not quantifier-free") fm, False)
         )
-    pp fm@(Qua All _ _) = do
+    renderFormula fm@(Qua All _ _) = do
       (_, _, fm') <- openFormulaPrefix fm
-      pp2 fm fm'
-    pp fm = pure $ ppFail fm
-    ppOk = ppQueryFormulaEx te
-    ppFail fm = text "(*" <> prettyLNFormula fm <> text "*)"
+      handleUniversalFormula fm fm'
+    renderFormula fm = pure (ppFail (Just "Lemma outside of logic fragment") fm, False)
+    ppOk f l = ppQueryFormulaEx ruleIdEvents te f l attrs
+    ppFail Nothing fm = text "(* Lemma outside of logic fragment *)" $$ text "(*" <> prettyLNFormula fm <> text "*)"
+    ppFail (Just reason) fm = text "(*" <> text reason <> text "*)" $$ text "(*" <> prettyLNFormula fm <> text "*)"
 
-    pp2 fm_original fm | isPropFormula fm = pure $ ppOk fm_original []
-    pp2 fm_original (Conn Imp p fm) | isPropFormula p = do
-      isExDisj <- disjunct_ex fm
-      pure $
-        if isExDisj
-          then ppOk fm_original []
-          else ppFail fm_original
-
-    -- pp2 fm_original (Conn Imp p fm@(Qua Ex _ _)) | isPropFormula p  = do
-    --             (_,_,fm') <- openFormulaPrefix fm
-    --             pure $ (if isPropFormula fm' then
-    --                         ppOk fm_original []
-    --                       else
-    --                         ppFail fm_original)
-    -- pp2 fm_original (Conn Imp p (Conn Or fm@(Qua Ex _ _)  fm2@(Qua Ex _ _))) | isPropFormula p  = do
-    --             (_,_,fm') <- openFormulaPrefix fm
-    --             (_,_,fm2') <- openFormulaPrefix fm2
-    --             pure $ (if isPropFormula fm' && isPropFormula fm2' then
-    --                         ppOk fm_original []
-    --                       else
-    --                         ppFail fm_original)
-
-    pp2 fm_original _ = pure $ ppFail fm_original
-
-    disjunct_ex fm@(Qua Ex _ _) = do
+    handleUniversalFormula fm_original fm | isQuantifierFree fm = pure (ppOk fm_original [], True)
+    handleUniversalFormula fm_original (Conn Imp p fm) | isQuantifierFree p = do
+      isExDisj <- isExistentialDisjunction fm
+      if isExDisj
+        then pure (ppOk fm_original [], True)
+        else do
+          -- Try handling nested implications/universals
+          -- Pattern: P => (All x. Q => R) is equivalent to P & Q => R (with x bound)
+          isNestedOk <- isNestedImplicationOk fm
+          pure $
+            if isNestedOk
+              then (ppOk fm_original [], True)
+              else (ppFail (Just "conclusion is not an existential disjunction") fm_original, False)
+    -- Handle Ex... (P => Q) case - existentials wrapping an implication
+    -- This arises from transforming not(Ex... P & not(Ex... Q))
+    handleUniversalFormula fm_original fm@(Qua Ex _ _) = do
       (_, _, fm') <- openFormulaPrefix fm
-      pure $ isPropFormula fm'
-    disjunct_ex (Conn Or fm@(Qua Ex _ _) fm2) = do
-      (_, _, fm') <- openFormulaPrefix fm
-      b <- disjunct_ex fm2
-      pure $ b && isPropFormula fm'
-    disjunct_ex (Conn Or fm2 fm@(Qua Ex _ _)) = do
-      (_, _, fm') <- openFormulaPrefix fm
-      b <- disjunct_ex fm2
-      pure $ b && isPropFormula fm'
-    disjunct_ex _ = pure False
+      handleUniversalFormula fm_original fm'
 
--- | ppLemma translates ONLY lemmas and only in the "classical way", i.e., with timepoints and so on
--- | The resulting translations are NOT suitable as ProVerif lemmas, axioms and restrictions (only as queries)
-ppLemma :: TypingEnvironment -> Lemma ProofSkeleton -> Doc
-ppLemma te p =
-  trace
-    ( "PROVERIF LEMMA: "
-        ++ render
-          ( vcat
-              ( map
-                  ( \fm -> case fm of
-                      Not fm' ->
-                        if allImplsEx fm' && p._lTraceQuantifier == ExistsTrace
-                          then printFmNameFormula fm' $$ text "(* Existential lemma " <> text p._lName <> text " has a leading negation, interpret ProVerif's answers accordingly!*)\n"
-                          else printFmNameFormula fm
-                      _ -> printFmNameFormula fm
-                  )
-                  fms
-              )
-              $$ if isEmpty comments then comments else text "(* To reconstruct lemma " <> text p._lName <> text ":" $$ comments $$ text "*)"
-          )
-        ++ " END"
-    )
-    $ vcat
-      ( map
-          ( \fm -> case fm of
-              Not fm' ->
-                if allImplsEx fm' && p._lTraceQuantifier == ExistsTrace
-                  then printFmNameFormula fm' $$ text "(* Existential lemma " <> text p._lName <> text " has a leading negation, interpret ProVerif's answers accordingly!*)\n"
-                  else printFmNameFormula fm
-              _ -> printFmNameFormula fm
-          )
-          fms
-      )
-      $$ if isEmpty comments then comments else text "(* To reconstruct lemma " <> text p._lName <> text ":" $$ comments $$ text "*)"
+    handleUniversalFormula fm_original _fm_inner =
+      pure (ppFail (Just "Lemma outside of logic fragment") fm_original, False)
+
+-- ===========================================================================
+-- SECTION 7: Lemma Translation
+-- ===========================================================================
+
+-- | Translate a lemma formula for ProVerif output.
+-- This function translates ONLY lemmas in the "classical way" with timepoints.
+-- The resulting translations are suitable only as ProVerif queries (not lemmas/axioms/restrictions).
+--
+-- Key steps:
+-- 1. Simplify and apply rewriting transformations
+-- 2. Split shared timepoints if needed
+-- 3. Split top-level connectives (AND for all-traces, OR for exists-trace)
+-- 4. Apply final transformations and print each subformula
+ppLemma :: S.Set String -> TypingEnvironment -> Lemma ProofSkeleton -> Doc
+ppLemma ruleIdEvents te p =
+  let subformulas = vcat (intersperse (text "") (zipWith (curry renderSubformula) fms hadNegationFlags))
+  in if isEmpty comments
+     then subformulas $$ text ""
+     else subformulas $$ text "" $$ reconstructionComment
   where
-    fms = map transformFm fms'
+    simplifiedFormula = simplifyFormula p._lFormula
+    -- Apply rewriting transformations FIRST before time splitting
+    -- This ensures De Bruijn indices remain correct when quantifiers are moved
+    rewrittenFormula = applyRewriteTransformations simplifiedFormula
+    needsRuleId = formulaHasSharedTimepoints rewrittenFormula
+    hadTimepointSplit = needsRuleId
+    formulaForProcessing =
+      if needsRuleId
+        then makeTimeVarsDistinct rewrittenFormula
+        else rewrittenFormula
+    fmsWithFlags = map transformFm fms'
+    fms = map fst fmsWithFlags
+    hadNegationFlags = map snd fmsWithFlags
 
-    printFmNameFormula f' = text "(*" <> text p._lName <> text "*)" $$ Precise.evalFresh (ppRestrictFormula te f') (avoidPrecise f') <> text "\n"
+    -- Apply all rewriting transformations that change formula structure
+    -- This must happen BEFORE makeTimeVarsDistinct to avoid De Bruijn index corruption
+    -- Uses FormulaShape classification to determine which transformation to apply
+    -- Finally applies pnf to flatten nested quantifiers (e.g., Ex x. A & Ex y. B -> Ex x y. A & B)
+    --
+    -- Order of transformations:
+    -- 1. Eliminate double negations
+    -- 2. Convert negated existentials with time constraints to implications
+    --    (not(Ex vars. A & not(#i=#j)) → All vars. A ==> #i=#j)
+    -- 3. Move negated actions from premise to conclusion (enables pattern matching)
+    -- 4. Classify formula shape
+    -- 5. Apply shape-specific transformation
+    -- 6. Flatten nested quantifiers
+    applyRewriteTransformations fm =
+      let fm1 = eliminateDoubleNegations fm
+          -- Move negated actions/existentials from premise to conclusion FIRST
+          -- This transforms: (not(Ex r. A@r) & B@i) ==> C into B@i ==> (C | (Ex r. A@r))
+          -- This MUST run before convertNegExWithTimeConstraint so that not(Ex...) in premise
+          -- gets moved to conclusion rather than being transformed in place
+          fm1a = moveNegatedActionsToConclusion fm1
+          -- Convert negated existentials with trailing time constraints to implications
+          -- This transforms: not(Ex vars. A & not(#i=#j)) into All vars. A ==> #i=#j
+          -- avoiding the need for a "leading negation" interpretation
+          -- Now this only handles not(Ex...) at top level or in conclusion, not in premise
+          fm1b = convertNegExWithTimeConstraint fm1a
+          fm2 = fm1b
+          shape = classifyFormulaShape p._lTraceQuantifier fm2
+          transformed = applyRewriteForShape shape fm2
+          -- Note: transformWithPullNots was removed as it can undo implication conversion
+          -- Apply pnf to flatten nested quantifiers in the conclusion
+          -- This handles cases like: All x. P => Ex y. A & Ex z. B -> All x. P => Ex y z. A & B
+          -- And: Ex x. A & Ex y. B -> Ex x y. A & B
+      in flattenNestedQuantifiers transformed
+
+    -- Flatten nested quantifiers using pnf, but preserve the structure for implications
+    -- For implications, only apply pnf to the conclusion if it has nested existentials
+    -- that need flattening (e.g., Ex x. A & Ex y. B), NOT if it's already a disjunction
+    flattenNestedQuantifiers :: LNFormula -> LNFormula
+    flattenNestedQuantifiers (Qua All x body) =
+      case flattenNestedQuantifiers body of
+        Conn Imp prem concl
+          | needsFlatteningInConclusion concl -> Qua All x (Conn Imp prem (pnf concl))
+          | otherwise -> Qua All x (Conn Imp prem concl)
+        body' -> Qua All x body'
+    flattenNestedQuantifiers (Conn Imp prem concl)
+      | needsFlatteningInConclusion concl = Conn Imp prem (pnf concl)
+      | otherwise = Conn Imp prem concl
+    flattenNestedQuantifiers fm@(Qua Ex _ _) = pnf fm
+    -- Handle Not(Qua Ex ...) - flatten the inner existential and wrap with Not
+    flattenNestedQuantifiers (Not fm@(Qua Ex _ _)) = Not (pnf fm)
+    -- Handle Conn And - recursively flatten each part (needed after splitting)
+    flattenNestedQuantifiers (Conn And left right) =
+      Conn And (flattenNestedQuantifiers left) (flattenNestedQuantifiers right)
+    flattenNestedQuantifiers fm = fm
+
+    -- Check if conclusion needs flattening (has nested Ex inside conjunction)
+    -- We DON'T want to flatten disjunctions of existentials - those are already in the right form
+    needsFlatteningInConclusion :: LNFormula -> Bool
+    needsFlatteningInConclusion (Qua Ex _ body) = needsFlatteningInConclusion body
+    needsFlatteningInConclusion (Conn And left right) = hasNestedEx left || hasNestedEx right
+    needsFlatteningInConclusion (Conn Or _ _) = False  -- Disjunctions don't need flattening
+    needsFlatteningInConclusion _ = False
+
+    -- Check if formula has a nested existential
+    hasNestedEx :: LNFormula -> Bool
+    hasNestedEx (Qua Ex _ _) = True
+    hasNestedEx (Conn And left right) = hasNestedEx left || hasNestedEx right
+    hasNestedEx _ = False
+
+    formula f' = Precise.evalFresh (ppRestrictFormula ruleIdEvents te f' useInduction) (avoidPrecise f')
+
+    -- Lemma name comment (always shown)
+    lemmaNameComment = text "(*" <> text p._lName <> text "*)"
+
+    -- For soem reason, "use_induction" attribute is named InvariantLemma.
+    useInduction
+      | InvariantLemma `elem` p._lAttributes = "[induction]"
+      | otherwise = ""
 
     -- assuming all formulas we are concerned with have quantifiers at their top level (after splitTopLvlConns)
-    transformFm fm = transformWithPullNots $ case () of
-      _
-        | allActImplsNotExAct fm -> pnf fm
-        | notExistsOfExists fm -> replNotAOrBWithAImpB $ either id id $ pullnots $ nnf fm
-        -- \| restructToAllImpEx fm /= fm -> restructToAllImpEx fm
-        | existsConjOfNotExists fm && p._lTraceQuantifier == ExistsTrace -> replAAndNotBWithAImpB $ either id id $ pullnots $ rearrangeAnd fm
-        -- \| existsConjOfNotExists fm -> replAAndNotBWithAImpB $ either id id $ pullnots $ changeAssocLeftToRight fm
-        | otherwise -> fm
+    -- Returns (transformed formula, hadLeadingNegation flag)
+    -- Note: Main rewriting has already been done by applyRewriteTransformations
+    transformFm fm =
+      let -- Detect if formula has leading negation
+          -- Check for simple Not (Ex ...) pattern as well as complex patterns
+          hasLeadingNotEx = case fm of
+            Not (Qua Ex _ _) -> True
+            _ -> False
+          -- Check for All x. ... ==> False pattern (equivalent to not(Ex x. ...))
+          -- This appears as All x. All y. ... Not(...) after normalization
+          hasAllImpliesFalse = case fm of
+            Qua All _ body -> checkAllImpliesNot body
+            _ -> False
+            where
+              checkAllImpliesNot (Qua All _ body) = checkAllImpliesNot body
+              checkAllImpliesNot (Not _) = True
+              checkAllImpliesNot (Conn Imp _ (TF False)) = True
+              checkAllImpliesNot _ = False
+          notExists = isNegatedExistsWithConjunction fm
+          existsConj = isExistsWithNegatedExistentials fm
+          hadLeadingNegation = hasLeadingNotEx || hasAllImpliesFalse || notExists || (existsConj && p._lTraceQuantifier == ExistsTrace)
+          -- Apply final cleanup (constraint movement, negated action movement, simplification, and expand negated timepoint comparisons)
+          -- moveNegatedActionsToConclusion transforms: (A & not(B)) ==> C into A ==> (C | B)
+          -- After moving negated actions, apply shape-based transformation to handle patterns like A ==> (not(B) | C)
+          movedToConclusion = moveNegatedActionsToConclusion $ moveConstraintsToConclusion fm
+          -- Apply shape-based transformation to move negated disjuncts from conclusion to premise
+          shape = classifyFormulaShape p._lTraceQuantifier movedToConclusion
+          shapeTranformed = applyRewriteForShape shape movedToConclusion
+          finalFormula = simplifyFormula $ expandNegatedTimepointComparisons shapeTranformed
+          hasLeadingNegationAfterTransform = case finalFormula of
+            Not _ -> True
+            _ -> False
+          -- Combine both checks: original detection OR negation introduced by transformation
+          finalHadLeadingNegation = hadLeadingNegation || hasLeadingNegationAfterTransform
+          result = (finalFormula, finalHadLeadingNegation)
+      in finalHadLeadingNegation `seq` result  -- Force evaluation of finalHadLeadingNegation
 
-    {- if existsConjOfNotExists fm
-          then trace (render $ prettyLNFormula $ either id id $ strongPullnots fm) $ either id id $ strongPullnots fm
-          else fm -}
-    -- case allImplsPrenexConc fm of
-    -- fm' -> trace (render $ prettyLNFormula $ pnf $ nnf fm) $ fm'
-    -- fm -> fm
-    -- where
-    -- maybePullAlls = if allAlls maybePrenexConcl then transformWithPullnots $ pnf maybePrenexConcl else maybePrenexConcl
-    -- maybePrenexConcl = if checkAllImpliesEx maybePulledExists == maybePulledExists then maybePulledExists else transformWithPullnots $ checkAllImpliesEx maybePulledExists
-    -- pulledNotsFm = transformWithPullnots fm --convToGuardedStruct fm
-    (fms', comments, _) = trace ("TAMARIN LEMMA: " ++ render (prettyLNFormula p._lFormula) ++ " END") $ splitTopLvlConns p._lTraceQuantifier 1 $ simplifyFormula p._lFormula
+    -- Split top-level connectives for the formula
+    (fms', comments, _) = splitTopLvlConns p._lTraceQuantifier 1 formulaForProcessing
 
+    -- Render a single subformula with appropriate comments
+    renderSubformula :: (LNFormula, Bool) -> Doc
+    renderSubformula (fm, hadNegation) =
+      let timepointComment = if hadTimepointSplit
+            then Just $ text "(* Timepoints in lemma have been split *)"
+            else Nothing
+          -- Get the formula to translate (inner formula for leading negation)
+          -- For Not (Qua Ex ...), strip the Not and emit the inner existential as a reachability query
+          -- ProVerif will check if it's reachable; if "true" (not reachable), the original property holds
+          (fmToTranslate, isExistentialNegation) = case fm of
+            Not fm'@(Qua Ex _ _) -> (fm', True)  -- Strip Not for any Not(Ex...) pattern
+            Not fm' | isAllImpliesExists fm' && p._lTraceQuantifier == ExistsTrace -> (fm', True)
+            _ -> (fm, False)
+          -- Check for existentially quantified K facts (not supported in ProVerif)
+          hasExistentialK = hasExistentiallyQuantifiedKFact fmToTranslate
+          -- Check for too many quantifier alternations AFTER all rewrites
+          alternations = countQuantifierAlternations fmToTranslate
+          -- Check if the formula to translate contains negated actions that will produce not(event(...))
+          -- This happens for exists-trace lemmas like "All x. A(x) ==> F" which become "Not (All x. A(x))"
+          -- and can't be transformed into a valid ProVerif query (ProVerif can't find a trace without an action)
+          hasNegatedActionInQuery = hasNegatedActionInFormula fmToTranslate
+          (queryDoc, succeeded)
+            | hasExistentialK =
+                (text "(* Lemma contains existentially quantified K fact which is not supported *)"
+                 $$ text "(*" <> prettyLNFormula fmToTranslate <> text "*)", False)
+            | alternations > 1 =
+                (text "(* Lemma has " <> text (show alternations) <> text " quantifier alternations (e.g., All-Ex-All). ProVerif only supports at most 1 alternation. *)"
+                 $$ text "(*" <> prettyLNFormula fmToTranslate <> text "*)", False)
+            | hasNegatedActionInQuery =
+                (text "(* Lemma has negated event (from exists-trace lemma with negation). ProVerif cannot find a trace without an action. *)"
+                 $$ text "(*" <> prettyLNFormula fm <> text "*)", False)
+            | otherwise = formula fmToTranslate
+          -- Determine negation warning (no lemma name, that's separate)
+          negationWarning
+            | isExistentialNegation && succeeded = Just $ text "(* Existential lemma has a leading negation, interpret ProVerif's answers accordingly! *)"
+            | hadNegation && succeeded = Just $ text "(* Lemma has a leading negation, interpret ProVerif's answers accordingly! *)"
+            | otherwise = Nothing
+          -- Build output: lemma name, timepoint comment, negation warning, query
+          parts = [lemmaNameComment]
+                  ++ catMaybes [timepointComment, negationWarning]
+                  ++ [queryDoc]
+      in vcat parts
+
+    -- Reconstruction comment for split lemmas
+    reconstructionComment =
+      if isEmpty comments
+      then text ""
+      else text "(* To reconstruct lemma " <> text p._lName <> text ":"
+           $$ comments
+           $$ text "*)" $$ text ""
+
+-- ===========================================================================
+-- SECTION 7b: Formula Shape Classification
+-- ===========================================================================
+
+-- | Classification of formula shapes for rewriting.
+-- Formulas are classified by their top-level structure to determine
+-- which rewrite strategy to apply. Each shape maps to exactly one
+-- transformation strategy.
+--
+-- Listed in priority order (first match wins during classification).
+data FormulaShape
+    = ShapeAllActionsImpliesNotExists
+      -- ^ ∀x. (A@i ⇒ ¬∃y. B@j)
+      -- Action: Convert to PNF
+
+    | ShapeNotExistsConj
+      -- ^ ¬(∃x. P ∧ Q ∧ ¬R) with exactly one negation
+      -- Action: Pull negations, convert ¬A∨B to A⇒B
+
+    | ShapeExistsConjNotExists
+      -- ^ ∃x. (P ∧ ¬∃y. Q)  [only for existential trace quantifier]
+      -- Action: Rearrange conjuncts, convert A∧¬B to A⇒B
+
+    | ShapeAllImpliesDisjWithNegations
+      -- ^ ∀x. (P ⇒ ¬Q₁ ∨ ¬Q₂ ∨ R)
+      -- Action: Move negated disjuncts to premise
+
+    | ShapeAllImpliesConjWithNegations
+      -- ^ ∀x. (P ⇒ ¬Q₁ ∧ ¬Q₂)
+      -- Action: Distribute implication over conjunction to create
+      -- (∀x. P ⇒ ¬Q₁) ∧ (∀x. P ⇒ ¬Q₂) which gets split by splitTopLvlConns
+
+    | ShapeOther
+      -- ^ No special structure detected
+      -- Action: No structural rewrite needed (identity transform)
+    deriving (Eq, Show)
+
+-- | Classify a formula's shape for rewriting.
+-- This examines the formula structure after double negation elimination
+-- and determines which rewrite strategy should be applied.
+classifyFormulaShape :: TraceQuantifier -> LNFormula -> FormulaShape
+classifyFormulaShape traceQuant fm
+    | isAllActionsImpliesNotExists fm = ShapeAllActionsImpliesNotExists
+    | isNegatedExistsWithConjunction fm = ShapeNotExistsConj
+    | isExistsWithNegatedExistentials fm && traceQuant == ExistsTrace = ShapeExistsConjNotExists
+    | isAllImpliesConjWithNegations fm = ShapeAllImpliesConjWithNegations
+    | isAllImpliesDisjWithNegations fm = ShapeAllImpliesDisjWithNegations
+    | otherwise = ShapeOther
+
+-- | Apply the rewrite strategy for a given formula shape.
+-- Each shape has exactly one associated transformation.
+applyRewriteForShape :: FormulaShape -> LNFormula -> LNFormula
+applyRewriteForShape shape fm = case shape of
+    ShapeAllActionsImpliesNotExists  -> convertPnfToNegatedExists $ pnf fm
+    ShapeNotExistsConj               -> transformNotExistsConjToImplication fm
+    ShapeExistsConjNotExists         -> transformExistsConjToNegatedImplication fm
+    ShapeAllImpliesConjWithNegations -> distributeImplicationOverConjunction fm
+    ShapeAllImpliesDisjWithNegations -> moveNegatedDisjunctsToPremise fm
+    ShapeOther                       -> fm
+  where
+    -- Convert the result of pnf to negated existential form
+    -- pnf(All x. A ==> not(Ex y. B)) = All x y. not(A) | not(B)
+    -- We want: not(Ex x y. A & B) which renders as a conjunction with leading negation
+    -- This is the standard form for reachability queries with negation
+    convertPnfToNegatedExists :: LNFormula -> LNFormula
+    convertPnfToNegatedExists formula =
+        -- Collect all quantifiers and the body
+        let (quants, body) = collectQuantifiers formula
+            -- Extract the negated atoms from the disjunction
+            atoms = collectNegatedAtoms body
+            -- Build the conjunction and wrap with existentials, then negate
+            conjunction = buildConjunction atoms
+            existential = wrapWithQuantifiers Ex quants conjunction
+        in Not existential
+
+    collectQuantifiers :: LNFormula -> ([(String, LSort)], LNFormula)
+    collectQuantifiers (Qua All (name, srt) body) =
+        let (rest, innerBody) = collectQuantifiers body
+        in ((name, srt) : rest, innerBody)
+    collectQuantifiers (Qua Ex (name, srt) body) =
+        let (rest, innerBody) = collectQuantifiers body
+        in ((name, srt) : rest, innerBody)
+    collectQuantifiers f = ([], f)
+
+    collectNegatedAtoms :: LNFormula -> [LNFormula]
+    collectNegatedAtoms (Conn Or p q) = collectNegatedAtoms p ++ collectNegatedAtoms q
+    collectNegatedAtoms (Not p) = [p]
+    collectNegatedAtoms _ = []
+
+-- ===========================================================================
+-- SECTION 8: Formula Transformations
+-- ===========================================================================
+
+-- | Apply pullNegationsToTop transformation with warning on partial rewrite
 transformWithPullNots :: LNFormula -> LNFormula
-transformWithPullNots f = case pullnots f of
+transformWithPullNots f = case pullNegationsToTop f of
   Left f' -> translationWarning ("Formula " ++ render (prettyLNFormula f) ++ " cannot be rewritten s.t. it either has only 1 ¬ or none, the result is:\n" ++ render (prettyLNFormula f') ++ "!\n\n") f'
   Right f' -> f'
 
--- turns out guardedness is potentially not good at all (Tamarin already permits only formulas that adhere to guarded quantification)
--- use the type structure for its associativity :)
-{-convToGuardedStruct f = case parseString [] "" plainFormula $ render $ prettyGuarded $ formulaToGuarded_ f of
-       Left _ -> f
-       Right fm' -> trace (render $ prettyLNFormula fm') fm'-}
+-- ===========================================================================
+-- SECTION 9: Timepoint Variable Handling
+-- ===========================================================================
 
-replAAndNotBWithAImpB :: ProtoFormula syn s c v -> ProtoFormula syn s c v
-replAAndNotBWithAImpB (Qua q x p) = Qua q x $ replAAndNotBWithAImpB p
-replAAndNotBWithAImpB (Conn And p (Not q)) = Not $ Conn Imp p q
-replAAndNotBWithAImpB (Conn c p q) = Conn c (replAAndNotBWithAImpB p) (replAAndNotBWithAImpB q)
-replAAndNotBWithAImpB (Not p) = Not (replAAndNotBWithAImpB p)
-replAAndNotBWithAImpB fm = fm
+-- | Make time variables distinct for each action occurrence in a formula.
+-- This ensures that events with shared timepoints in Tamarin get distinct time variables in ProVerif.
+-- Transforms: ∃ x #i. A(x)@i & B(x)@i  into  ∃ x #i1 #i2. A(x)@i1 & B(x)@i2
+makeTimeVarsDistinct :: LNFormula -> LNFormula
+makeTimeVarsDistinct fm =
+  let sharedTimeVars = findSharedTimeVars fm
+  in if M.null sharedTimeVars
+     then fm
+     else splitTimeVars sharedTimeVars fm
 
-rearrangeAnd :: ProtoFormula syn s c v -> ProtoFormula syn s c v
-rearrangeAnd (Qua q x p) = Qua q x $ rearrangeAnd p
-rearrangeAnd (Conn And (Conn And (Not p) q) f) = Conn And q (Conn And (Not p) f)
-rearrangeAnd (Conn And (Conn And p (Not q)) f) = Conn And p (Conn And (Not q) f)
-rearrangeAnd (Conn c p q) = Conn c (rearrangeAnd p) (rearrangeAnd q)
-rearrangeAnd (Not p) = Not (rearrangeAnd p)
-rearrangeAnd fm = fm
-
-replNotAOrBWithAImpB :: ProtoFormula syn s c v -> ProtoFormula syn s c v
-replNotAOrBWithAImpB (Qua q x p) = Qua q x $ replNotAOrBWithAImpB p
-replNotAOrBWithAImpB (Conn Or (Not p) q) = Conn Imp p q
-replNotAOrBWithAImpB (Conn c p q) = Conn c (replNotAOrBWithAImpB p) (replNotAOrBWithAImpB q)
-replNotAOrBWithAImpB (Not p) = Not (replNotAOrBWithAImpB p)
-replNotAOrBWithAImpB fm = fm
-
-{-reorderQuants :: LNGuarded -> LNGuarded
-reorderQuants (GGuarded qua ss as gf) = GGuarded qua ss (sortNotsFst as) (reorderQuants gf)
+-- | Find time variables (LSortNode quantifiers) that are used more than once
+-- Returns: Map from (variable name, quantifier depth) to occurrence count
+-- Note: quantifier depth is where the quantifier appears, not the Bound index from action perspective
+findSharedTimeVars :: LNFormula -> M.Map (String, Integer) Int
+findSharedTimeVars fm =
+  M.filter (> 1) $ countTimeVarOccurrences [] 0 fm M.empty
   where
-    sortNotsFst xs = uncurry (++) (partition (\f -> case f of
-                                                          (GGuarded All [] [a] gfalse) -> True
-                                                          _ -> False) xs)
-reorderQuants (GDisj disj)            = gconj $ map reorderQuants (getDisj disj)
-reorderQuants (GConj conj)            = gdisj $ map reorderQuants (getConj conj)
-reorderQuants af                      = af
--}
+    -- ctx: list of (name, sort) for each quantifier (newest first)
+    -- depth: current depth (number of enclosing quantifiers)
+    countTimeVarOccurrences :: [(String, LSort)] -> Integer -> LNFormula -> M.Map (String, Integer) Int -> M.Map (String, Integer) Int
+    countTimeVarOccurrences ctx depth (Ato (Action timeVar _fact)) acc =
+      case viewTerm timeVar of
+        Lit (Var (Bound idx)) | idx < depth ->
+          -- Compute quantifier depth: if action is at depth D and uses Bound B,
+          -- the quantifier is at depth (D - B - 1)
+          let quantifierDepth = depth - idx - 1
+          in case drop (fromIntegral idx) ctx of
+               (name, LSortNode) : _ ->
+                 M.insertWith (+) (name, quantifierDepth) 1 acc
+               _ -> acc
+        _ -> acc
+    countTimeVarOccurrences ctx depth (Conn _ p q) acc =
+      let acc' = countTimeVarOccurrences ctx depth p acc
+      in countTimeVarOccurrences ctx depth q acc'
+    countTimeVarOccurrences ctx depth (Not p) acc = countTimeVarOccurrences ctx depth p acc
+    countTimeVarOccurrences ctx depth (Qua _q (name, varSort) p) acc =
+      countTimeVarOccurrences ((name, varSort) : ctx) (depth + 1) p acc
+    countTimeVarOccurrences _ _ _ acc = acc
+
+-- | Split time variables that occur multiple times
+-- For each quantifier matching a shared time var, replace with N copies
+-- and adjust Bound indices in action atoms
+splitTimeVars :: M.Map (String, Integer) Int -> LNFormula -> LNFormula
+splitTimeVars sharedVars fm =
+  fst $ splitAndReindexTimeVars [] 0 0 M.empty fm
+  where
+    -- ctx: list of (name, sort, original_depth) for tracking quantifiers
+    -- depth: current depth (adjusted as we add quantifiers)
+    -- originalDepth: the depth in the original formula (before any splits)
+    -- seenCounts: tracks how many times we've seen each (originalName, originalDepth)
+    splitAndReindexTimeVars :: [(String, LSort, Integer)] -> Integer -> Integer -> M.Map (String, Integer) Int -> LNFormula
+       -> (LNFormula, M.Map (String, Integer) Int)
+
+    splitAndReindexTimeVars ctx depth originalDepth seenCounts (Qua q (name, srt) p) =
+      -- Check if this quantifier is a shared time variable
+      -- Use originalDepth for lookup since sharedVars was computed from original formula
+      let lookupKey = (name, originalDepth)
+      in case M.lookup lookupKey sharedVars of
+        Just count | srt == LSortNode ->
+          -- This is a shared time variable - split it into multiple quantifiers
+          let makeQuantifiers i body
+                | i > count = body
+                | otherwise =
+                    let newName = name ++ show i
+                    in Qua q (newName, srt) (makeQuantifiers (i + 1) body)
+              -- Shift indices in p by (count - 1) because we're adding (count - 1) extra quantifiers
+              p_shifted = shiftFreeIndices (fromIntegral (count - 1)) p
+              -- Process the shifted body with updated context
+              -- Add count entries to context (one for each new quantifier)
+              -- IMPORTANT: Store the original name (before splitting), not the split name
+              newCtxEntries = [(name, srt, originalDepth) | _ <- [1..count]]
+              (p', seenCounts') = splitAndReindexTimeVars (newCtxEntries ++ ctx) (depth + fromIntegral count) (originalDepth + 1) seenCounts p_shifted
+          in (makeQuantifiers 1 p', seenCounts')
+        _ ->
+          -- Normal quantifier - just process recursively
+          let (p', seenCounts') = splitAndReindexTimeVars ((name, srt, originalDepth) : ctx) (depth + 1) (originalDepth + 1) seenCounts p
+          in (Qua q (name, srt) p', seenCounts')
+
+    splitAndReindexTimeVars ctx depth _originalDepth seenCounts (Ato (Action timeVar fact)) =
+      case viewTerm timeVar of
+        Lit (Var (Bound idx)) | idx < depth ->
+          -- Check if this bound variable refers to a split time variable
+          case drop (fromIntegral idx) ctx of
+            (origName, LSortNode, origDepth) : _ ->
+              let lookupKey = (origName, origDepth)
+              in -- Check if the original quantifier was split
+              case M.lookup lookupKey sharedVars of
+                Just count | count > 1 ->
+                  -- This action uses a split time variable
+                  -- Determine which occurrence this is
+                  let key = (origName, origDepth)
+                      currentCount = M.findWithDefault 0 key seenCounts
+                      newSeenCounts = M.insert key (currentCount + 1) seenCounts
+                      -- Adjust the Bound index: subtract currentCount because j1 is furthest, j2 is closest
+                      -- If original was Bound idx, first occurrence uses Bound idx, second uses Bound (idx-1), etc.
+                      newIdx = idx - fromIntegral currentCount
+                      newTimeVar = lit $ Var $ Bound newIdx
+                  in (Ato (Action newTimeVar fact), newSeenCounts)
+                _ -> (Ato (Action timeVar fact), seenCounts)
+            _ -> (Ato (Action timeVar fact), seenCounts)
+        _ -> (Ato (Action timeVar fact), seenCounts)
+
+    splitAndReindexTimeVars ctx depth originalDepth seenCounts (Conn c p q) =
+      let (p', seenCounts') = splitAndReindexTimeVars ctx depth originalDepth seenCounts p
+          (q', seenCounts'') = splitAndReindexTimeVars ctx depth originalDepth seenCounts' q
+      in (Conn c p' q', seenCounts'')
+
+    splitAndReindexTimeVars ctx depth originalDepth seenCounts (Not p) =
+      let (p', seenCounts') = splitAndReindexTimeVars ctx depth originalDepth seenCounts p
+      in (Not p', seenCounts')
+
+    splitAndReindexTimeVars _ _ _ seenCounts f = (f, seenCounts)
+
+-- ===========================================================================
+-- SECTION 10: Constraint Movement
+-- ===========================================================================
+
+-- | Move temporal and equality constraints from premise to conclusion for ProVerif compatibility.
+-- ProVerif requires: "Disequalities and inequalities on time variables should not occur before the premise."
+-- Transforms: (A && C) ==> B  into  A ==> (¬C || B)
+-- For Less: (A && (i < j)) ==> B becomes A ==> ((i >= j) || B)
+-- For disequality: (A && ¬(i = j)) ==> B becomes A ==> ((i = j) || B)
+moveConstraintsToConclusion :: LNFormula -> LNFormula
+moveConstraintsToConclusion fm = case fm of
+  -- Handle quantifiers recursively
+  Qua q x p -> Qua q x (moveConstraintsToConclusion p)
+
+  -- Main transformation: (A && constraint) ==> B becomes A ==> (¬constraint || B)
+  Conn Imp premise conclusion ->
+    let (constraints, premise') = extractConstraints premise
+    in if null constraints
+       then Conn Imp (moveConstraintsToConclusion premise') (moveConstraintsToConclusion conclusion)
+       else Conn Imp (moveConstraintsToConclusion premise') (addConstraintsToConclusion constraints (moveConstraintsToConclusion conclusion))
+
+  -- Recursively process other connectives
+  Conn c p q -> Conn c (moveConstraintsToConclusion p) (moveConstraintsToConclusion q)
+  Not p -> Not (moveConstraintsToConclusion p)
+
+  -- Base cases
+  _ -> fm
+  where
+    -- Check if an atom is a constraint (Less or EqE on time variables)
+    isConstraint :: LNFormula -> Bool
+    isConstraint (Ato (Less _ _)) = True
+    isConstraint (Ato (EqE _ _)) = True
+    isConstraint (Not (Ato (EqE _ _))) = True
+    isConstraint _ = False
+
+    -- Extract constraints from a formula in the premise
+    -- Returns: (list of constraints, formula without constraints)
+    extractConstraints :: LNFormula -> ([LNFormula], LNFormula)
+    extractConstraints (Conn And p q)
+      | isConstraint q =
+          let (cs, p') = extractConstraints p
+          in (q : cs, p')
+      | isConstraint p =
+          let (cs, q') = extractConstraints q
+          in (p : cs, q')
+      | otherwise =
+          let (cs1, p') = extractConstraints p
+              (cs2, q') = extractConstraints q
+          in (cs1 ++ cs2, if null cs1 && null cs2 then Conn And p q else if null cs1 then Conn And p q' else if null cs2 then Conn And p' q else Conn And p' q')
+    extractConstraints (Qua Ex v p) =
+      let (cs, p') = extractConstraints p
+      in (cs, Qua Ex v p')
+    extractConstraints f
+      | isConstraint f = ([f], TF True)
+      | otherwise = ([], f)
+
+    -- Add negated constraints to conclusion with OR
+    -- For (i < j): negate to (i >= j) which is (i > j) || (i = j)
+    -- For ¬(i = j): negate to (i = j)
+    addConstraintsToConclusion :: [LNFormula] -> LNFormula -> LNFormula
+    addConstraintsToConclusion [] conclusion = conclusion
+    addConstraintsToConclusion (c:cs) conclusion =
+      let negatedC = negateConstraint c
+          conclusion' = Conn Or negatedC conclusion
+      in addConstraintsToConclusion cs conclusion'
+
+    -- Negate a constraint for moving to conclusion
+    negateConstraint :: LNFormula -> LNFormula
+    negateConstraint (Ato (Less i j)) =
+      -- ¬(i < j) is (i >= j) which is (i > j) || (i = j)
+      -- In ProVerif this becomes: (i > j) || (i = j)
+      -- We use Not Less to represent >=
+      Conn Or (Ato (Less j i)) (Ato (EqE i j))
+    negateConstraint (Not (Ato (EqE i j))) =
+      -- ¬¬(i = j) is (i = j)
+      Ato (EqE i j)
+    negateConstraint (Ato (EqE i j)) =
+      -- ¬(i = j) is (i ≠ j)
+      Not (Ato (EqE i j))
+    negateConstraint c = Not c
+
+-- | Convert negated existentials with trailing time constraints to implications.
+-- This transforms patterns like:
+--   not(Ex #i #j vars. A@i & B@j & not(#i=#j))
+-- into:
+--   All #i #j vars. (A@i & B@j) ==> #i=#j
+--
+-- Similarly for Less constraints:
+--   not(Ex #i #j #k vars. A & #i < #j & #j < #k)
+-- into:
+--   All #i #j #k vars. A ==> not(#i < #j) | not(#j < #k)
+--   which simplifies to: All #i #j #k vars. A ==> (#j <= #i) | (#k <= #j)
+--
+-- This avoids the "leading negation" pattern and puts time constraints in the
+-- conclusion where ProVerif can handle them properly.
+convertNegExWithTimeConstraint :: LNFormula -> LNFormula
+convertNegExWithTimeConstraint fm = case fm of
+  -- Main pattern: not(Ex vars. body) where body has trailing time constraints
+  Not fm'@(Qua Ex _ _) ->
+    -- First, collect all the nested existential quantifiers and get the inner body
+    let (vars, innerBody) = collectExistentialVars fm'
+        -- Build a context from the collected vars (innermost first after reversing)
+        -- vars are collected outermost first, so reverse for de Bruijn lookup
+        ctx = reverse vars
+     in case extractTrailingTimeConstraints ctx innerBody of
+      Just (conjuncts, constraints) | not (null constraints) ->
+        -- Build: All vars. conjuncts ==> disjunctionOfConstraints
+        let premise = buildConjunction conjuncts
+            -- For not(#i=#j), conclusion is #i=#j (remove negation)
+            -- For #i < #j, conclusion is not(#i < #j) which we'll expand later
+            conclusion = buildConclusionFromConstraints constraints
+            -- Wrap with all the universal quantifiers (converted from existential)
+         in wrapWithQuantifiers All vars (Conn Imp premise conclusion)
+      _ -> Not (convertNegExWithTimeConstraint fm')
+
+  -- Recurse through other structures
+  Qua q x p -> Qua q x (convertNegExWithTimeConstraint p)
+  Conn c p q -> Conn c (convertNegExWithTimeConstraint p) (convertNegExWithTimeConstraint q)
+  Not p -> Not (convertNegExWithTimeConstraint p)
+  _ -> fm
+  where
+    -- Collect all existential quantifier variables from nested Ex structure
+    collectExistentialVars (Qua Ex x body) =
+      let (vars, innerBody) = collectExistentialVars body
+       in (x : vars, innerBody)
+    collectExistentialVars body = ([], body)
+
+    -- Extract trailing time constraints from a conjunction
+    -- Returns (other conjuncts, time constraints) if time constraints are found
+    -- ctx is the binder context (innermost first) for looking up bound variable sorts
+    extractTrailingTimeConstraints :: [(String, LSort)] -> LNFormula -> Maybe ([LNFormula], [LNFormula])
+    extractTrailingTimeConstraints ctx f =
+      let conjuncts = flattenConjunction f
+          (timeCs, others) = partition (isNegatedTimeConstraintOrLess ctx) conjuncts
+       in if null timeCs then Nothing else Just (others, timeCs)
+
+    -- Check if formula is a negated equality on time variables: not(#i = #j)
+    -- Or a Less constraint: #i < #j
+    -- IMPORTANT: Only match actual time variable comparisons, not term disequalities like not(b=ba)
+    isNegatedTimeConstraintOrLess :: [(String, LSort)] -> LNFormula -> Bool
+    isNegatedTimeConstraintOrLess ctx (Not (Ato (EqE t1 t2))) =
+      -- Only match if both terms are time variables (LSortNode)
+      isTimeVar ctx t1 && isTimeVar ctx t2
+    isNegatedTimeConstraintOrLess _ (Ato (Less _ _)) = True  -- Less is always on time vars
+    isNegatedTimeConstraintOrLess _ _ = False
+
+    -- Check if a term is a time variable
+    -- Free variables: check the sort is LSortNode
+    -- Bound variables: look up the binder context to check the sort
+    isTimeVar ctx t = case viewTerm t of
+      Lit (Var (Free v)) -> lvarSort v == LSortNode
+      Lit (Var (Bound idx)) ->
+        -- Look up the sort in the context
+        let i = fromIntegral idx
+         in i < length ctx && snd (ctx !! i) == LSortNode
+      _ -> False  -- Compound terms are not time variables
+
+    -- Flatten a conjunction into a list
+    flattenConjunction :: LNFormula -> [LNFormula]
+    flattenConjunction (Conn And p q) = flattenConjunction p ++ flattenConjunction q
+    flattenConjunction (Qua Ex x body) = [Qua Ex x body]  -- Don't recurse into existentials
+    flattenConjunction f = [f]
+
+    -- Build conclusion from extracted constraints
+    -- For not(#i=#j), the conclusion is #i=#j (negation removed)
+    -- For #i < #j, the conclusion is (#j < #i) | (#i = #j) (i.e., #i >= #j)
+    buildConclusionFromConstraints :: [LNFormula] -> LNFormula
+    buildConclusionFromConstraints [] = TF True
+    buildConclusionFromConstraints [c] = negateTimeConstraint c
+    buildConclusionFromConstraints (c:cs) =
+      Conn Or (negateTimeConstraint c) (buildConclusionFromConstraints cs)
+
+    -- Negate a time constraint for moving to conclusion
+    negateTimeConstraint :: LNFormula -> LNFormula
+    negateTimeConstraint (Not (Ato (EqE i j))) = Ato (EqE i j)  -- not(not(#i=#j)) = #i=#j
+    negateTimeConstraint (Ato (Less i j)) =
+      -- not(#i < #j) = #i >= #j = (#j < #i) | (#i = #j)
+      Conn Or (Ato (Less j i)) (Ato (EqE i j))
+    negateTimeConstraint f = Not f  -- fallback
+
+-- | Move negated actions from premise to conclusion.
+-- ProVerif doesn't allow negated events in queries at all.
+-- Transforms: (A & not(B@t)) ==> C  into  A ==> (C | B@t)
+-- This is valid because: A & not(B) ==> C  ≡  A ==> C | B
+moveNegatedActionsToConclusion :: LNFormula -> LNFormula
+moveNegatedActionsToConclusion fm = case fm of
+  -- Handle quantifiers recursively
+  Qua q x p -> Qua q x (moveNegatedActionsToConclusion p)
+
+  -- Main transformation: (A && not(action)) ==> B becomes A ==> (B || action)
+  Conn Imp premise conclusion ->
+    let (negatedActions, premise') = extractNegatedActions premise
+    in if null negatedActions
+       then Conn Imp (moveNegatedActionsToConclusion premise') (moveNegatedActionsToConclusion conclusion)
+       else Conn Imp (moveNegatedActionsToConclusion premise') (addActionsToConclusion negatedActions (moveNegatedActionsToConclusion conclusion))
+
+  -- Recursively process other connectives
+  Conn c p q -> Conn c (moveNegatedActionsToConclusion p) (moveNegatedActionsToConclusion q)
+  Not p -> Not (moveNegatedActionsToConclusion p)
+
+  -- Base cases
+  _ -> fm
+  where
+    -- Check if a formula is a negated action, negated existential, or disjunction of negations
+    -- Patterns:
+    --   Not (Ato (Action ...))           -- negated bare action (usually invalid in Tamarin)
+    --   Not (Qua Ex _ body)              -- negated existential, where body contains action
+    --   Conn Or (Not a) (Not b)          -- disjunction of negations = not(a & b) by De Morgan
+    isNegatedAction :: LNFormula -> Bool
+    isNegatedAction (Not (Ato (Action _ _))) = True
+    isNegatedAction (Not (Qua Ex _ _)) = True  -- negated existential
+    isNegatedAction (Conn Or (Not _) (Not _)) = True  -- disjunction of negations
+    isNegatedAction _ = False
+
+    -- Extract the inner formula from a negated action pattern
+    -- For Not (Ato action) -> Ato action
+    -- For Not (Ex x. body) -> Ex x. body  (preserving the existential)
+    -- For Conn Or (Not a) (Not b) -> Conn And a b  (De Morgan)
+    extractInnerFormula :: LNFormula -> LNFormula
+    extractInnerFormula (Not inner) = inner
+    extractInnerFormula (Conn Or (Not a) (Not b)) = Conn And a b  -- De Morgan: not(a) | not(b) = not(a & b)
+    extractInnerFormula f = f
+
+    -- Extract negated actions from a formula in the premise
+    -- Returns: (list of unnegated formulas to move to conclusion, formula without negated actions)
+    extractNegatedActions :: LNFormula -> ([LNFormula], LNFormula)
+    extractNegatedActions (Conn And p q) =
+      -- Extract from both children
+      let (actsP, p') = extractNegatedActions p
+          (actsQ, q') = extractNegatedActions q
+          allActs = actsP ++ actsQ
+      in if null allActs
+         then ([], Conn And p q)
+         else
+           -- At least one negated action found
+           -- Build remaining formula from the non-negated parts
+           case (isNegatedAction p, isNegatedAction q, actsP, actsQ) of
+             -- Both p and q are directly negated actions
+             (True, True, _, _) ->
+               (allActs, TF True)  -- Nothing left in premise except true
+             -- Only p is a direct negated action
+             (True, False, _, _) ->
+               (allActs, q')
+             -- Only q is a direct negated action
+             (False, True, _, _) ->
+               (allActs, p')
+             -- Neither is directly negated, but they may have nested negated actions
+             (False, False, _, _) ->
+               (allActs, Conn And p' q')
+    extractNegatedActions f
+      | isNegatedAction f = ([extractInnerFormula f], TF True)
+      | otherwise = ([], f)
+
+    -- Add unnegated actions to conclusion as disjuncts
+    addActionsToConclusion :: [LNFormula] -> LNFormula -> LNFormula
+    addActionsToConclusion [] conclusion = conclusion
+    addActionsToConclusion (action:rest) conclusion =
+      addActionsToConclusion rest (Conn Or conclusion action)
+
+-- | Transform not(Ex x1...xn. P1 & P2 & ... & (Ex y. Q) & ... & not(Ex z. R) & ...)
+-- into: All x1...xn y ... . (P1 & P2 & ... & Q & ...) ==> (Ex z. R | ...)
+--
+-- This transformation uses the standard approach: apply nnf to push negation inside,
+-- then use pnf to pull all quantifiers to the front (with proper De Bruijn shifting).
+--
+-- Input: not(Ex x. P(x) & (Ex y. Q(y)) & not(Ex z. R(z)))
+-- After nnf: All x. not(P(x)) | (All y. not(Q(y))) | (Ex z. R(z))
+--          = All x. not(P(x) & (Ex y. Q(y))) | (Ex z. R(z))
+-- After pnf: All x y. (not(P(x)) | not(Q(y))) | (Ex z. R(z))
+--          = All x y. not(P(x) & Q(y)) | (Ex z. R(z))
+--          = All x y. (P(x) & Q(y)) => (Ex z. R(z))
+--
+-- The key insight is that we only want to pull UNIVERSAL quantifiers from the disjunction,
+-- not existentials. The existentials should stay where they are as separate disjuncts.
+-- This is because (Ex r. A) | (Ex r. B) is semantically "there exists r for A OR there exists r for B"
+-- while Ex r. (A | B) means "there exists ONE r that makes A OR B true" - different semantics!
+transformNotExistsConjToImplication :: LNFormula -> LNFormula
+transformNotExistsConjToImplication fm =
+    -- Apply NNF (negation normal form) to push negation inside
+    -- This converts not(Ex...) to All... and flips inner negations correctly
+    let nnfFormula = nnf fm
+        -- Apply custom prenex that only pulls UNIVERSAL quantifiers, not existentials
+        -- This keeps existentials as separate disjuncts in the conclusion
+        prenexFormula = prenexUniversalsOnly nnfFormula
+        -- Convert the resulting disjunction to implication form
+        -- All x y. (not(P) | not(Q) | R) becomes All x y. (P & Q) => R
+    in convertDisjunctionToImplication prenexFormula
+  where
+    -- Custom prenex that only pulls universal quantifiers, leaving existentials in place
+    prenexUniversalsOnly :: LNFormula -> LNFormula
+    prenexUniversalsOnly (Qua All x body) = Qua All x (prenexUniversalsOnly body)
+    prenexUniversalsOnly (Qua Ex x body) = Qua Ex x (prenexUniversalsOnly body)
+    prenexUniversalsOnly (Conn And p q) = pullUniversalsOnly $ prenexUniversalsOnly p .&&. prenexUniversalsOnly q
+    prenexUniversalsOnly (Conn Or p q) = pullUniversalsOnly $ prenexUniversalsOnly p .||. prenexUniversalsOnly q
+    prenexUniversalsOnly f = f
+
+    -- Pull only universal quantifiers from connectives, not existentials
+    pullUniversalsOnly :: LNFormula -> LNFormula
+    pullUniversalsOnly (Conn And (Qua All x p) (Qua All x' q)) | x == x' = Qua All x (pullUniversalsOnly (p .&&. q))
+    pullUniversalsOnly (Conn And (Qua All x p) q) = Qua All x (pullUniversalsOnly (p .&&. shiftFreeIndices 1 q))
+    pullUniversalsOnly (Conn And p (Qua All x q)) = Qua All x (pullUniversalsOnly (shiftFreeIndices 1 p .&&. q))
+    pullUniversalsOnly (Conn Or (Qua All x p) (Qua All x' q)) | x == x' = Qua All x (pullUniversalsOnly (p .||. q))
+    pullUniversalsOnly (Conn Or (Qua All x p) q) = Qua All x (pullUniversalsOnly (p .||. shiftFreeIndices 1 q))
+    pullUniversalsOnly (Conn Or p (Qua All x q)) = Qua All x (pullUniversalsOnly (shiftFreeIndices 1 p .||. q))
+    -- Don't pull existentials - leave them in place!
+    pullUniversalsOnly f = f
+
+    -- Convert All x. (not(P) | Q) to All x. (P => Q)
+    -- More generally: All x. (not(P1) | not(P2) | ... | Q1 | Q2 | ...)
+    --              => All x. (P1 & P2 & ...) => (Q1 | Q2 | ...)
+    convertDisjunctionToImplication :: LNFormula -> LNFormula
+    convertDisjunctionToImplication (Qua All x body) =
+        Qua All x (convertDisjunctionToImplication body)
+    convertDisjunctionToImplication (Qua Ex x body) =
+        -- Existential in conclusion - keep it
+        Qua Ex x (convertDisjunctionToImplication body)
+    convertDisjunctionToImplication disjunction =
+        let (negated, positive) = partitionDisjuncts disjunction
+            -- negated contains formulas that were Not(...), we take the inner part for premise
+            premise = buildConjunction negated
+            -- positive contains existentials and atoms for conclusion
+            conclusion = buildDisjunction positive
+        in if null negated
+           then conclusion
+           else Conn Imp premise conclusion
+
+    -- Partition disjuncts into negated (premise) and positive (conclusion)
+    partitionDisjuncts :: LNFormula -> ([LNFormula], [LNFormula])
+    partitionDisjuncts (Conn Or p q) =
+        let (neg1, pos1) = partitionDisjuncts p
+            (neg2, pos2) = partitionDisjuncts q
+        in (neg1 ++ neg2, pos1 ++ pos2)
+    partitionDisjuncts (Not p) = ([p], [])  -- Negated term goes to premise
+    partitionDisjuncts p = ([], [p])        -- Positive term goes to conclusion
+
+-- | Transform Ex x. (P & not(Ex y. Q) & not(Ex z. R)) to Not(All x. P => (Ex y. Q | Ex z. R))
+-- This is the dual of transformNotExistsConjToImplication.
+-- The pattern Ex x. (A & not(B)) is equivalent to not(All x. A => B).
+-- We reuse the not(Ex...) transformation by wrapping with Not and then transforming.
+transformExistsConjToNegatedImplication :: LNFormula -> LNFormula
+transformExistsConjToNegatedImplication fm =
+    -- Wrap the existential formula with Not to get not(Ex x. P & not(Q))
+    -- Then apply the not(Ex...) transformation which gives All x. not(P) | Q
+    -- Finally the outer Not gives us not(All x. P => Q)
+    let notFm = Not fm
+        transformed = transformNotExistsConjToImplication notFm
+    in Not transformed
+
+-- | Flatten nested implications for axiom translation.
+-- In ProVerif, axioms and restrictions don't support nested correspondences like A => (B => C).
+-- This function flattens them: A => (B => C) becomes (A & B) => C
+-- This is logically equivalent: A => (B => C) = ¬A ∨ (¬B ∨ C) = ¬(A ∧ B) ∨ C = (A ∧ B) => C
+--
+-- IMPORTANT: This transformation is ONLY valid for direct nested implications.
+-- The pattern A => ((D => E) & F) CANNOT be transformed to (A & D) => (E & F)
+-- because this is NOT logically equivalent. Use hasNestedImplicationInConjunction
+-- to detect such unsupported patterns before calling this function.
+--
+-- Also, A => (All x. B => C) can only be flattened to All x. (A & B) => C if x is NOT
+-- free in A. Use hasVariableCaptureInNestedImplication to detect this case.
+flattenNestedImplications :: LNFormula -> LNFormula
+flattenNestedImplications = go
+  where
+    go (Qua q x p) = Qua q x (go p)
+    go (Conn Imp p (Conn Imp q r)) =
+      -- A => (B => C) becomes (A & B) => C, then recurse on C
+      go (Conn Imp (Conn And p q) r)
+    go (Conn Imp p (Qua All x q)) =
+      -- A => (All x. Q) - need to look inside the All
+      -- If Q is an implication, we can potentially flatten it
+      -- SOUNDNESS CHECK: x must not be free in p, otherwise variable capture occurs
+      -- x is (String, LSort), frees returns [LVar], so check by name and sort
+      let freeInP = frees p
+          (xName, xSort) = x
+          xFreeInP = any (\v -> lvarName v == xName && lvarSort v == xSort) freeInP
+      in if xFreeInP
+         then Conn Imp (go p) (Qua All x (go q))  -- Cannot flatten safely, just recurse
+         else case go (Qua All x q) of
+           Qua All x' (Conn Imp q' r') ->
+             -- A => (All x. B => C) becomes All x. (A & B) => C
+             -- Safe because x is not free in A
+             Qua All x' (Conn Imp (Conn And (shiftFreeIndices 1 p) q') r')
+           other -> Conn Imp (go p) other
+    go (Conn Imp p (Conn And q r)) =
+      -- A => (B & C) - we can only recurse, NOT flatten implications inside B or C
+      -- The transformation A => ((D => E) & F) -> (A & D) => (E & F) is UNSOUND
+      -- Just recurse on each part
+      Conn Imp (go p) (Conn And (go q) (go r))
+    go (Conn c p q) = Conn c (go p) (go q)
+    go (Not p) = Not (go p)
+    go f = f
+
+-- | Check if a formula has nested implications inside conjunctions in the conclusion.
+-- Such formulas cannot be soundly flattened and are outside ProVerif's supported fragment.
+-- Pattern: A => ((B => C) & D) or A => (D & (B => C))
+hasNestedImplicationInConjunction :: LNFormula -> Bool
+hasNestedImplicationInConjunction = go
+  where
+    go (Qua _ _ p) = go p
+    go (Conn Imp _ conclusion) = hasImpInConj conclusion
+    go (Conn _ p q) = go p || go q
+    go (Not p) = go p
+    go _ = False
+
+    -- Check if there's an implication inside a conjunction
+    hasImpInConj (Conn And p q) = hasImp p || hasImp q || hasImpInConj p || hasImpInConj q
+    hasImpInConj (Qua _ _ body) = hasImpInConj body
+    hasImpInConj _ = False
+
+    -- Check if the formula is or contains an implication at the top level
+    hasImp (Conn Imp _ _) = True
+    hasImp (Qua _ _ body) = hasImp body
+    hasImp _ = False
+
+-- | Check if a formula has variable capture issues in nested quantified implications.
+-- Pattern: A => (All x. B => C) where x is free in A cannot be flattened safely.
+hasVariableCaptureInNestedImplication :: LNFormula -> Bool
+hasVariableCaptureInNestedImplication = go
+  where
+    go (Qua _ _ p) = go p
+    go (Conn Imp p (Qua All x q)) =
+      let freeInP = frees p
+          (xName, xSort) = x
+          xFreeInP = any (\v -> lvarName v == xName && lvarSort v == xSort) freeInP
+      in (xFreeInP && hasNestedImp q) || go p || go q
+    go (Conn _ p q) = go p || go q
+    go (Not p) = go p
+    go _ = False
+
+    hasNestedImp (Conn Imp _ _) = True
+    hasNestedImp (Qua _ _ body) = hasNestedImp body
+    hasNestedImp _ = False
+
+-- | Check if a formula contains not(...event...) anywhere.
+-- This pattern is not supported in ProVerif axioms/restrictions.
+hasNegatedEventInFormula :: LNFormula -> Bool
+hasNegatedEventInFormula = go
+  where
+    go (Qua _ _ p) = go p
+    go (Not p) = hasEventAnywhere p || go p
+    go (Conn _ p q) = go p || go q
+    go _ = False
+
+    hasEventAnywhere (Ato (Action _ _)) = True
+    hasEventAnywhere (Not f) = hasEventAnywhere f
+    hasEventAnywhere (Conn _ f1 f2) = hasEventAnywhere f1 || hasEventAnywhere f2
+    hasEventAnywhere (Qua _ _ f) = hasEventAnywhere f
+    hasEventAnywhere _ = False
+
+-- | Check if a negated restriction can potentially be rewritten to positive form.
+-- Pattern: not(Ex... (P & Q) & (i ≠ j)) can become All... (P & Q) => (i = j)
+-- Returns a description of the pattern if found, Nothing otherwise.
+canRewriteNegatedRestriction :: LNFormula -> Maybe String
+canRewriteNegatedRestriction (Not fm@(Qua Ex _ _)) =
+  -- Check if the body has a conjunction ending with an inequality
+  let body = getExistentialBody fm
+  in if hasInequalityInConj body
+     then Just "Pattern: not(Ex... P & (i ≠ j)) can be rewritten as All... P => (i = j)"
+     else Nothing
+  where
+    getExistentialBody (Qua Ex _ b) = getExistentialBody b
+    getExistentialBody b = b
+
+    hasInequalityInConj (Conn And _ (Not (Ato (EqE _ _)))) = True
+    hasInequalityInConj (Conn And (Not (Ato (EqE _ _))) _) = True
+    hasInequalityInConj (Conn And p q) = hasInequalityInConj p || hasInequalityInConj q
+    hasInequalityInConj _ = False
+canRewriteNegatedRestriction _ = Nothing
+
+-- | Check if a formula has a simple negated action pattern that cannot be translated.
+-- Pattern: not(Ex x. Action(x)@i) - this cannot be rewritten to a positive form
+isSimpleNegatedAction :: LNFormula -> Bool
+isSimpleNegatedAction (Not fm@(Qua Ex _ _)) =
+  let body = getExistentialBody fm
+  in isJustAction body
+  where
+    getExistentialBody (Qua Ex _ b) = getExistentialBody b
+    getExistentialBody b = b
+
+    isJustAction (Ato (Action _ _)) = True
+    isJustAction _ = False
+isSimpleNegatedAction _ = False
+
+data TimeVarKey
+  = FreeTimeVar LVar
+  | BoundTimeVar Int
+  deriving (Show, Eq, Ord)
+
+data BinderInfo = BinderInfo
+  { _binderId :: Int,
+    _binderSort :: LSort
+  }
+
+collectActionsWithTimepoints :: LNFormula -> M.Map TimeVarKey [String]
+collectActionsWithTimepoints fm = snd (collectActions [] 0 fm M.empty)
+  where
+    collectActions ctx nextId (Ato (Action timeVar (Fact tag _ _))) acc =
+      let (nextId', maybeKey) = extractKey ctx nextId timeVar
+          updatedAcc = case maybeKey of
+            Just key -> M.insertWith (++) key [factTagName tag] acc
+            Nothing -> acc
+       in (nextId', updatedAcc)
+    collectActions _ctx nextId (Ato _) acc = (nextId, acc)
+    collectActions _ctx nextId (TF _) acc = (nextId, acc)
+    collectActions ctx nextId (Not p) acc = collectActions ctx nextId p acc
+    collectActions ctx nextId (Conn _ p q) acc =
+      let (nextAfterP, acc') = collectActions ctx nextId p acc
+       in collectActions ctx nextAfterP q acc'
+    collectActions ctx nextId (Qua _ (_, varSort) body) acc =
+      let binder = BinderInfo nextId varSort
+       in collectActions (binder : ctx) (nextId + 1) body acc
+
+    extractKey ctx nextId timeVar =
+      case viewTerm timeVar of
+        Lit (Var (Free v)) ->
+          if lvarSort v == LSortNode
+            then (nextId, Just (FreeTimeVar v))
+            else (nextId, Nothing)
+        Lit (Var (Bound i)) ->
+          case drop (fromIntegral i) ctx of
+            BinderInfo bid bSort : _ ->
+              if bSort == LSortNode
+                then (nextId, Just (BoundTimeVar bid))
+                else (nextId, Nothing)
+            [] -> (nextId, Nothing)
+        _ -> (nextId, Nothing)
+
+-- | Find events that share timepoints in a formula
+eventsSharingTimepoints :: LNFormula -> S.Set String
+eventsSharingTimepoints fm =
+  let actionMap = collectActionsWithTimepoints fm
+      sharedTimepoints = M.filter ((> 1) . length) actionMap
+   in S.fromList . concatMap (S.toList . S.fromList) $ M.elems sharedTimepoints
+
+-- | Check if a formula has any shared timepoints
+formulaHasSharedTimepoints :: LNFormula -> Bool
+formulaHasSharedTimepoints = not . S.null . eventsSharingTimepoints
+
+formulaUsesRuleIdEvents :: S.Set String -> ProtoFormula syn (a, LSort) c LVar -> Bool
+formulaUsesRuleIdEvents ruleIdEvents =
+  foldFormula
+    ( \atom -> case atom of
+        Action _ (Fact tag _ _) -> factTagName tag `S.member` ruleIdEvents
+        _ -> False
+    )
+    (const False)
+    id
+    (\_ p q -> p || q)
+    (\_ _ p -> p)
+
+-- | Detect which event fact tags appear with shared timepoints in lemmas.
+-- Returns a set of fact tag names that need rule IDs.
+detectSharedTimepointEvents :: [ProtoLemma LNFormula ProofSkeleton] -> S.Set String
+detectSharedTimepointEvents lemmas =
+  S.unions $ map (eventsSharingTimepoints . L.get lFormula) lemmas
 
 loadLemmas ::
+  S.Set String ->  -- sharedEventTags: events that need rule IDs
+  Bool ->  -- hasSpecificLemmas: whether --lemma flag was used
   (ProtoLemma LNFormula ProofSkeleton -> Bool) ->
   TranslationContext ->
   TypingEnvironment ->
   OpenTheory ->
-  [Doc]
-loadLemmas lemSel tc te thy = map (ppLemma te) proverifLemmas
+  ([Doc], [Doc], S.Set ProVerifHeader)  -- (axioms, queries, headers)
+loadLemmas sharedEventTags hasSpecificLemmas lemSel tc te thy = (axiomDocs, queryDocs, headers)
   where
     thyLemmas = theoryLemmas thy
 
-    proverifLemmas = filter isApplicableLemma thyLemmas
+    -- Classify all lemmas
+    classified = [(lem, classifyLemma hasSpecificLemmas tc lemSel lem) | lem <- thyLemmas]
 
-    isApplicableLemma lem =
-      lemSel lem &&
-      not (skipReuseOrSrc tc &&
-           (ReuseLemma `elem` lem._lAttributes || SourceLemma `elem` lem._lAttributes)) &&
-      moduleCondition lem
+    -- Separate into axioms and queries
+    axiomsLemmas = [lem | (lem, AsAxiom) <- classified]
+    queryLemmas = [lem | (lem, AsQuery) <- classified]
 
-    moduleCondition lem =
-      let modules = concat [ ls | LemmaModule ls <- lem._lAttributes ]
-      in null modules || exportModule (trans tc) `elem` modules
+    -- Include both axioms and queries for fact extraction
+    allIncludedLemmas = axiomsLemmas ++ queryLemmas
+
+    -- Translate axioms using ppAxiomLemma
+    axiomDocs = map (ppAxiomLemma sharedEventTags te) axiomsLemmas
+
+    -- Translate queries using existing ppLemma
+    queryDocs = map (ppLemma sharedEventTags te) queryLemmas
+
+    allFacts = concatMap (formulaFacts . L.get lFormula) allIncludedLemmas
+    headers = makeEventHeaders sharedEventTags allFacts
+
+-- | Classify how a lemma should be translated based on selector and attributes
+classifyLemma ::
+  Bool ->  -- ^ hasSpecificLemmas: whether --lemma flag was used
+  TranslationContext
+  -> (Lemma ProofSkeleton -> Bool)  -- ^ lemSel selector
+  -> Lemma ProofSkeleton
+  -> LemmaTranslationMode
+classifyLemma hasSpecificLemmas tc lemSel lem
+  -- If lemma doesn't pass module condition, exclude it
+  | not (moduleCondition lem) = ExcludeLemma
+
+  -- If specific lemmas were targeted AND this lemma is selected
+  | hasSpecificLemmas && lemSel lem =
+      -- Direct targeting: always treat as query (strip reuse/source behavior)
+      AsQuery
+
+  -- If specific lemmas targeted, this one is NOT selected, BUT it's reuse/source
+  | hasSpecificLemmas && not (lemSel lem) && isReuseOrSource lem =
+      if shouldSkipHelperLemma lem
+        then ExcludeLemma
+        else AsAxiom
+
+  -- If specific lemmas targeted, this one is NOT selected, and NOT reuse/source
+  | hasSpecificLemmas && not (lemSel lem) = ExcludeLemma
+
+  -- If NO specific lemmas targeted (default: all lemmas), and is reuse/source
+  | not hasSpecificLemmas && isReuseOrSource lem =
+      if shouldSkipHelperLemma lem
+        then ExcludeLemma
+        else AsAxiom
+
+  -- If NO specific lemmas targeted and lemma is NOT reuse/source
+  | not hasSpecificLemmas && not (isReuseOrSource lem) = AsQuery
+
+  -- Default fallback
+  | otherwise = AsQuery
+  where
+    shouldSkipHelperLemma l =
+      (skipReuseLemmas tc && ReuseLemma `elem` l._lAttributes)
+        || (skipSourceLemmas tc && SourceLemma `elem` l._lAttributes)
+
+    isReuseOrSource l =
+      ReuseLemma `elem` l._lAttributes || SourceLemma `elem` l._lAttributes
+
+    moduleCondition l =
+      let modules = concat [ls | LemmaModule ls <- l._lAttributes]
+       in null modules || exportModule (trans tc) `elem` modules
 
 ------------------------------------------------------------------------------
 -- Header Generation
@@ -1364,10 +2501,11 @@ headerOfFunSym ((f, (k, pub, Constructor)), inTypes, outType) =
 headerOfFunSym _ = S.empty
 
 -- | Load headers from an OpenTheory into a set of ProVerif Headers
-loadHeaders :: TranslationContext -> OpenTheory -> TypingEnvironment -> IO (S.Set ProVerifHeader)
-loadHeaders tc thy typeEnv = do
+loadHeaders :: S.Set String -> TranslationContext -> OpenTheory -> TypingEnvironment -> IO (S.Set ProVerifHeader)
+loadHeaders ruleIdEvents tc thy typeEnv = do
   eqHeaders <- foldMap (headersOfRule tc typeEnv) sigRules
-  pure $ typedHeaderOfFunSym
+  pure $
+    typedHeaderOfFunSym
       `S.union` headerBuiltins'
       `S.union` eqHeaders
       `S.union` eventHeaders
@@ -1383,16 +2521,30 @@ loadHeaders tc thy typeEnv = do
     -- builtin headers need to be filtered, to make sure we don't redefine a user-defined function
     headerBuiltins' = S.filter keep headerBuiltins
       where
-        funNames = S.fromList [ n | Fun _ n _ _ _ <- S.toList typedHeaderOfFunSym ]
+        funNames = S.fromList [n | Fun _ n _ _ _ <- S.toList typedHeaderOfFunSym]
         keep (Fun _ n _ _ _) = n `S.notMember` funNames
-        keep _               = True
+        -- Models define g/0 themselves even when using the diffi-hellman builtin.
+        -- FIXME: Given builtins higher precedence than user defined functions seems more intuitive.
+        keep (Sym _ n _ _) = n `S.notMember` funNames
+        keep _ = True
 
     -- all user declared function symbols have typinginfos
     userDeclaredFunctions = theoryFunctionTypingInfos thy
     typedHeaderOfFunSym = foldMap headerOfFunSym userDeclaredFunctions
 
     -- events headers
-    eventHeaders = M.foldrWithKey (\tag types acc -> HEvent ('e' : factTagName tag) ("(" ++ makeArgtypes types ++ ")") `S.insert` acc) S.empty typeEnv.events
+    eventHeaders =
+      M.foldrWithKey
+        ( \tag types acc ->
+            let factName = factTagName tag
+                adjustedTypes =
+                  if factName `S.member` ruleIdEvents
+                    then Nothing : types
+                    else types
+            in HEvent ('e' : factName) ("(" ++ makeArgtypes adjustedTypes ++ ")") `S.insert` acc
+        )
+        S.empty
+        typeEnv.events
     -- generating headers for equations
     sigRules = S.toList (stRules sig)
 
@@ -1449,18 +2601,18 @@ prettyProVerifHeader = \case
   Eq eqtype quant eq pub -> text eqtype <> text " " <> text quant <> text " " <> text eq <> text pub <> text "."
   Sym symkind name symtype [] -> text symkind <> text " " <> text name <> text symtype <> text "."
   Sym symkind name symtype attr -> text symkind <> text " " <> text name <> text symtype <> text "[" <> fsep (punctuate comma (map text attr)) <> text "]" <> text "."
-  Fun "" _ _ _ _ -> emptyDoc
+  Fun "" _ _ _ _ -> text ""
   Fun fkind name _ symtype [] -> text fkind <> text " " <> text name <> text symtype <> text "."
   Fun fkind name _ symtype attr ->
     text fkind <> text " " <> text name <> text symtype <> text "[" <> fsep (punctuate comma (map text attr)) <> text "]" <> text "."
 
 prettyDeepSecHeader :: ProVerifHeader -> Doc
 prettyDeepSecHeader = \case
-  Type _ -> emptyDoc -- no types in deepsec
+  Type _ -> text "" -- no types in deepsec
   Eq "reduc" _ eq _ -> text "reduc" <> text " " <> text eq <> text "."
   Eq eqtype _ eq _ -> error $ "Deepsec does not support equations ATM: " ++ eqtype ++ " " ++ eq
-  HEvent _ _ -> emptyDoc
-  Table _ _ -> emptyDoc
+  HEvent _ _ -> text ""
+  Table _ _ -> text ""
   -- drop symtypes in symbol declarations
   Sym symkind name _ [] -> text symkind <> text " " <> text name <> text "."
   Sym symkind name _ attr ->
@@ -1468,7 +2620,7 @@ prettyDeepSecHeader = \case
       then text symkind <> text " " <> text name <> text "[private]" <> text "."
       else text symkind <> text " " <> text name <> text "."
   -- only keep arity for fun declarations
-  Fun "" _ _ _ _ -> emptyDoc
+  Fun "" _ _ _ _ -> text ""
   Fun fkind name arity _ [] ->
     text fkind
       <> text " "
@@ -1562,28 +2714,31 @@ makeAnnotations thy p = res
         else translateTermsReport pr
 
 -- | Pull out nots in formula
-pullnots :: LNFormula -> Either LNFormula LNFormula
-pullnots fm =
-  let fm_partially_rewritten = fixedpoint pullStep fm -- nots pulled out by pullStep can enable new pull-out steps, so need to compute fixed point
+pullNegationsToTop :: LNFormula -> Either LNFormula LNFormula
+pullNegationsToTop fm =
+  let fm_partially_rewritten = fixedpoint applyPullNegationStep fm -- nots pulled out by applyPullNegationStep can enable new pull-out steps, so need to compute fixed point
    in if onlyTopLevelNot fm_partially_rewritten
         then Right fm_partially_rewritten -- in this case, formula is fully rewritten, i.e. has only 1 top-level not or no nots at all
         else Left fm_partially_rewritten -- Error with partially rewritten formula
   where
     fixedpoint f phi = if phi /= f phi then fixedpoint f (f phi) else phi
 
-    pullStep fm' = case fm' of
+    applyPullNegationStep fm' = case fm' of
       Conn And (Not p) (Not q) -> Not $ p .||. q
       Conn Or (Not p) (Not q) -> Not $ p .&&. q
-      Conn Imp p (Not q) -> if isLessOrEqe q then Conn Imp p (Not q) else Not $ p .&&. q
+      Conn Imp p (Not q) ->
+        case q of
+          Not q' -> Conn Imp (applyPullNegationStep p) (applyPullNegationStep q')  -- q is ¬¬..., simplify to q' by removing double negation
+          _ -> if isLessOrEqe q then Conn Imp (applyPullNegationStep p) (Not (applyPullNegationStep q)) else Not $ applyPullNegationStep p .&&. applyPullNegationStep q
       Conn Iff (Not p) q -> Not $ p .<=>. q
       Conn Iff p (Not q) -> Not $ p .<=>. q
-      Conn c p q -> Conn c (pullStep p) (pullStep q)
+      Conn c p q -> Conn c (applyPullNegationStep p) (applyPullNegationStep q)
       Qua All x (Not p) -> Not $ Qua Ex x p
       Qua Ex x (Not p) -> Not $ Qua All x p
-      Qua qua x p -> Qua qua x $ pullStep p
+      Qua qua x p -> Qua qua x $ applyPullNegationStep p
       Not (Not p) -> p
       Not (Ato (EqE t1 t2)) -> Not (Ato (EqE t1 t2))
-      Not p -> Not $ pullStep p
+      Not p -> Not $ applyPullNegationStep p
       _ -> fm'
 
     -- Don't pull nots infront of equality tests/comparisons.
@@ -1592,129 +2747,311 @@ pullnots fm =
     isLessOrEqe _ = False
 
 onlyTopLevelNot :: ProtoFormula syn s c v -> Bool
-onlyTopLevelNot (Not p) = noNots p -- top-level not expected if rewriting was successful
-onlyTopLevelNot p = noNots p -- no top-level not may mean the rewriting has been successful and the formula has no nots at all
+onlyTopLevelNot (Not p) = hasNoNegations p -- top-level not expected if rewriting was successful
+onlyTopLevelNot p = hasNoNegations p -- no top-level not may mean the rewriting has been successful and the formula has no nots at all
 
-noNots :: ProtoFormula syn s c v -> Bool
-noNots (Not (Ato (EqE _ _))) = True -- check that there are no nots below top level (except before equality tests/comparisons)
-noNots (Not (Ato (Less _ _))) = True
-noNots (Not _) = False
-noNots (Conn _ p q) = noNots p && noNots q
-noNots (Qua _ _ p) = noNots p
-noNots _ = True
-
-{-
--- | ProVerif does not allow equalities in the premise/in existential lemmas.
--- | If possible, we merge the variables/terms and remove the equality.
-mergeEqs :: LNFormula -> LNFormula
-mergeEqs f@(Qua All _ _) = mergeEqsUniv f
-where
-    mergeEqsUniv (Qua All x p) = mergeEqsUniv p
-    mergeEqsUniv (Conn p q) = merge
-mergeEqs f@(Qua Ex _ _) = mergeEqsEx f
--}
-
-allAlls :: LNFormula -> Bool
-allAlls p =
-  onlyQua All p
-    && ( (1 :: Int)
-           < foldFormula
-             (const 0)
-             (const 0)
-             (const 0)
-             (\c q1 q2 -> case c of Imp -> 1 + q1 + q2; _ -> q1 + q2)
-             (\_ _ q1 -> q1)
-             p
-       )
-
-restructToAllImpEx :: LNFormula -> LNFormula
-restructToAllImpEx (Qua All x p) = Qua All x $ restructToAllImpEx p
-restructToAllImpEx (Conn Imp p q) = Conn Imp p (pnf q)
-restructToAllImpEx fm = fm
-
--- | Check if the formula has the structure All x1...xn. (f_a => Ex y1...yn. f_b)
-checkAllImpliesEx :: LNFormula -> LNFormula
-checkAllImpliesEx (Qua All x p) = Qua All x $ checkAll p
-  where
-    checkAll (Qua All y f) = Qua All y $ checkAll f
-    checkAll (Conn Imp q1 q2) = Conn Imp q1 (pnf q2)
-    checkAll f = f
--- \$ checkEx q2
---      checkAll f = f
---      checkEx f = if and $
---                          foldFormula (const [True]) (const [True]) (const [True])
---                          (\_ _ _-> [True]) (\q _ q1 -> case q of Ex -> q1; All -> [False]) f
---                  then pnf f else f
-checkAllImpliesEx f = f
-
--- | Check if a formula has only universal quantifiers and more than one implication.
--- allAlls :: LNFormula -> Bool
--- allAlls p = onlyQua All p
---            && ((1::Int) < foldFormula (const 0) (const 0) (const 0)
---                          (\c q1 q2 -> case c of Imp -> 1 + q1 + q2; _ -> q1 + q2) (\_ _ q1 -> q1) p)
-
--- | Check if a formula is of the form All x1 ... xn. (F => (not(Ex y1 ... yn. F')).
-allImplsNotEx :: LNFormula -> Bool
-allImplsNotEx (Qua All _ body) = allImplsNotEx body
-allImplsNotEx (Conn Imp p (Not f'@(Qua Ex _ _))) = isPropFormula p && onlyEx f'
-  where
-    onlyEx (Qua Ex _ body') = isPropFormula body' || onlyEx body'
-    onlyEx _ = False
-allImplsNotEx _ = False
+hasNoNegations :: ProtoFormula syn s c v -> Bool
+hasNoNegations (Not (Ato (EqE _ _))) = True -- check that there are no nots below top level (except before equality tests/comparisons)
+hasNoNegations (Not (Ato (Less _ _))) = True
+hasNoNegations (Not _) = False
+hasNoNegations (Conn _ p q) = hasNoNegations p && hasNoNegations q
+hasNoNegations (Qua _ _ p) = hasNoNegations p
+hasNoNegations _ = True
 
 -- | Check if a formula is of the form All x1 ... xn. (F => (Ex y1 ... yn. F') or All x1 ... xn. (F => (Ex y1 ... yn. F') \/ (Ex y1' ... yn'. F'').
-allImplsEx :: LNFormula -> Bool
-allImplsEx (Qua All _ body) = allImplsEx body
-allImplsEx f@(Conn Imp p q) = isPropFormula f || (isPropFormula p && onlyEx q)
+isAllImpliesExists :: LNFormula -> Bool
+isAllImpliesExists (Qua All _ body) = isAllImpliesExists body
+isAllImpliesExists f@(Conn Imp p q) = isQuantifierFree f || (isQuantifierFree p && hasOnlyExistentials q)
   where
-    onlyEx (Qua Ex _ body') = isPropFormula body' || onlyEx body'
-    onlyEx (Conn Or (Qua Ex _ b1) (Qua Ex _ b2)) = isPropFormula b1 || isPropFormula b2
-    onlyEx _ = False
-allImplsEx _ = False
+    hasOnlyExistentials (Qua Ex _ body') = isQuantifierFree body' || hasOnlyExistentials body'
+    hasOnlyExistentials (Conn Or (Qua Ex _ b1) (Qua Ex _ b2)) = isQuantifierFree b1 || isQuantifierFree b2
+    -- Allow temporal/equality constraints in disjunction with existentials
+    hasOnlyExistentials (Conn Or f1 f2) | isConstr f1 || isConstr f2 = hasOnlyExistentials f1 || hasOnlyExistentials f2 || isConstr f1 || isConstr f2
+    hasOnlyExistentials fm | isConstr fm = True
+    hasOnlyExistentials _ = False
+    -- Check if a formula is a temporal or equality constraint
+    isConstr (Ato (Less _ _)) = True
+    isConstr (Ato (EqE _ _)) = True
+    isConstr (Not (Ato (EqE _ _))) = True
+    isConstr (Conn Or g1 g2) = isConstr g1 && isConstr g2
+    isConstr _ = False
+isAllImpliesExists _ = False
 
--- | Check if a formula is of the form All x1 ... xn. (F => F') and F' contains quantifiers.
--- | If so, return the formula where F' is in PNF else return the input formula.
-allImplsPrenexConc :: LNFormula -> LNFormula
-allImplsPrenexConc (Qua All x body) = Qua All x $ allImplsPrenexConc body
-allImplsPrenexConc f@(Conn Imp p q) = if isPropFormula p && not (isPropFormula q) then Conn Imp p (pnf q) else f
-allImplsPrenexConc f = f
-
--- | Check if a formula is of the form not(Ex x1 ... xn. F) where F is a conjunction, may contain existential quantifiers and has one negation.
-notExistsOfExists :: LNFormula -> Bool
-notExistsOfExists (Not (Qua Ex _ body)) = existsConjUnderNot body && ((1 :: Int) == (foldFormula (const 0) (const 0) (1 +) (\_ p q -> p + q) (\_ _ p -> p) $ body))
+-- | Check if a formula is of the form not(Ex x1 ... xn. F) where F is a conjunction
+-- that may contain:
+--   - Atoms (action facts)
+--   - Positive existential quantifiers: Ex y. G  (e.g., Ex #j. K(s)@j)
+--   - Negated existential quantifiers: not(Ex y. G)  (e.g., not(Ex #r. RevLtk(A)@r))
+--
+-- This covers the common secrecy pattern:
+--   not(Ex A B s #i. Secret(A,B,s)@i & (Ex #j. K(s)@j) & not(Ex #r. RevLtk(A)@r) & not(Ex #r. RevLtk(B)@r))
+--
+-- After NNF and implication conversion, this becomes:
+--   All A B s #i. Secret(A,B,s)@i & (Ex #j. K(s)@j) ==> Ex #r. RevLtk(A)@r | Ex #r. RevLtk(B)@r
+--
+-- Which is exactly what ProVerif can handle (K in premise becomes attacker()).
+isNegatedExistsWithConjunction :: LNFormula -> Bool
+isNegatedExistsWithConjunction (Not (Qua Ex _ body)) =
+    isValidConjunctionBody body && hasNegatedExistential body
   where
-    existsConjUnderNot (Qua Ex _ p) = existsConjUnderNot p
-    existsConjUnderNot (Conn And p q) = existsConjUnderNot p && existsConjUnderNot q
-    existsConjUnderNot (Conn {}) = False
-    existsConjUnderNot _ = True
-notExistsOfExists _ = False
+    -- Check if body is a valid conjunction structure
+    -- Valid elements: atoms, Ex quantifiers (positive or negated), and And connectives
+    isValidConjunctionBody (Qua Ex _ p) = isValidConjunctionBody p
+    isValidConjunctionBody (Conn And p q) = isValidConjunctionBody p && isValidConjunctionBody q
+    -- Allow negated existentials: not(Ex y. G)
+    isValidConjunctionBody (Not (Qua Ex _ p)) = isValidConjunctionBody p
+    -- Universal quantifiers inside existential body are not supported
+    isValidConjunctionBody (Qua All _ _) = False
+    -- Disallow other connectives at this level (Or, Imp, Iff would break the pattern)
+    isValidConjunctionBody (Conn {}) = False
+    -- Atoms (including action facts) are fine
+    isValidConjunctionBody (Ato _) = True
+    -- TF (true/false) is fine
+    isValidConjunctionBody (TF _) = True
+    -- Simple negated atoms are fine (like not(A@i))
+    isValidConjunctionBody (Not (Ato _)) = True
+    -- Any other Not should be rejected
+    isValidConjunctionBody (Not _) = False
+
+    -- Check if body contains at least one negated existential
+    -- This ensures we only apply this transformation when there's something to move to conclusion
+    hasNegatedExistential (Qua Ex _ p) = hasNegatedExistential p
+    hasNegatedExistential (Conn And p q) = hasNegatedExistential p || hasNegatedExistential q
+    hasNegatedExistential (Not (Qua Ex _ _)) = True
+    hasNegatedExistential _ = False
+isNegatedExistsWithConjunction _ = False
 
 -- | -- | Check if a formula is of the form Ex x1 ... xn. F where F contains only negative existential quantifiers and conjunctions.
-existsConjOfNotExists :: LNFormula -> Bool
-existsConjOfNotExists (Qua Ex _ body) = existsConjOfNotExists body
-existsConjOfNotExists (Conn _ p q) = checkNotExists p && checkNotExists q
+-- This pattern requires at least one negated existential to be useful for transformation.
+isExistsWithNegatedExistentials :: LNFormula -> Bool
+isExistsWithNegatedExistentials (Qua Ex _ body) = isExistsWithNegatedExistentials body
+isExistsWithNegatedExistentials (Conn And p0 q0) = hasNegatedEx && checkNotExists p0 && checkNotExists q0
   where
-    checkNotExists (Not (Qua Ex _ p)) = checkExistsInNotExists p
-    checkNotExists (Conn And p q) = checkNotExists p && checkNotExists q
-    checkNotExists (Conn {}) = False
-    checkNotExists _ = True
+    -- Check that there's at least one negated existential in the formula
+    hasNegatedEx = hasNegExIn p0 || hasNegExIn q0
+    hasNegExIn (Not (Qua Ex _ _)) = True
+    hasNegExIn (Conn And p' q') = hasNegExIn p' || hasNegExIn q'
+    hasNegExIn _ = False
 
-    checkExistsInNotExists (Qua Ex _ p) = checkExistsInNotExists p
-    checkExistsInNotExists (Conn And p q) = checkNotExists p && checkNotExists q
+    -- Check that all conjuncts are either atoms, negated existentials, or conjunctions thereof
+    -- IMPORTANT: bare Qua Ex should NOT match - only negated ones
+    checkNotExists (Not (Qua Ex _ p')) = checkExistsInNotExists p'
+    checkNotExists (Conn And p' q') = checkNotExists p' && checkNotExists q'
+    checkNotExists (Qua Ex _ _) = False  -- Bare existential - doesn't match this pattern
+    checkNotExists (Conn {}) = False
+    checkNotExists _ = True  -- Atoms are OK
+
+    checkExistsInNotExists (Qua Ex _ p') = checkExistsInNotExists p'
+    checkExistsInNotExists (Conn And p' q') = checkNotExists p' && checkNotExists q'
     checkExistsInNotExists (Conn {}) = False
     checkExistsInNotExists _ = True
-existsConjOfNotExists _ = False
+isExistsWithNegatedExistentials _ = False
 
--- | Check if a formula contains only one type of quantifier.
-onlyQua :: Quantifier -> ProtoFormula syn s c v -> Bool
-onlyQua qua =
-  and
-    . foldFormula
-      (const [True])
-      (const [True])
-      (const [True])
-      (\_ q1 q2 -> q1 ++ q2)
-      (\q _ q1 -> if qua == q then q1 else [False])
+-- | Check if a formula has existentially quantified K (attacker knowledge) facts.
+-- K facts can only be supported when universally quantified (in the premise).
+-- This function returns True if there are K facts that are existentially quantified.
+--
+-- The quantification context is determined by:
+-- - Under Ex x. P: everything is existentially quantified
+-- - Under All x. P: everything is universally quantified
+-- - In implication (A ==> B):
+--     * Premise A stays in same context (universal if under All)
+--     * Conclusion B: always existential (we're asserting B must hold)
+-- - Under Not: the quantification context flips
+hasExistentiallyQuantifiedKFact :: LNFormula -> Bool
+hasExistentiallyQuantifiedKFact = go True  -- Start in existential context (top-level)
+  where
+    -- isExistential: True if we're in an existential context, False if universal
+    go _isExistential (Qua Ex _ body) = go True body  -- Ex always makes context existential
+    go _isExistential (Qua All _ body) = go False body  -- All makes context universal
+    go _isExistential (Conn Imp premise conclusion) =
+      -- Premise is always universal context (we're assuming premise holds)
+      -- Conclusion is always existential context (we're asserting it)
+      go False premise || go True conclusion
+    go isExistential (Conn _ p q) = go isExistential p || go isExistential q
+    go isExistential (Not p) = go (not isExistential) p  -- Negation flips context
+    go isExistential (Ato (Action _ fact)) = isExistential && isKFactLocal fact
+    go _ _ = False
+
+    -- Check if a fact is a K fact (K() or KU())
+    isKFactLocal f@(Fact tag _ _) = (tag == KUFact) || isKLogFact f
+
+-- | Eliminate double negations: not(not(P)) ==> P
+-- This should be done before any other transformations
+eliminateDoubleNegations :: LNFormula -> LNFormula
+eliminateDoubleNegations (Not (Not p)) = eliminateDoubleNegations p
+eliminateDoubleNegations (Qua q (name, srt) p) = Qua q (name, srt) (eliminateDoubleNegations p)
+eliminateDoubleNegations (Conn c p q) = Conn c (eliminateDoubleNegations p) (eliminateDoubleNegations q)
+eliminateDoubleNegations (Not p) = Not (eliminateDoubleNegations p)
+eliminateDoubleNegations p = p
+
+-- | Expand negated timepoint comparisons: not(i < j) ==> (j < i) | (i = j)
+-- ProVerif doesn't support not(i < j) syntax but does support <, >, <=, >=
+-- We expand to the disjunction which is semantically equivalent to i >= j
+expandNegatedTimepointComparisons :: LNFormula -> LNFormula
+expandNegatedTimepointComparisons (Not (Ato (Less i j))) =
+  -- not(i < j) becomes (j < i) || (i = j)
+  Conn Or (Ato (Less j i)) (Ato (EqE i j))
+expandNegatedTimepointComparisons (Qua q x p) = Qua q x (expandNegatedTimepointComparisons p)
+expandNegatedTimepointComparisons (Conn c p q) = Conn c (expandNegatedTimepointComparisons p) (expandNegatedTimepointComparisons q)
+expandNegatedTimepointComparisons (Not p) = Not (expandNegatedTimepointComparisons p)
+expandNegatedTimepointComparisons p = p
+
+-- | Check if a formula is of the form All x1 ... xn. A ==> (not B1) | (not B2) | ... | C1 | C2 | ...
+-- where at least one disjunct is negated
+-- IMPORTANT: We exclude formulas that contain equalities in negated disjuncts, as ProVerif doesn't support
+-- equality constraints in reachability query premises
+isAllImpliesDisjWithNegations :: LNFormula -> Bool
+isAllImpliesDisjWithNegations (Qua All _ body) = isAllImpliesDisjWithNegations body
+isAllImpliesDisjWithNegations (Conn Imp _ concl) = hasNegatedDisjunctWithoutComparison concl
+  where
+    hasNegatedDisjunctWithoutComparison (Conn Or p q) =
+      hasNegatedDisjunctWithoutComparison p || hasNegatedDisjunctWithoutComparison q
+    hasNegatedDisjunctWithoutComparison (Not (Qua Ex _ _)) = True
+    hasNegatedDisjunctWithoutComparison (Not f) = not (containsComparison f)
+    hasNegatedDisjunctWithoutComparison _ = False
+
+    -- Check if a formula contains comparison constraints (EqE or Less)
+    -- We want to keep negations of comparisons in the conclusion
+    -- Equalities like (x = ch) are represented as Ato (EqE x ch)
+    -- Timepoint comparisons like (#i < #j) are represented as Ato (Less i j)
+    containsComparison (Ato (EqE _ _)) = True
+    containsComparison (Ato (Less _ _)) = True
+    containsComparison (Ato (Last _)) = False
+    containsComparison (Ato (Action _ _)) = False
+    containsComparison (Qua _ _ body) = containsComparison body
+    containsComparison (Conn _ p q) = containsComparison p || containsComparison q
+    containsComparison (Not p) = containsComparison p
+    containsComparison _ = False
+isAllImpliesDisjWithNegations _ = False
+
+-- | Detect ∀x. (P ⇒ ¬Q₁ ∧ ¬Q₂ ∧ ...) pattern
+-- This pattern needs to be distributed into multiple queries:
+-- (∀x. P ⇒ ¬Q₁) ∧ (∀x. P ⇒ ¬Q₂) ∧ ...
+-- Because ProVerif doesn't support negated events in conclusions
+isAllImpliesConjWithNegations :: LNFormula -> Bool
+isAllImpliesConjWithNegations (Qua All _ body) = isAllImpliesConjWithNegations body
+isAllImpliesConjWithNegations (Conn Imp _ concl) = isConjOfNegatedExistentials concl
+  where
+    -- Check if conclusion is a conjunction where at least one conjunct is a negated existential
+    isConjOfNegatedExistentials (Conn And p q) =
+      (isNegatedExistential p || isConjOfNegatedExistentials p) &&
+      (isNegatedExistential q || isConjOfNegatedExistentials q)
+    isConjOfNegatedExistentials f = isNegatedExistential f
+
+    isNegatedExistential (Not (Qua Ex _ _)) = True
+    isNegatedExistential _ = False
+isAllImpliesConjWithNegations _ = False
+
+-- | Transform A ==> (not B1) | (not B2) | ... | C1 | C2 | ... into A & B1 & B2 & ... ==> C1 | C2 | ...
+-- This moves negated disjuncts from the conclusion to the premise
+-- Also pulls existential quantifiers from premise conjuncts to top level as universal quantifiers
+-- When all disjuncts are negated, returns Not(A & B1 & B2 & ...) which will be handled as a leading negation
+moveNegatedDisjunctsToPremise :: LNFormula -> LNFormula
+moveNegatedDisjunctsToPremise fm = case fm of
+  Qua All x p ->
+    -- Process the body and then re-wrap with All, but also pull out any new quantifiers
+    let p' = moveNegatedDisjunctsToPremise p
+     in case p' of
+          -- If the result has new All quantifiers at the top, merge them
+          Qua All y body -> Qua All x (Qua All y body)
+          _ -> Qua All x p'
+  Conn Imp premise conclusion ->
+    let (negatedTerms, positiveTerms) = partitionDisjuncts conclusion
+     in if null negatedTerms
+          then fm  -- No negated terms, return unchanged
+          else
+            -- Build new premise: premise & B1 & B2 & ...
+            let newPremise = buildConjunction (premise : negatedTerms)
+             in case positiveTerms of
+                  -- All disjuncts were negated: pull Ex quantifiers and return Not(premise)
+                  -- This will be properly handled as a leading negation by the existing machinery
+                  [] ->
+                    let prenexForm = prenex newPremise
+                     in Not prenexForm
+                  -- Some positive terms remain: build implication and pull Ex quantifiers
+                  (t:ts) ->
+                    let newConclusion = buildDisjunction (t:ts)
+                        implication = Conn Imp newPremise newConclusion
+                     in pullExFromPremise implication
+  _ -> fm
+  where
+    -- Partition disjuncts into (negated terms with negation removed, positive terms)
+    partitionDisjuncts :: LNFormula -> ([LNFormula], [LNFormula])
+    partitionDisjuncts (Conn Or p q) =
+      let (negsP, posP) = partitionDisjuncts p
+          (negsQ, posQ) = partitionDisjuncts q
+       in (negsP ++ negsQ, posP ++ posQ)
+    partitionDisjuncts (Not p) = ([p], [])  -- Remove the Not, add to negated terms
+    partitionDisjuncts p = ([], [p])  -- Add to positive terms
+
+    -- Pull existential quantifiers from premise conjuncts to top level as universal
+    -- Transform: (A & Ex x. B) ==> C into All x. (A & B) ==> C
+    -- The quantifiers are pulled out of the implication entirely
+    pullExFromPremise :: LNFormula -> LNFormula
+    pullExFromPremise (Conn Imp premise conclusion) =
+      let premise' = convertExToAllInConj premise
+          prenexPremise = prenex premise'
+       in pullQuantifiersOut (Conn Imp prenexPremise conclusion)
+    pullExFromPremise f = f
+
+    -- Pull All quantifiers from the premise of an implication to the outside
+    -- When moving a quantifier out, we must shift indices in the conclusion
+    -- to account for the new quantifier level
+    pullQuantifiersOut :: LNFormula -> LNFormula
+    pullQuantifiersOut (Conn Imp (Qua All x premise) conclusion) =
+      -- Shift free indices in conclusion by 1 to account for the new quantifier
+      let shiftedConclusion = shiftFreeIndices 1 conclusion
+       in Qua All x (pullQuantifiersOut (Conn Imp premise shiftedConclusion))
+    pullQuantifiersOut f = f
+
+    -- Convert Ex quantifiers to All quantifiers within conjunctions
+    convertExToAllInConj :: LNFormula -> LNFormula
+    convertExToAllInConj (Conn And p q) =
+      convertExToAllInConj p .&&. convertExToAllInConj q
+    convertExToAllInConj (Qua Ex x body) =
+      Qua All x (convertExToAllInConj body)
+    convertExToAllInConj (Qua q x body) =
+      Qua q x (convertExToAllInConj body)
+    convertExToAllInConj f = f
+
+-- | Distribute implication over a conjunction of negated existentials
+-- Transforms: ∀x. (P ⇒ ¬Q₁ ∧ ¬Q₂) into (∀x. P ⇒ ¬Q₁) ∧ (∀x. P ⇒ ¬Q₂)
+-- which is equivalent to: not(∃x. P ∧ Q₁) ∧ not(∃x. P ∧ Q₂)
+-- This produces a top-level conjunction that will be split by splitTopLvlConns
+-- Each resulting formula will be processed independently with leading negation
+distributeImplicationOverConjunction :: LNFormula -> LNFormula
+distributeImplicationOverConjunction fm = case fm of
+  Qua All x body ->
+    case distributeImplicationOverConjunction body of
+      -- If the body became a conjunction, distribute the All over it
+      -- Then recursively process each part to convert Qua All (Not (Qua Ex ...)) to Not (Qua Ex ...)
+      Conn And p q ->
+        let leftProcessed = distributeImplicationOverConjunction (Qua All x p)
+            rightProcessed = distributeImplicationOverConjunction (Qua All x q)
+        in Conn And leftProcessed rightProcessed
+      -- If the body is Not (Qua Ex ...), pull the Not outside and convert All to Ex
+      -- All x. not(Ex y. P) is equivalent to not(Ex x y. P)
+      Not (Qua Ex y innerBody) -> Not (Qua Ex x (Qua Ex y innerBody))
+      -- If the body is a single Not (Qua Ex ...) without nested Qua Ex
+      Not innerBody -> Not (Qua Ex x innerBody)
+      body' -> Qua All x body'
+  Conn Imp premise (Conn And concl1 concl2) ->
+    -- Distribute: (P => Q1 & Q2) becomes (P => Q1) & (P => Q2)
+    -- Then recursively process in case there are more conjuncts
+    let left = distributeImplicationOverConjunction (Conn Imp premise concl1)
+        right = distributeImplicationOverConjunction (Conn Imp premise concl2)
+     in Conn And left right
+  Conn Imp premise (Not (Qua Ex x body)) ->
+    -- For a single negated existential: P => not(Ex x. Q)
+    -- Transform to: not(Ex x. P & Q)
+    -- This is done by moving P into the existential and negating the whole thing
+    let -- Shift premise indices to account for the new quantifier
+        shiftedPremise = shiftFreeIndices 1 premise
+        -- The body already contains nested existentials, just add the conjunction
+        newBody = Conn And shiftedPremise body
+     in Not (Qua Ex x newBody)
+  _ -> fm
 
 -- | Recursively split a formula at its connectives (until we split it into subformulas that start with quantifiers).
 -- | Also add a formal comment so that the user knows how to reconstruct the original formula.
@@ -1735,18 +3072,6 @@ splitTopLvlConns AllTraces step (Conn And p q) =
     (fstP, sndP, stepP) = splitTopLvlConns AllTraces step p
     (fstQ, sndQ, stepQ) = splitTopLvlConns AllTraces stepP q
 
-{- splitTopLvlConns AllTraces step (Conn Or p q) =
-    (fstP ++ fstQ,
-     sndP $$ sndQ $$ text ("Distribution of a universal trace quantifier over ∨ yields a stronger statement!\nA positive result is transferable, while a negative result is not!" ++ "\n" ++ show stepQ ++ ". Combine ")
-                     $$ prettyLNFormula p
-                     $$ text " and "
-                     $$ prettyLNFormula q
-                     $$ text " with ∨.",
-     stepQ + 1)
-  where
-    (fstP, sndP, stepP) = splitTopLvlConns AllTraces step p
-    (fstQ, sndQ, stepQ) = splitTopLvlConns AllTraces stepP q -}
-
 splitTopLvlConns ExistsTrace step (Conn Or p q) =
   ( fstP ++ fstQ,
     sndP
@@ -1762,33 +3087,6 @@ splitTopLvlConns ExistsTrace step (Conn Or p q) =
     (fstP, sndP, stepP) = splitTopLvlConns ExistsTrace step p
     (fstQ, sndQ, stepQ) = splitTopLvlConns ExistsTrace stepP q
 
--- distributing exists over AND yields a weaker statement (implied by the undistributed statement => useless)
-
-{- splitTopLvlConns AllTraces step (Conn Imp p q) =
-    (fstNotP ++ fstQ,
-     sndNotP $$ sndQ $$ text ("Distribution of a universal trace quantifier over ⇒.\nA ⇒ B is being treated as ¬A ∨ B!\nThe distribution yields a stronger statement!" ++ "\n" ++ show stepQ ++ ". Combine ")
-                           $$ prettyLNFormula p
-                           $$ text " and "
-                           $$ prettyLNFormula q
-                           $$ text " with ⇒ (attention: negate the premise).",
-     stepQ + 1)
-  where
-    (fstNotP, sndNotP, stepP) = splitTopLvlConns AllTraces step (Not p)
-    (fstQ, sndQ, stepQ) = splitTopLvlConns AllTraces stepP q -}
-
--- case is OK, but it does not happen in Tamarin
-{-splitTopLvlConns ExistsTrace step (Conn Imp p q) =
-    (fstNotP ++ fstQ,
-     sndNotP $$ sndQ $$ text (show stepQ ++ ". Combine ")
-                           $$ prettyLNFormula p
-                           $$ text " and "
-                           $$ prettyLNFormula q
-                           $$ text " with ⇒ (attention: negate the premise).",
-     stepQ + 1)
-  where
-    (fstNotP, sndNotP, stepP) = splitTopLvlConns AllTraces step (Not p)
-    (fstQ, sndQ, stepQ) = splitTopLvlConns  ExistsTrace stepP q-}
-
 splitTopLvlConns _ step fm = ([fm], mempty, step)
 
 ------------------------------------------------------------------------------
@@ -1797,50 +3095,50 @@ splitTopLvlConns _ step fm = ([fm], mempty, step)
 
 data PVElement = R | RSL
 
-ppAtomR :: TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
-ppAtomR te b = ppProtoAtomR te b (const emptyDoc)
+ppAtomR :: S.Set String -> TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppAtomR ruleIdEvents te b = ppProtoAtomR ruleIdEvents te b (const emptyDoc)
 
 -- only used for ProVerif queries display
 -- the Bool is set to False when we must negate the atom
-ppNAtomR :: TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
-ppNAtomR te b = ppAtomR te b (fst . ppLNTerm emptyTC)
+ppNAtomR :: S.Set String -> TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppNAtomR ruleIdEvents te b = ppAtomR ruleIdEvents te b (fst . ppLNTerm emptyTC)
 
-ppProtoAtomR ::
-  (HighlightDocument d, Ord k, Show k, Show c) =>
-  TypingEnvironment ->
-  Bool ->
-  (s (Term (Lit c k)) -> d) ->
-  (Term (Lit c k) -> d) ->
-  ProtoAtom s (Term (Lit c k)) ->
-  (d, M.Map k SapicType)
-ppProtoAtomR te _ _ ppT (Action _ f@(Fact tag _ ts))
+ppProtoAtomR :: (Ord a1, Show a1, Show c, Typeable a1, HighlightDocument a2) => S.Set String -> TypingEnvironment -> Bool -> (s (Term (Lit c a1)) -> a2) -> (Term (Lit c a1) -> a2) -> ProtoAtom s (Term (Lit c a1)) -> (a2, M.Map a1 SapicType)
+ppProtoAtomR ruleIdEvents te _ _ ppT (Action _ f@(Fact tag _ ts))
   | factTagArity tag /= length ts = translationFail $ "MALFORMED function" ++ show tag
   | (tag == KUFact) || isKLogFact f -- treat KU() and K() facts the same
     =
       (ppFactL "attacker" ts, M.empty)
   | otherwise =
-      ( text "event(" <> ppFactL ('e' : factTagName tag) ts <> text ")",
+      ( text "event(" <> eventArgs ('e' : factTagName tag) ts <> text ")",
         typeVarsEvent te tag ts
       )
   where
+    factName = factTagName tag
+    useRuleId = factName `S.member` ruleIdEvents
     ppFactL n t = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ map ppT t
-ppProtoAtomR _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
-ppProtoAtomR _ False _ ppT (EqE l r) =
+    eventArgs n t
+      | useRuleId = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ (text "rid" : map ppT t)
+      | otherwise = ppFactL n t
+ppProtoAtomR _ _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
+ppProtoAtomR _ _ False _ ppT (EqE l r) =
   (sep [ppT l <-> opEqual, ppT r], M.empty)
-ppProtoAtomR _ True _ ppT (EqE l r) =
+ppProtoAtomR _ _ True _ ppT (EqE l r) =
   (sep [ppT l <-> text "<>", ppT r], M.empty)
 -- sep [ppNTerm l <-> text "≈", ppNTerm r]
-ppProtoAtomR _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
-ppProtoAtomR _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
-ppProtoAtomR _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
+ppProtoAtomR _ _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
+ppProtoAtomR _ _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
+ppProtoAtomR _ _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
 
 ppLFormulaR ::
   (MonadFresh m, Ord c, HighlightDocument b, Functor syn) =>
+  Bool -> -- True if we want to remove timepoint declarations.
+  S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
   (TypingEnvironment -> Bool -> ProtoAtom syn (Term (Lit c LVar)) -> (b, M.Map LVar SapicType)) ->
   ProtoFormula syn (String, LSort) c LVar ->
   m ([LVar], (b, M.Map LVar SapicType))
-ppLFormulaR te ppAt =
+ppLFormulaR keepTimeVars _ruleIdEvents te ppAt =
   pp
   where
     pp (Ato a) = pure ([], ppAt te False (toLAt a))
@@ -1864,21 +3162,32 @@ ppLFormulaR te ppAt =
       scopeFreshness $ do
         (vs, _, fm') <- openFormulaPrefix fm
         (vsp, d') <- pp fm'
-        pure (filter (\v -> lvarSort v /= LSortNode) (vs ++ vsp), d')
+        pure (filter (\v -> keepTimeVars || lvarSort v /= LSortNode) (vs ++ vsp), d')
 
 ppQueryFormulaR ::
   (MonadFresh m, Functor s) =>
+  Bool -> -- True if we want to remove timepoint declarations.
   PVElement ->
+  S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
   ProtoFormula s (String, LSort) Name LVar ->
   [LVar] ->
+  String ->
   m Doc
-ppQueryFormulaR pe te fm extravs = do
-  (vs, (p, typeVars)) <- ppLFormulaR te ppNAtomR fm
+ppQueryFormulaR keepTimeVars pe ruleIdEvents te fm extravs attrs = do
+  (vs, (p, typeVars)) <- ppLFormulaR keepTimeVars ruleIdEvents te (if keepTimeVars then ppNAtom ruleIdEvents else ppNAtomR ruleIdEvents) fm
+  let includeRuleId = formulaUsesRuleIdEvents ruleIdEvents fm
+  let ruleIdVar = text "rid:bitstring"
+  let allVars = map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs)
+  let quantifiedVars =
+        if includeRuleId
+          then ruleIdVar : allVars
+          else allVars
   pure $
     sep
-      [ text word <> fsep (punctuate comma (map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs))) <> text ";",
+      [ text word <> fsep (punctuate comma quantifiedVars) <> text ";",
         nest 1 p,
+        text attrs,
         text "."
       ]
   where
@@ -1886,252 +3195,401 @@ ppQueryFormulaR pe te fm extravs = do
       R -> "restriction "
       RSL -> "axiom "
 
-ppQueryFormulaExR :: PVElement -> TypingEnvironment -> LNFormula -> [LVar] -> Doc
-ppQueryFormulaExR pe te fm vs =
-  Precise.evalFresh (ppQueryFormulaR pe te fm vs) (avoidPrecise fm)
+ppQueryFormulaExR :: Bool -> PVElement -> S.Set String -> TypingEnvironment -> LNFormula -> [LVar] -> String -> Doc
+ppQueryFormulaExR keepTimeVars pe ruleIdEvents te fm vs attrs =
+  Precise.evalFresh (ppQueryFormulaR keepTimeVars pe ruleIdEvents te fm vs attrs) (avoidPrecise fm)
 
 ppRestrictFormulaR ::
   PVElement ->
+  S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
-  ProtoFormula Unit2 (String, LSort) Name LVar ->
+  LNFormula ->
+  String ->
   Precise.FreshT Data.Functor.Identity.Identity Doc
-ppRestrictFormulaR pe te frm =
+ppRestrictFormulaR pe ruleIdEvents te frm attrs =
   if any (\(Fact tag _ _) -> factTagName tag == "KU") (formulaFacts frm) -- don't allow KU facts, nothing corresponding in PV
-    || hasLessOrTmpEq frm -- by this point we have stripped the less if that was possible in the 1st place
-    || allActImplsExAct frm
+    || (hasLessOrTmpEqInPremise frm && not (hasDistinctFact frm)) -- by this point we have stripped the less if that was possible in the 1st place
     then pure $ ppFail frm
-    else pp $ allImplExLessWoTmps frm
+    else let transformedFrm = allImplExLessWoTmps frm
+             -- Flatten nested implications for axioms: A => (B => C) becomes (A & B) => C
+             flattenedFrm = flattenNestedImplications transformedFrm
+         in if hasTopLevelNegatedAction flattenedFrm
+            then pure $ ppFailNegatedAction flattenedFrm
+            -- Check for nested implications in conclusion (axioms don't support this)
+            else if rejectNestedImplicationInConclusion && hasNestedImplicationInConclusion flattenedFrm
+            then pure $ ppFailNestedImpl flattenedFrm
+            else pp flattenedFrm
   where
+    -- Check if the formula has nested implications in the conclusion
+    -- This is not supported for axioms in ProVerif
+    rejectNestedImplicationInConclusion = case pe of
+      R -> False
+      RSL -> True
+
+    hasNestedImplicationInConclusion = checkNested False
+      where
+        checkNested inConc (Qua _ _ q) = checkNested inConc q
+        checkNested False (Conn Imp _ q) = checkNested True q  -- Enter conclusion
+        checkNested True (Conn Imp _ _) = True  -- Nested implication in conclusion
+        checkNested inConc (Conn _ l r) = checkNested inConc l || checkNested inConc r
+        checkNested inConc (Not n) = checkNested inConc n
+        checkNested _ _ = False
+
+    ppFailNestedImpl fm = text "(*" <> prettyLNFormula fm <> text "*)" $$
+                text ("(* " ++ failMsg ++ " has nested implication in conclusion which is not supported for axioms in ProVerif. *)") $$
+                text ""
+      where
+        failMsg = case pe of
+          R -> "Restriction"
+          RSL -> "Axiom"
+
     pp (Not fm@(Qua Ex _ _)) = do
       (vs, _, fm') <- openFormulaPrefix fm
-      pure
-        ( if isPropFormula fm'
-            then ppOk fm' vs
-            else ppFail fm
-        )
+      -- Check if this is a simple negated action that can't be rewritten
+      if isSimpleNegatedAction (Not fm)
+        then pure $ ppFailSimpleNegatedAction (Not fm)
+        else if isQuantifierFree fm'
+          then pure $ ppOk fm' vs
+          else
+            -- Check if it could be rewritten to positive form
+            case canRewriteNegatedRestriction (Not fm) of
+              Just rewriteHint -> pure $ ppFailWithRewriteHint (Not fm) rewriteHint
+              Nothing -> pure $ ppFail (Not fm)
     pp fm@(Qua All _ _) = do
       (_, _, fm') <- openFormulaPrefix fm
-      pp2 fm fm'
+      handleUniversalFormula fm fm'
     pp fm = pure $ ppFail fm
-    ppOk = ppQueryFormulaExR pe te
-    ppFail fm = text "(*" <> prettyLNFormula fm <> text "*)"
+    ppOk f l = ppQueryFormulaExR keepTimeVars pe ruleIdEvents te f l attrs
+      where
+        keepTimeVars = case pe of
+          R -> True
+          RSL -> hasDistinctFact frm || hasTimepointEqInConclusion frm
+    ppFail fm = text "(*" <> prettyLNFormula fm <> text "*)" $$
+                text ("(* " ++ failMsg ++ " translation failed. Results may be incomplete. *)") $$
+                text ""
+      where
+        failMsg = case pe of
+          R -> "Restriction"
+          RSL -> "Axiom"
+    -- Special failure message for negated actions (from exists-trace lemmas with leading negation)
+    ppFailNegatedAction fm = text "(*" <> prettyLNFormula fm <> text "*)" $$
+                text ("(* " ++ failMsg ++ " has negated event (from exists-trace lemma with negation). Cannot translate to ProVerif. *)") $$
+                text ""
+      where
+        failMsg = case pe of
+          R -> "Restriction"
+          RSL -> "Axiom"
+    -- Failure message for simple negated actions like not(Ex x i. Neq(x,x)@i)
+    ppFailSimpleNegatedAction fm = text "(*" <> prettyLNFormula fm <> text "*)" $$
+                text ("(* " ++ failMsg ++ " contains negated event that cannot be expressed in ProVerif. *)") $$
+                text ""
+      where
+        failMsg = case pe of
+          R -> "Restriction"
+          RSL -> "Axiom"
+    -- Failure message with a rewrite hint
+    ppFailWithRewriteHint fm hintMsg = text "(*" <> prettyLNFormula fm <> text "*)" $$
+                text ("(* " ++ failMsg ++ " translation failed. " ++ hintMsg ++ " *)") $$
+                text ""
+      where
+        failMsg = case pe of
+          R -> "Restriction"
+          RSL -> "Axiom"
 
-    pp2 fm_original fm | isPropFormula fm = do
+    handleUniversalFormula fm_original fm | isQuantifierFree fm = do
       pure $ ppOk fm_original []
-    pp2 fm_original (Conn Imp p fm) | isPropFormula p = do
-      isExDisj <- disjunct_ex fm
-      pure $
-        if isExDisj
-          then ppOk fm_original []
-          else ppFail fm_original
-    pp2 fm_original _ = pure $ ppFail fm_original
+    handleUniversalFormula fm_original (Conn Imp p fm) | isQuantifierFree p = do
+      isExDisj <- isExistentialDisjunction fm
+      if isExDisj
+        then pure $ ppOk fm_original []
+        else do
+          -- Try handling nested implications/universals
+          isNestedOk <- isNestedImplicationOk fm
+          pure $
+            if isNestedOk
+              then ppOk fm_original []
+              else ppFail fm_original
+    handleUniversalFormula fm_original _ = pure $ ppFail fm_original
 
-    disjunct_ex fm@(Qua Ex _ _) = do
-      (_, _, fm') <- openFormulaPrefix fm
-      pure $ isPropFormula fm'
-    disjunct_ex (Conn Or fm@(Qua Ex _ _) fm2) = do
-      (_, _, fm') <- openFormulaPrefix fm
-      b <- disjunct_ex fm2
-      pure $ b && isPropFormula fm'
-    disjunct_ex (Conn Or fm2 fm@(Qua Ex _ _)) = do
-      (_, _, fm') <- openFormulaPrefix fm
-      b <- disjunct_ex fm2
-      pure $ b && isPropFormula fm'
-    disjunct_ex _ = pure False
+    hasDistinctFact fm =
+      any (\(Fact tag _ _) -> factTagName tag == "DistinctFact") (formulaFacts fm)
 
-    -- pp2 fm_original (Conn Imp p fm@(Qua Ex _ _)) | isPropFormula p  = do
-    --             (_,_,fm') <- openFormulaPrefix fm
-    --             pure $ (if isPropFormula fm' then
-    --                         ppOk fm_original []
-    --                       else
-    --                         ppFail fm_original)
-    -- pp2 fm_original (Conn Imp p (Conn Or fm@(Qua Ex _ _)  fm2@(Qua Ex _ _))) | isPropFormula p  = do
-    --             (_,_,fm') <- openFormulaPrefix fm
-    --             (_,_,fm2') <- openFormulaPrefix fm2
-    --             pure $ (if isPropFormula fm' && isPropFormula fm2' then
-    --                         ppOk fm_original []
-    --                       else
-    --                         ppFail fm_original)
+    -- Check if formula has timepoint equality/inequality in conclusion
+    hasTimepointEqInConclusion fm = checkConclusion fm
+      where
+        checkConclusion (Qua _ _ p) = checkConclusion p
+        checkConclusion (Conn Imp _ q) = hasTimepointConstraint q
+        checkConclusion f = hasTimepointConstraint f
 
-    -- check if a formula has no timepoint comparisons/eqs; should've been removed at that point
-    hasLessOrTmpEq fm =
+        hasTimepointConstraint (Ato a) = case a of
+          EqE t1 t2 -> isTimepoint t1 || isTimepoint t2
+          Less _ _ -> True
+          _ -> False
+        hasTimepointConstraint (Not p) = hasTimepointConstraint p
+        hasTimepointConstraint (Conn _ p q) = hasTimepointConstraint p || hasTimepointConstraint q
+        hasTimepointConstraint (Qua _ _ p) = hasTimepointConstraint p
+        hasTimepointConstraint _ = False
+
+        isTimepoint t = t `elem` getFormulaActsTmps fm
+
+    -- check if a formula has timepoint comparisons/eqs in the premise
+    -- (temporal constraints in the conclusion are ok for ProVerif)
+    hasLessOrTmpEqInPremise fm = go False fm
+      where
+        go inConclusion (Qua _ _ p) = go inConclusion p  -- preserve inConclusion state through quantifiers
+        go False (Conn Imp p q) = hasLessOrTmpEqAnywhere p || go True q
+        go inConclusion (Conn And p q) = go inConclusion p || go inConclusion q
+        go inConclusion (Conn Or p q) = go inConclusion p || go inConclusion q
+        go inConclusion (Not p) = go inConclusion p
+        go True _ = False  -- We're in conclusion, temporal constraints are OK
+        go False (Ato a) = case a of
+          Less _ _ -> True
+          EqE t1 _ -> t1 `elem` getFormulaActsTmps fm
+          _ -> False
+        go False _ = False
+
+    -- check if a formula has timepoint comparisons/eqs anywhere
+    hasLessOrTmpEqAnywhere fm2 =
       foldFormula
         ( \a -> case a of
             Less _ _ -> True
-            EqE t1 _ -> t1 `elem` formulaActsTmps
+            EqE t1 _ -> t1 `elem` getFormulaActsTmps fm2
             _ -> False
         )
         (const False)
         (const False)
         (\_ p q -> p || q)
         (\_ _ p -> p)
-        fm
+        fm2
+
+    -- Get all timepoint variables from actions in a formula
+    getFormulaActsTmps = foldFormula extractActionTimepoint (const []) id (\_ p q -> p ++ q) (\_ _ p -> p)
       where
-        -- gather the of the actions to check of we have some eq/ineq with them
-        formulaActsTmps = foldFormula fAto (const []) id (\_ p q -> p ++ q) (\_ _ p -> p) fm
-          where
-            fAto a = case a of
-              Action tf _ -> [tf]
-              _ -> []
+        extractActionTimepoint a = case a of
+          Action tf _ -> [tf]
+          _ -> []
 
--- | Only works for restrictions (due to them being different types than lemmas)
-ppRestr :: TypingEnvironment -> Restriction -> Doc
-ppRestr te rstr =
-  trace
-    ( "PROVERIF RESTR: "
-        ++ render
-          ( text "(*"
-              <> text rstr._rstrName
-              <> text "*)"
-              $$ Precise.evalFresh (ppRestrictFormulaR R te fm) (avoidPrecise fm)
-          )
-        ++ " END"
-    )
-    $ text "(*"
-      <> text rstr._rstrName
-      <> text "*)"
-      $$ Precise.evalFresh (ppRestrictFormulaR R te fm) (avoidPrecise fm)
+-- | Translate a restriction to ProVerif format
+ppRestr :: S.Set String -> TypingEnvironment -> Restriction -> Doc
+ppRestr ruleIdEvents te rstr =
+  timepointComment
+    $$ text "(*" <> text rstr._rstrName <> text "*)"
+    $$ case tryRewriteNegatedRestriction fm of
+         Just rewritten ->
+           -- Successfully rewrote the negated restriction
+           text "(* Original: " <> prettyLNFormula rstr._rstrFormula <> text " *)"
+           $$ Precise.evalFresh (ppRestrictFormulaR R ruleIdEvents te rewritten "") (avoidPrecise rewritten)
+         Nothing ->
+           -- Check for unsupported patterns
+           if hasNestedImplicationInConjunction fm
+           then text "(* " <> prettyLNFormula rstr._rstrFormula <> text " *)"
+                $$ text "(* Formula has nested implications inside conjunctions (e.g., A => ((B => C) & D))."
+                $$ text "   This pattern cannot be soundly transformed to ProVerif's supported fragment."
+                $$ text "   The formula is outside the supported ProVerif fragment. *)"
+                $$ text ""
+           else if hasVariableCaptureInNestedImplication fm
+           then text "(* " <> prettyLNFormula rstr._rstrFormula <> text " *)"
+                $$ text "(* Formula has variable capture in nested quantified implications (e.g., A(x) => (All x. B => C))."
+                $$ text "   Flattening would change the semantics. *)"
+                $$ text ""
+           else if hasProblematicNegation fm
+           then text "(* " <> prettyLNFormula fm <> text " *)"
+                $$ text "(* Restriction has negated event which is not supported in ProVerif. *)"
+                $$ text ""
+           else Precise.evalFresh (ppRestrictFormulaR R ruleIdEvents te fm "") (avoidPrecise fm)
   where
-    fm = transformWithPullNots $ transformWithStamps $ trace ("TAMARIN RESTR: " ++ render (prettyLNFormula rstr._rstrFormula) ++ " END") $ rstr._rstrFormula
+    -- Apply transformations for restrictions:
+    -- 1. First simplify (converts A => F to Not A)
+    -- 2. Then move constraints to conclusion
+    -- 3. Then move negated actions to conclusion: (A & not(B)) => C -> A => (C | B)
+    -- 4. Then expand negated timepoint comparisons
+    -- 5. Then flatten nested implications: A => (B => C) -> (A & B) => C
+    --    (ProVerif doesn't allow nested implications in restrictions)
+    -- 6. Finally pull negations to top (converts All x. Not A to Not (Ex x. A))
+    -- This order is important: simplify first so A => F becomes Not A,
+    -- then pullNegationsToTop can pull that Not to the top level
+    simplifiedFormula =
+      transformWithPullNots
+        $ simplifyFormula
+        $ flattenNestedImplications
+        $ expandNegatedTimepointComparisons
+        $ moveNegatedActionsToConclusion
+        $ moveConstraintsToConclusion
+        $ simplifyFormula rstr._rstrFormula
+    needsRuleId = formulaHasSharedTimepoints simplifiedFormula
+    timepointComment = if needsRuleId
+                       then text "(* Timepoints in restriction have been split *)"
+                       else text ""
+    fm = if needsRuleId
+         then makeTimeVarsDistinct simplifiedFormula
+         else simplifiedFormula
 
-{-fm = case parseString [] "" plainFormula $ render $ prettyGuarded gf of
-       Left e -> error (show e ++ render (prettyGuarded gf))
-       Right fm' -> fm' --- trace (show $ render $ prettyGuarded $ formulaToGuarded_ rstr._rstrFormula) $ fm'
-transformWithPullnots f = case pullnots f of
-    Left _ -> f
-    Right f' -> f'
-gf = formulaToGuarded_ $ transformWithPullnots $ transformWithStamps rstr._rstrFormula-}
+    -- Check if a formula has a problematic negation (negated event at top level)
+    hasProblematicNegation (Not f) = hasEventAnywhere f
+    hasProblematicNegation _ = False
 
--- | Printer for reuse/src lemmas.
+    hasEventAnywhere (Ato (Action _ _)) = True
+    hasEventAnywhere (Not f) = hasEventAnywhere f
+    hasEventAnywhere (Conn _ f1 f2) = hasEventAnywhere f1 || hasEventAnywhere f2
+    hasEventAnywhere (Qua _ _ f) = hasEventAnywhere f
+    hasEventAnywhere _ = False
+
+    -- Try to rewrite negated restrictions to positive form
+    -- Pattern: not((A@i & B@j) & (i ≠ j)) → (A@i & B@j) => (i = j)
+    -- Pattern: not(Ex... (A@i & A@j) & (i ≠ j)) → All... (A@i & A@j) => (i = j)
+    tryRewriteNegatedRestriction :: LNFormula -> Maybe LNFormula
+    tryRewriteNegatedRestriction (Not fm') = tryRewriteNegatedBody fm'
+    tryRewriteNegatedRestriction _ = Nothing
+
+    -- Try to rewrite the body of a negated formula
+    tryRewriteNegatedBody :: LNFormula -> Maybe LNFormula
+    -- not(Ex x. P) -> All x. not(P) ... but we need to rewrite not(P) further
+    tryRewriteNegatedBody (Qua Ex v f) = do
+      rewritten <- tryRewriteNegatedBody f
+      Just $ Qua All v rewritten
+    -- Pattern: not((P) & (i ≠ j)) -> P => (i = j)
+    -- Note: inequality (i ≠ j) is represented as Not (EqE i j)
+    tryRewriteNegatedBody (Conn And premise (Not (Ato (EqE t1 t2)))) =
+      Just $ Conn Imp premise (Ato (EqE t1 t2))
+    tryRewriteNegatedBody _ = Nothing
+
+-- | Printer for reuse/src lemmas as ProVerif axioms.
 -- | Different than ppLemma in that it ignores timepoints and does transformations custom to these lemmas.
-ppReuseSrcLemma :: TypingEnvironment -> Lemma ProofSkeleton -> Doc
-ppReuseSrcLemma te l =
-  text "(*"
+ppAxiomLemma :: S.Set String -> TypingEnvironment -> Lemma ProofSkeleton -> Doc
+ppAxiomLemma ruleIdEvents te l =
+  timepointComment
+    $$ text "(*"
     <> text l._lName
+    <> text " [reuse/source lemma translated as axiom]"
     <> text "*)"
-    $$ Precise.evalFresh (ppRestrictFormulaR RSL te fm) (avoidPrecise fm)
+    $$ if hasNestedImplicationInConjunction fm
+       then text "(* " <> prettyLNFormula l._lFormula <> text " *)"
+            $$ text "(* Formula has nested implications inside conjunctions (e.g., A => ((B => C) & D))."
+            $$ text "   This pattern cannot be soundly transformed to ProVerif's supported fragment."
+            $$ text "   The formula is outside the supported ProVerif fragment. *)"
+            $$ text ""
+       else if hasVariableCaptureInNestedImplication fm
+       then text "(* " <> prettyLNFormula l._lFormula <> text " *)"
+            $$ text "(* Formula has variable capture in nested quantified implications (e.g., A(x) => (All x. B => C))."
+            $$ text "   Flattening would change the semantics. *)"
+            $$ text ""
+       else if hasNegatedEventInFormula fm
+       then text "(* " <> prettyLNFormula l._lFormula <> text " *)"
+            $$ text "(* Axiom has negated event (not(...event...)) which is not supported in ProVerif. *)"
+            $$ text ""
+       else Precise.evalFresh (ppRestrictFormulaR RSL ruleIdEvents te fm "") (avoidPrecise fm)
   where
-    fm = allImplExLessWoTmps $ transformWithPullNots $ transformWithStamps l._lFormula
-
-{-fm = transformWithPullnots $ case parseString [] "" plainFormula $ render $ prettyGuarded gf of
-       Left _ -> error "should not happen"
-       Right fm' -> fm' --- trace (show $ render $ prettyGuarded $ formulaToGuarded_ rstr._rstrFormula) $ fm'
-transformWithPullnots f = case pullnots f of
-    Left _ -> f
-    Right f' -> f'
-gf = formulaToGuarded_ $ transformWithStamps l._lFormula-}
+    -- Apply same transformations as for restrictions
+    -- Order matters:
+    -- 1. First move negated actions from premise to conclusion BEFORE pullNots
+    --    (pullNots combines negations via De Morgan, making individual movement impossible)
+    -- 2. Then move constraints to conclusion
+    -- 3. Then apply pullNots to normalize negations
+    -- 4. Then flatten nested implications: A => (B => C) -> (A & B) => C
+    -- 5. Then expand negated timepoint comparisons: not(i < j) -> (j < i) | (i = j)
+    -- 6. Finally simplify
+    simplifiedFormula =
+      simplifyFormula
+        $ flattenNestedImplications
+        $ expandNegatedTimepointComparisons
+        $ transformWithPullNots
+        $ moveConstraintsToConclusion
+        $ moveNegatedActionsToConclusion l._lFormula
+    needsRuleId = formulaHasSharedTimepoints simplifiedFormula
+    timepointComment = if needsRuleId
+                       then text "(* Timepoints in lemma have been split *)\n"
+                       else text ""
+    fm = if needsRuleId
+         then makeTimeVarsDistinct simplifiedFormula
+         else simplifiedFormula
 
 -- Check if a formula is of the form "All x1 .. xn tA. A(x1 ... xn)@tA ==> not (Ex y1 ... yn tB. B(y1 ... yn)@tB)"
-allActImplsNotExAct :: LNFormula -> Bool
-allActImplsNotExAct (Qua All _ body) = allActImplsNotExAct body
-allActImplsNotExAct f@(Conn Imp p@(Ato at) (Not q)) = isActionAtom at && onlyEx q
+isAllActionsImpliesNotExists :: LNFormula -> Bool
+isAllActionsImpliesNotExists (Qua All _ body) = isAllActionsImpliesNotExists body
+isAllActionsImpliesNotExists (Conn Imp p (Not q)) = onlyActionAtoms p && hasOnlyExistentials q
   where
-    onlyEx (Qua Ex _ body') = onlyEx body'
-    onlyEx (Ato a) = isActionAtom a
-    onlyEx _ = False
-allActImplsNotExAct _ = False
-
--- Check if a formula is of the form "All x1 .. xn tA. A(x1 ... xn)@tA ==> Ex y1 ... yn tB. B(y1 ... yn)@tB"
--- We reject such formulas as lemmas/axioms/restrictions.
-allActImplsExAct :: LNFormula -> Bool
-allActImplsExAct (Qua All _ body) = allActImplsExAct body
-allActImplsExAct f@(Conn Imp p@(Ato at) q) = isActionAtom at && onlyEx q
-  where
-    onlyEx (Qua Ex _ body') = onlyEx body'
-    onlyEx (Ato a) = isActionAtom a
-    onlyEx _ = False
-allActImplsExAct _ = False
+    hasOnlyExistentials (Qua Ex _ body') = hasOnlyExistentials body'
+    hasOnlyExistentials (Ato a) = isActionAtom a
+    hasOnlyExistentials _ = False
+    -- Check if formula contains only action atoms (possibly connected by conjunctions)
+    onlyActionAtoms (Ato at) = isActionAtom at
+    onlyActionAtoms (Conn And p1 p2) = onlyActionAtoms p1 && onlyActionAtoms p2
+    onlyActionAtoms _ = False
+isAllActionsImpliesNotExists _ = False
 
 -- Check if a formula is of the form "All x1 .. xn tA. A(x1 ... xn)@tA ==> Ex y1 ... yn tB. B(y1 ... yn)@tB & tB < tA"
 -- If so, remove the less (it's implicit as we translate to a basic correspondence).
 allImplExLessWoTmps :: LNFormula -> LNFormula
 allImplExLessWoTmps (Qua All x p) = Qua All x $ allImplExLessWoTmps p
 allImplExLessWoTmps (Conn Imp (Ato (Action tA fA)) q) = Conn Imp (Ato (Action tA fA)) $ case q of
-  (Qua Ex x p) -> Qua Ex x $ onlyEx p
+  (Qua Ex x p) -> Qua Ex x $ hasOnlyExistentials p
   f -> f
   where
-    onlyEx (Qua Ex x p) = Qua Ex x $ onlyEx p
-    onlyEx f@(Conn And (Ato (Action tB fB)) (Ato (Less tB' tA'))) = if tA == tA' && tB == tB' then Ato (Action tB fB) else f
-    onlyEx f = f
+    hasOnlyExistentials (Qua Ex x p) = Qua Ex x $ hasOnlyExistentials p
+    hasOnlyExistentials f@(Conn And (Ato (Action tB fB)) (Ato (Less tB' tA'))) = if tA == tA' && tB == tB' then Ato (Action tB fB) else f
+    hasOnlyExistentials f = f
 allImplExLessWoTmps f = f
 
-transformWithStamps :: LNFormula -> LNFormula
-transformWithStamps f = if snd $ go False f then forAll ("st0", LSortFresh) (LVar "st0" LSortFresh 0) $ forAll ("st1", LSortFresh) (LVar "st1" LSortFresh 1) $ fst $ go False f else fst $ go False f
+-- | Check if a formula contains a negated action that will produce not(event(...)) in ProVerif.
+-- This is used for lemmas/queries where the formula to translate has a negation that can't be
+-- stripped (unlike Not (Qua Ex ...) which is handled specially).
+--
+-- The key patterns that produce invalid ProVerif:
+-- - Not (Ato (Action ...)) - bare negated action
+-- - Not (Qua All _ body) where body contains actions - renders as not(event(...))
+hasNegatedActionInFormula :: LNFormula -> Bool
+hasNegatedActionInFormula (Not (Ato (Action _ _))) = True
+hasNegatedActionInFormula (Not (Qua All _ body)) = containsAction body
   where
-    go False (Qua All s fm) = (Qua All s $ fst $ go False fm, snd recCall)
-      where
-        recCall = go False fm
-    go False fm@(Conn Imp (Conn And l r) tmpEq) = case (l, r, tmpEq) of
-      (Ato (Action i1 (Fact (ProtoFact m1 name1 arr1) ann1 ts1)), Ato (Action i2 (Fact (ProtoFact m2 name2 arr2) ann2 ts2)), Ato (EqE t1 t2)) ->
-        -- matches both OnlyOnce and Unique restriction types
-        if ((i2 == t1 && i1 == t2) || (i1 == t1 && i2 == t2)) && name1 == name2
-          then (Conn Imp (Conn And l' r') tmpEq', True)
-          else (fm, False)
-        where
-          l' = Ato (Action i1 (Fact (ProtoFact m1 (newName name1) (arr1 + 1)) ann1 (varTerm (Free $ LVar "st0" LSortFresh 0) : ts1)))
-          r' = Ato (Action i2 (Fact (ProtoFact m2 (newName name2) (arr2 + 1)) ann2 (varTerm (Free $ LVar "st1" LSortFresh 1) : ts2)))
-          tmpEq' = Ato (EqE (varTerm (Free $ LVar "st0" LSortFresh 0)) (varTerm (Free $ LVar "st1" LSortFresh 1)))
-          newName "OnlyOnce" = "OnlyOnce"
-          newName name = "U" ++ name
-      (Conn And (Ato (Action i1 (Fact (ProtoFact m1 name1 arr1) ann1 ts1))) (Ato (Action i2 (Fact (ProtoFact m2 name2 arr2) ann2 _))), Ato (EqE tA tB), Ato (EqE t1 t2)) ->
-        -- handle the OnlyOnce variant with A=B in addition to the OnlyOnces
-        if ((i2 == t1 && i1 == t2) || (i1 == t1 && i2 == t2)) && name1 == name2 -- hacky, but ProVerif does not have a problem with the dangling B
-          then (Conn Imp (Conn And l' r') tmpEq', True)
-          else (fm, False)
-        where
-          l' = Ato (Action i1 (Fact (ProtoFact m1 "OnlyOnce" (arr1 + 1)) ann1 (varTerm (Free $ LVar "st0" LSortFresh 0) : ts1)))
-          r' = Ato (Action i2 (Fact (ProtoFact m2 "OnlyOnce" (arr2 + 1)) ann2 (varTerm (Free $ LVar "st1" LSortFresh 1) : ts1)))
-          tmpEq' = Ato (EqE (varTerm (Free $ LVar "st0" LSortFresh 0)) (varTerm (Free $ LVar "st1" LSortFresh 1)))
-      _ -> (fm, False)
-    go _ fm = (fm, False)
+    containsAction (Ato (Action _ _)) = True
+    containsAction (Qua All _ b) = containsAction b
+    containsAction (Qua Ex _ b) = containsAction b
+    containsAction (Conn _ p q) = containsAction p || containsAction q
+    containsAction _ = False
+-- Recurse through quantifiers and connectives to find nested negated actions
+hasNegatedActionInFormula (Qua _ _ body) = hasNegatedActionInFormula body
+hasNegatedActionInFormula (Conn _ p q) = hasNegatedActionInFormula p || hasNegatedActionInFormula q
+hasNegatedActionInFormula _ = False
 
-loadRestrictions ::
-  TranslationContext ->
-  TypingEnvironment ->
-  OpenTheory ->
-  [Doc]
-loadRestrictions _ te thy = map (ppRestr te) thyRestrs
+-- | Check if a formula has a negated action that cannot be translated to ProVerif.
+-- The pattern Not (Qua Ex ...) at the TOP level is fine - it becomes a reachability query
+-- with a "leading negation" comment. What we need to reject is negated actions
+-- INSIDE a query body, like: A ==> not(Ex x. B(x)@i) where the negation is in the conclusion
+-- of an implication, or bare Not (Ato (Action _ _)).
+--
+-- NOTE: For queries, Not (Qua Ex _ body) is VALID and handled by renderFormula which
+-- strips the Not and emits the inner existential as a reachability query.
+hasTopLevelNegatedAction :: LNFormula -> Bool
+hasTopLevelNegatedAction (Not (Ato (Action _ _))) = True
+-- Not (Qua Ex ...) at the very top level is fine - it's handled as a leading negation query
+-- We only need to check inside quantifiers or connectives
+hasTopLevelNegatedAction (Qua All _ body) = hasTopLevelNegatedAction body
+hasTopLevelNegatedAction (Qua Ex _ body) = hasTopLevelNegatedAction body
+hasTopLevelNegatedAction (Conn And p q) = hasTopLevelNegatedAction p || hasTopLevelNegatedAction q
+hasTopLevelNegatedAction (Conn Or p q) = hasTopLevelNegatedAction p || hasTopLevelNegatedAction q
+-- Check for negated events inside implications (conclusion)
+hasTopLevelNegatedAction (Conn Imp _ concl) = hasNegatedEventInConclusion concl
   where
-    thyRestrs = theoryRestrictions thy
+    -- Check if conclusion contains a negated event that ProVerif can't handle
+    hasNegatedEventInConclusion (Not (Ato (Action _ _))) = True
+    hasNegatedEventInConclusion (Not (Qua Ex _ _)) = True  -- not(Ex ...) in conclusion is problematic
+    hasNegatedEventInConclusion (Conn And p q) = hasNegatedEventInConclusion p || hasNegatedEventInConclusion q
+    hasNegatedEventInConclusion (Conn Or p q) = hasNegatedEventInConclusion p || hasNegatedEventInConclusion q
+    hasNegatedEventInConclusion _ = False
+hasTopLevelNegatedAction _ = False
 
-findActsByTmp :: (Eq t) => [GAtom t] -> t -> [GAtom t]
-findActsByTmp (a : as) tmp = case a of
-  GEqE _ _ -> findActsByTmp as tmp
-  GAction t _ -> if t == tmp then a : findActsByTmp as tmp else findActsByTmp as tmp
-findActsByTmp [] _ = []
+loadRestrictions :: S.Set String -> TranslationContext -> TypingEnvironment -> OpenTheory -> ([Doc], S.Set ProVerifHeader)
+loadRestrictions sharedEventTags _ te thy =
+  let rs = theoryRestrictions thy
+      docs = map (ppRestr sharedEventTags te) rs
+      allFacts = concatMap (formulaFacts . L.get rstrFormula) rs
+      validFacts =
+        [ f | f@(Fact tag _ _) <- allFacts, factTagName tag `notElem` ["OnlyOnce", "DistinctFact"]
+        ]
+      headers = makeEventHeaders sharedEventTags validFacts
+   in (docs, headers)
 
-{-modifyAtoms :: ((Integer, Atom (VTerm Name (BVar LVar))) -> (Integer, Atom (VTerm Name (BVar LVar)))) -> (Integer, LNGuarded) -> (Integer, LNGuarded)
-modifyAtoms f (i, GDisj d) = (i, GDisj $ Disj $ map (\a -> snd $ modifyAtoms f (i,a)) $ getDisj d)
-modifyAtoms f (i, GConj c) = (i, GConj $ Conj $ map (\a -> snd $ modifyAtoms f (i,a)) $ getConj c)
-modifyAtoms f (i, GGuarded q vs gas gf) = case q of
-                                            All -> (i, GGuarded q vs (modifiedAtoms i gas) (snd $ modifyAtoms f (i, gf)))
-                                            Ex -> (i, GGuarded q vs gas gf)
-    where
-        modifiedAtoms ind = snd . foldl (\(i, acc) a -> (fst (f (i, a)), acc ++ [snd (f (i, a))])) (ind, [])
-        -- modifiedFormulas ind = snd . foldl (\(i, acc) a -> (fst (modifyAtoms i a), acc ++ [snd (modifyAtoms i a)])) (ind, [])
-modifyAtoms f (i, GAto a) = (i, GAto $ snd $ f (i, a))
-
-modifyOnlyOnceAtom :: Integer -> Atom (VTerm Name (BVar LVar)) -> Atom (VTerm Name (BVar LVar))
-modifyOnlyOnceAtom i a = case a of
-                            Action t f -> case f of
-                                              Fact (ProtoFact m "OnlyOnce" arr) ann ts -> Action t (Fact (ProtoFact m "OnlyOnce" (arr+1)) ann (varTerm (Bound i):ts))
-                                              _ -> a
-                            _ -> a
-
-modifyOnlyOnceEqe :: Integer -> Atom (VTerm Name (BVar LVar)) -> Atom (VTerm Name (BVar LVar))
-modifyOnlyOnceEqe i a = case a of
-                            EqE t1 t2 -> if True then EqE (varTerm (Bound (i-1))) (varTerm (Bound i)) else a
-                            _ -> a
-
-varVecLen :: LNGuarded -> Integer
-varVecLen (GGuarded _ vs _ _) = genericLength vs
-varVecLen _ = 0-}
-
-{-modifyAtoms :: LNFormula -> LNFormula
-modifyAtoms = mapAtoms (\_ a -> case a of
-                                       Action _ f -> case f of
-                                                         Fact tag an terms -> case tag of
-                                                             ProtoFact _ "OnlyOnce" _ -> ProtoFact _ "OnlyOnce" _
-                                                             _ -> a
-                                                         _ -> a
-                                       _ -> a)-}
+-- | Detect events that share timepoints in restrictions
+detectSharedTimepointEventsRestrictions :: [Restriction] -> S.Set String
+detectSharedTimepointEventsRestrictions restrictions =
+  S.unions $ map (eventsSharingTimepoints . _rstrFormula) restrictions

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -880,7 +880,7 @@ ppSapic tc (ProcessComb (Cond a) _ pl pr) =
     ppFact' p =
       case expandFormula (predicates tc) (toLFormula p) of
         Left _ -> translationFail "Export does not support tamarin predicates in conditionnals."
-        Right form -> (fst . snd $ Precise.evalFresh (ppLFormula emptyTypeEnv (ppNAtom S.empty) form) (avoidPrecise form), S.empty)
+        Right form -> (fst . snd $ Precise.evalFresh (ppLFormula emptyTypeEnv (ppNAtom M.empty S.empty) form) (avoidPrecise form), S.empty)
     addElseBranch (d, s) = case pr of
       ProcessNull _ -> (d, s)
       _ ->
@@ -1046,7 +1046,7 @@ addAttackerReportProc tc thy p =
         theoryPredicates thy
     (_, (formula, _)) = case reportPreds of
       Nothing -> translationFail "Translation Error, the Report predicate must be defined."
-      Just (Predicate _ form) -> Precise.evalFresh (ppLFormula emptyTypeEnv (ppNAtom S.empty) form) (avoidPrecise form)
+      Just (Predicate _ form) -> Precise.evalFresh (ppLFormula emptyTypeEnv (ppNAtom M.empty S.empty) form) (avoidPrecise form)
 
 ------------------------------------------------------------------------------
 -- Main printer for processes
@@ -1183,6 +1183,7 @@ typeVarsEvent TypingEnvironment {events = ev} tag ts =
 
 ppProtoAtom ::
   (HighlightDocument d, Ord k, Show k, Show c) =>
+  (Term (Lit c k) -> Maybe d) -> -- per-occurrence rule-id variable of a timepoint variable, if any
   S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
   Bool ->
@@ -1190,7 +1191,7 @@ ppProtoAtom ::
   (Term (Lit c k) -> d) ->
   ProtoAtom s (Term (Lit c k)) ->
   (d, M.Map k SapicType)
-ppProtoAtom ruleIdEvents te _ _ ppT (Action v f@(Fact tag _ ts))
+ppProtoAtom ridOf ruleIdEvents te _ _ ppT (Action v f@(Fact tag _ ts))
   | factTagArity tag /= length ts = translationFail $ "MALFORMED function" ++ show tag
   | (tag == KUFact) || isKLogFact f -- treat KU() and K() facts the same
     =
@@ -1208,25 +1209,37 @@ ppProtoAtom ruleIdEvents te _ _ ppT (Action v f@(Fact tag _ ts))
     useRuleId = factName `S.member` ruleIdEvents
     ppFactL n t = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ map ppT t
     eventArgs n t
-      | useRuleId = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ (text "rid" : map ppT t)
+      | useRuleId = nestShort' (n ++ "(") ")" . fsep . punctuate comma $ (ridDoc : map ppT t)
       | otherwise = ppFactL n t
-ppProtoAtom _ _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
-ppProtoAtom _ _ False _ ppT (EqE l r) =
-  (sep [ppT l <-> opEqual, ppT r], M.empty)
-ppProtoAtom _ _ True _ ppT (EqE l r) =
-  (sep [ppT l <-> text "<>", ppT r], M.empty)
+    ridDoc = fromMaybe (text "rid") (ridOf v)
+ppProtoAtom _ _ _ _ ppS _ (Syntactic s) = (ppS s, M.empty)
+-- A temporal equality between rule-id instrumented events is translated as an
+-- equality of their rule-id variables: distinct ProVerif events never share a
+-- timepoint, while in Tamarin equal timepoints mean "same rule instance".
+ppProtoAtom ridOf _ _ False _ ppT (EqE l r) =
+  case (ridOf l, ridOf r) of
+    (Just dl, Just dr) -> (sep [dl <-> opEqual, dr], M.empty)
+    _ -> (sep [ppT l <-> opEqual, ppT r], M.empty)
+ppProtoAtom ridOf _ _ True _ ppT (EqE l r) =
+  case (ridOf l, ridOf r) of
+    (Just dl, Just dr) -> (sep [dl <-> text "<>", dr], M.empty)
+    _ -> (sep [ppT l <-> text "<>", ppT r], M.empty)
 -- sep [ppNTerm l <-> text "≈", ppNTerm r]
-ppProtoAtom _ _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
-ppProtoAtom _ _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
-ppProtoAtom _ _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
+ppProtoAtom _ _ _ _ _ ppT (Less u v) = (ppT u <-> opLess <-> ppT v, M.empty)
+ppProtoAtom _ _ _ _ _ ppT (Subterm u v) = (text "subterm(" <> ppT u <> comma <> ppT v <> text ")", M.empty)
+ppProtoAtom _ _ _ _ _ _ (Last i) = (operator_ "last" <> parens (text (show i)), M.empty)
 
-ppAtom :: S.Set String -> TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
-ppAtom ruleIdEvents te b = ppProtoAtom ruleIdEvents te b (const emptyDoc)
+ppAtom :: M.Map String String -> S.Set String -> TypingEnvironment -> Bool -> (LNTerm -> Doc) -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppAtom ridNames ruleIdEvents te b = ppProtoAtom ridOf ruleIdEvents te b (const emptyDoc)
+  where
+    ridOf t = case viewTerm t of
+      Lit (Var (LVar n LSortNode _)) -> text <$> M.lookup n ridNames
+      _ -> Nothing
 
 -- only used for ProVerif queries display
 -- the Bool is set to False when we must negate the atom
-ppNAtom :: S.Set String -> TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
-ppNAtom ruleIdEvents te b = ppAtom ruleIdEvents te b (fst . ppLNTerm emptyTC)
+ppNAtom :: M.Map String String -> S.Set String -> TypingEnvironment -> Bool -> ProtoAtom s LNTerm -> (Doc, M.Map LVar SapicType)
+ppNAtom ridNames ruleIdEvents te b = ppAtom ridNames ruleIdEvents te b (fst . ppLNTerm emptyTC)
 
 mapLits :: (Ord a, Ord b) => (a -> b) -> Term a -> Term b
 mapLits f t = case viewTerm t of
@@ -1308,17 +1321,27 @@ countQuantifierAlternations = go Nothing
     go ctx (Conn _ p q) = max (go ctx p) (go ctx q)
 
 ppQueryFormula ::
-  (MonadFresh m, Functor s) =>
+  (MonadFresh m) =>
+  M.Map String String ->
   S.Set String ->
   TypingEnvironment ->
-  ProtoFormula s (String, LSort) Name LVar ->
+  ProtoFormula Unit2 (String, LSort) Name LVar ->
   [LVar] ->
   String ->
   m Doc
-ppQueryFormula ruleIdEvents te fm extravs attrs = do
-  (vs, (p, typeVars)) <- ppLFormula te (ppNAtom ruleIdEvents) fm
-  let includeRuleId = formulaUsesRuleIdEvents ruleIdEvents fm
+ppQueryFormula ridNames ruleIdEvents te fm extravs attrs = do
+  (vs, (p, typeVars)) <- ppLFormula te (ppNAtom ridNames ruleIdEvents) fm
+  -- The shared "rid" variable is needed for rule-id instrumented events
+  -- without a per-occurrence rule-id variable (see ridOccurrenceNames);
+  -- the per-occurrence variables are declared separately below.
+  let includeRuleId
+        | M.null ridNames = formulaUsesRuleIdEvents ruleIdEvents fm
+        | otherwise =
+            any
+              (\(tv, tag) -> tag `S.member` ruleIdEvents && tv `M.notMember` ridNames)
+              (collectEventTimeVars fm)
   let ruleIdVar = text "rid:bitstring"
+  let ridEqVars = [text (n ++ ":bitstring") | n <- S.toList . S.fromList $ M.elems ridNames]
   let allVarsList = S.toList . S.fromList $ extravs ++ vs
   -- Check for name collisions between term and timepoint variables
   -- In Tamarin, t and #t are different, but in ProVerif they'd both be 't'
@@ -1331,9 +1354,7 @@ ppQueryFormula ruleIdEvents te fm extravs attrs = do
     else do
       let allVars = map (ppTimeTypeVar typeVars) allVarsList
       let quantifiedVars =
-            if includeRuleId
-              then ruleIdVar : allVars
-              else allVars
+            [ruleIdVar | includeRuleId] ++ ridEqVars ++ allVars
       let queryLine =
             case quantifiedVars of
               [] -> text "query;"
@@ -1352,17 +1373,18 @@ ppTimeTypeVar te lvar =
     Nothing -> ppLVar lvar <> text ":bitstring"
     Just t -> ppLVar lvar <> text ":" <> text (ppType t)
 
-ppQueryFormulaEx :: S.Set String -> TypingEnvironment -> LNFormula -> [LVar] -> String -> Doc
-ppQueryFormulaEx ruleIdEvents te fm vs attrs =
-  Precise.evalFresh (ppQueryFormula ruleIdEvents te fm vs attrs) (avoidPrecise fm)
+ppQueryFormulaEx :: M.Map String String -> S.Set String -> TypingEnvironment -> LNFormula -> [LVar] -> String -> Doc
+ppQueryFormulaEx ridNames ruleIdEvents te fm vs attrs =
+  Precise.evalFresh (ppQueryFormula ridNames ruleIdEvents te fm vs attrs) (avoidPrecise fm)
 
 ppRestrictFormula ::
+  M.Map String String ->
   S.Set String ->
   TypingEnvironment ->
   ProtoFormula Unit2 (String, LSort) Name LVar ->
   String ->
   Precise.FreshT Data.Functor.Identity.Identity (Doc, Bool)
-ppRestrictFormula ruleIdEvents te frm attrs =
+ppRestrictFormula ridNames ruleIdEvents te frm attrs =
   if any (\(Fact tag _ _) -> factTagName tag == "KU") $ formulaFacts frm
     then -- todo: Add all translation warnings to the wellformedness report.
       pure (ppFail (Just "lemma contains KU fact") frm, False)
@@ -1395,7 +1417,7 @@ ppRestrictFormula ruleIdEvents te frm attrs =
       (_, _, fm') <- openFormulaPrefix fm
       handleUniversalFormula fm fm'
     renderFormula fm = pure (ppFail (Just "Lemma outside of logic fragment") fm, False)
-    ppOk f l = ppQueryFormulaEx ruleIdEvents te f l attrs
+    ppOk f l = ppQueryFormulaEx ridNames ruleIdEvents te f l attrs
     ppFail Nothing fm = text "(* Lemma outside of logic fragment *)" $$ text "(*" <> prettyLNFormula fm <> text "*)"
     ppFail (Just reason) fm = text "(*" <> text reason <> text "*)" $$ text "(*" <> prettyLNFormula fm <> text "*)"
 
@@ -1461,15 +1483,19 @@ ppLemma ruleIdEvents te p =
     -- Finally applies pnf to flatten nested quantifiers (e.g., Ex x. A & Ex y. B -> Ex x y. A & B)
     --
     -- Order of transformations:
-    -- 1. Eliminate double negations
-    -- 2. Convert negated existentials with time constraints to implications
+    -- 1. Eliminate temporal equality constraints by unifying the equated
+    --    timepoints (Ex #j. B@j & #i=#j → B@i), so the shared-timepoint
+    --    splitting applies to them
+    -- 2. Eliminate double negations
+    -- 3. Convert negated existentials with time constraints to implications
     --    (not(Ex vars. A & not(#i=#j)) → All vars. A ==> #i=#j)
-    -- 3. Move negated actions from premise to conclusion (enables pattern matching)
-    -- 4. Classify formula shape
-    -- 5. Apply shape-specific transformation
-    -- 6. Flatten nested quantifiers
+    -- 4. Move negated actions from premise to conclusion (enables pattern matching)
+    -- 5. Classify formula shape
+    -- 6. Apply shape-specific transformation
+    -- 7. Flatten nested quantifiers
     applyRewriteTransformations fm =
-      let fm1 = eliminateDoubleNegations fm
+      let fm0 = eliminateTemporalEqualities fm
+          fm1 = eliminateDoubleNegations fm0
           -- Move negated actions/existentials from premise to conclusion FIRST
           -- This transforms: (not(Ex r. A@r) & B@i) ==> C into B@i ==> (C | (Ex r. A@r))
           -- This MUST run before convertNegExWithTimeConstraint so that not(Ex...) in premise
@@ -1524,7 +1550,14 @@ ppLemma ruleIdEvents te p =
     hasNestedEx (Conn And left right) = hasNestedEx left || hasNestedEx right
     hasNestedEx _ = False
 
-    formula f' = Precise.evalFresh (ppRestrictFormula ruleIdEvents te f' useInduction) (avoidPrecise f')
+    -- Rule-id instrumented events get per-occurrence rule-id variables, and
+    -- temporal equalities that survive rewriting are translated as rule-id
+    -- equalities. Lemmas whose timepoints were split keep the shared "rid"
+    -- scheme throughout, since the split copies are tied together by that
+    -- shared variable.
+    formula f' =
+      let ridNames = if hadTimepointSplit then M.empty else ridOccurrenceNames ruleIdEvents f'
+       in Precise.evalFresh (ppRestrictFormula ridNames ruleIdEvents te f' useInduction) (avoidPrecise f')
 
     -- Lemma name comment (always shown)
     lemmaNameComment = text "(*" <> text p._lName <> text "*)"
@@ -1728,6 +1761,166 @@ transformWithPullNots f = case pullNegationsToTop f of
 -- ===========================================================================
 -- SECTION 9: Timepoint Variable Handling
 -- ===========================================================================
+
+-- | Eliminate temporal equality constraints by unifying the equated timepoint
+-- variables (one-point rule). In Tamarin, @Ex #j. B()\@j & #i = #j@ is
+-- equivalent to @B()\@i@; rewriting the explicit-equality form into the
+-- shared-variable form lets the shared-timepoint splitting (rule-id
+-- instrumentation) apply, instead of leaving behind an equality between two
+-- distinct ProVerif timepoints, which is never satisfiable there (every
+-- ProVerif event has a unique timepoint).
+-- Dually for universals: @All #j. (A()\@j & #i = #j) ==> C@ becomes
+-- @A()\@i ==> C@. Both rewrites are equivalences, so they are sound at any
+-- polarity.
+eliminateTemporalEqualities :: LNFormula -> LNFormula
+eliminateTemporalEqualities fm0 =
+  let fm' = go fm0
+   in if fm' == fm0 then fm0 else simplifyFormula fm'
+  where
+    go (Qua q v@(_, LSortNode) body) =
+      let body' = go body
+       in case pinningEq q body' of
+            Just repl -> substituteBinder repl body'
+            Nothing -> Qua q v body'
+    go (Qua q v body) = Qua q v (go body)
+    go (Conn c p q) = Conn c (go p) (go q)
+    go (Not p) = Not (go p)
+    go fm = fm
+
+    -- Find an equality that pins the binder being eliminated (Bound 0 at the
+    -- binder level) to a variable bound outside of it, in a position where the
+    -- equality is definite: a positive conjunct under an existential,
+    -- respectively a positive premise conjunct of the implication under a
+    -- universal. Returns the replacement variable, indexed relative to the
+    -- position of the binder with the binder itself removed.
+    pinningEq :: Quantifier -> LNFormula -> Maybe (BVar LVar)
+    pinningEq Ex body = findPin 0 body
+    pinningEq All body = descendAll 0 body
+      where
+        descendAll d (Qua All _ b) = descendAll (d + 1) b
+        descendAll d (Conn Imp prem _) = findPin d prem
+        descendAll _ _ = Nothing
+
+    -- Search positive conjunct positions (through conjunctions and nested
+    -- existentials) at depth d below the binder being eliminated.
+    findPin :: Integer -> LNFormula -> Maybe (BVar LVar)
+    findPin d (Conn And p q) = findPin d p `orElse` findPin d q
+    findPin d (Qua Ex _ p) = findPin (d + 1) p
+    findPin d (Ato (EqE s t)) = pin d s t `orElse` pin d t s
+    findPin _ _ = Nothing
+
+    pin d s t = case (viewTerm s, viewTerm t) of
+      (Lit (Var (Bound i)), Lit (Var other))
+        | i == d -> case other of
+            Bound k | k > d -> Just (Bound (k - d - 1))
+            Free v | lvarSort v == LSortNode -> Just (Free v)
+            _ -> Nothing
+      _ -> Nothing
+
+    orElse m@(Just _) _ = m
+    orElse Nothing n = n
+
+    -- Substitute the eliminated binder by repl (indexed relative to the
+    -- binder's position, with the binder itself already removed) and shift the
+    -- indices of all enclosing binders down accordingly. The pinning equality
+    -- itself becomes trivial (t = t) and is removed by the final
+    -- simplifyFormula.
+    substituteBinder :: BVar LVar -> LNFormula -> LNFormula
+    substituteBinder repl = mapAtoms (\d a -> fmap (mapLits (fmap (adjust d))) a)
+      where
+        adjust d (Bound i)
+          | i == d = case repl of
+              Bound r -> Bound (r + d)
+              Free v -> Free v
+          | i > d = Bound (i - 1)
+        adjust _ v = v
+
+-- | Resolve a timepoint term to its variable name if it is a node-sorted
+-- variable: bound (resolved through the given quantifier context) or free.
+timeVarNameIn :: [(String, LSort)] -> VTerm Name (BVar LVar) -> Maybe String
+timeVarNameIn ctx t = case viewTerm t of
+  Lit (Var (Bound i)) -> case drop (fromIntegral i) ctx of
+    (n, LSortNode) : _ -> Just n
+    _ -> Nothing
+  Lit (Var (Free v)) | lvarSort v == LSortNode -> Just (lvarName v)
+  _ -> Nothing
+
+-- | Collect (time variable name, fact tag name) pairs for all action atoms
+-- that are translated to ProVerif events (i.e. excluding K/KU facts).
+collectEventTimeVars :: LNFormula -> [(String, String)]
+collectEventTimeVars = go []
+  where
+    go ctx (Ato (Action tv f@(Fact tag _ _)))
+      | tag == KUFact || isKLogFact f = []
+      | otherwise = maybe [] (\n -> [(n, factTagName tag)]) (timeVarNameIn ctx tv)
+    go ctx (Not p) = go ctx p
+    go ctx (Conn _ p q) = go ctx p ++ go ctx q
+    go ctx (Qua _ v p) = go (v : ctx) p
+    go _ _ = []
+
+-- | Collect pairs of time-variable names linked by a temporal equality:
+-- an equality atom #i = #j (possibly negated), or a negated strict
+-- comparison not(#i < #j), which is expanded later into a disjunction
+-- containing the equality.
+collectTemporalEqPairs :: LNFormula -> [(String, String)]
+collectTemporalEqPairs = go []
+  where
+    go ctx (Ato (EqE l r)) = pairOf ctx l r
+    go ctx (Not (Ato (Less l r))) = pairOf ctx l r
+    go ctx (Not p) = go ctx p
+    go ctx (Conn _ p q) = go ctx p ++ go ctx q
+    go ctx (Qua _ v p) = go (v : ctx) p
+    go _ _ = []
+
+    pairOf ctx l r = case (timeVarNameIn ctx l, timeVarNameIn ctx r) of
+      (Just a, Just b) | a /= b -> [(a, b)]
+      _ -> []
+
+-- | Per-occurrence rule-id variable names for rule-id instrumented events in
+-- formulas without split timepoints. The shared "rid" variable is only
+-- meaningful for split-timepoint groups, whose copies it ties to the same
+-- rule instance; reusing it across independent event occurrences would
+-- silently constrain them to the same rule instance. Instead, each event
+-- occurrence gets its own rule-id variable, named after its time variable.
+--
+-- This also gives temporal equalities that survive rewriting (e.g. in
+-- disjunctions such as at-or-before: #j < #i | #j = #i) a translation: in
+-- ProVerif, distinct events never share a timepoint, so a timepoint equality
+-- would be unsatisfiable there. Since in Tamarin equal timepoints mean "same
+-- rule instance", such an equality is translated as an equality between the
+-- rule-id variables of the two events instead.
+--
+-- Only time variables used by exactly one instrumented event are mapped;
+-- anything else falls back to the shared "rid" scheme.
+ridOccurrenceNames :: S.Set String -> LNFormula -> M.Map String String
+ridOccurrenceNames ruleIdEvents fm = M.fromSet ("rid_" ++) mapped
+  where
+    eventTVs = collectEventTimeVars fm
+    tagsOf n = [tag | (n', tag) <- eventTVs, n' == n]
+    mapped =
+      S.fromList
+        [ n
+        | (n, _) <- eventTVs,
+          case tagsOf n of
+            [tag] -> tag `S.member` ruleIdEvents
+            _ -> False
+        ]
+
+-- | Event tags linked by temporal equalities that survive rewriting; these
+-- need rule-id instrumentation so the equality can be translated as a
+-- rule-id equality (see 'ridEqualityNames').
+temporalEqualityLinkedEvents :: LNFormula -> S.Set String
+temporalEqualityLinkedEvents fm =
+  S.fromList $
+    concat
+      [ tagsOf a ++ tagsOf b
+      | (a, b) <- collectTemporalEqPairs fm,
+        not (null (tagsOf a)),
+        not (null (tagsOf b))
+      ]
+  where
+    eventTVs = collectEventTimeVars fm
+    tagsOf n = [tag | (n', tag) <- eventTVs, n' == n]
 
 -- | Make time variables distinct for each action occurrence in a formula.
 -- This ensures that events with shared timepoints in Tamarin get distinct time variables in ProVerif.
@@ -2396,7 +2589,15 @@ formulaUsesRuleIdEvents ruleIdEvents =
 -- Returns a set of fact tag names that need rule IDs.
 detectSharedTimepointEvents :: [ProtoLemma LNFormula ProofSkeleton] -> S.Set String
 detectSharedTimepointEvents lemmas =
-  S.unions $ map (eventsSharingTimepoints . L.get lFormula) lemmas
+  S.unions $ map (analyze . L.get lFormula) lemmas
+  where
+    -- Definite temporal equalities are eliminated by unifying the equated
+    -- timepoints, turning them into shared timepoints; equalities that
+    -- survive (e.g. in disjunctions) are translated as rule-id equalities,
+    -- so their events need rule-id instrumentation as well.
+    analyze fm =
+      let fm' = eliminateTemporalEqualities fm
+       in eventsSharingTimepoints fm' `S.union` temporalEqualityLinkedEvents fm'
 
 loadLemmas ::
   S.Set String ->  -- sharedEventTags: events that need rule IDs
@@ -3165,24 +3366,30 @@ ppLFormulaR keepTimeVars _ruleIdEvents te ppAt =
         pure (filter (\v -> keepTimeVars || lvarSort v /= LSortNode) (vs ++ vsp), d')
 
 ppQueryFormulaR ::
-  (MonadFresh m, Functor s) =>
+  (MonadFresh m) =>
   Bool -> -- True if we want to remove timepoint declarations.
   PVElement ->
+  M.Map String String ->
   S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
-  ProtoFormula s (String, LSort) Name LVar ->
+  ProtoFormula Unit2 (String, LSort) Name LVar ->
   [LVar] ->
   String ->
   m Doc
-ppQueryFormulaR keepTimeVars pe ruleIdEvents te fm extravs attrs = do
-  (vs, (p, typeVars)) <- ppLFormulaR keepTimeVars ruleIdEvents te (if keepTimeVars then ppNAtom ruleIdEvents else ppNAtomR ruleIdEvents) fm
-  let includeRuleId = formulaUsesRuleIdEvents ruleIdEvents fm
+ppQueryFormulaR keepTimeVars pe ridNames0 ruleIdEvents te fm extravs attrs = do
+  -- Per-occurrence rule-id variables only make sense while timepoints are kept.
+  let ridNames = if keepTimeVars then ridNames0 else M.empty
+  (vs, (p, typeVars)) <- ppLFormulaR keepTimeVars ruleIdEvents te (if keepTimeVars then ppNAtom ridNames ruleIdEvents else ppNAtomR ruleIdEvents) fm
+  let includeRuleId
+        | M.null ridNames = formulaUsesRuleIdEvents ruleIdEvents fm
+        | otherwise =
+            any
+              (\(tv, tag) -> tag `S.member` ruleIdEvents && tv `M.notMember` ridNames)
+              (collectEventTimeVars fm)
   let ruleIdVar = text "rid:bitstring"
+  let ridEqVars = [text (n ++ ":bitstring") | n <- S.toList . S.fromList $ M.elems ridNames]
   let allVars = map (ppTimeTypeVar typeVars) (S.toList . S.fromList $ extravs ++ vs)
-  let quantifiedVars =
-        if includeRuleId
-          then ruleIdVar : allVars
-          else allVars
+  let quantifiedVars = [ruleIdVar | includeRuleId] ++ ridEqVars ++ allVars
   pure $
     sep
       [ text word <> fsep (punctuate comma quantifiedVars) <> text ";",
@@ -3195,18 +3402,19 @@ ppQueryFormulaR keepTimeVars pe ruleIdEvents te fm extravs attrs = do
       R -> "restriction "
       RSL -> "axiom "
 
-ppQueryFormulaExR :: Bool -> PVElement -> S.Set String -> TypingEnvironment -> LNFormula -> [LVar] -> String -> Doc
-ppQueryFormulaExR keepTimeVars pe ruleIdEvents te fm vs attrs =
-  Precise.evalFresh (ppQueryFormulaR keepTimeVars pe ruleIdEvents te fm vs attrs) (avoidPrecise fm)
+ppQueryFormulaExR :: Bool -> PVElement -> M.Map String String -> S.Set String -> TypingEnvironment -> LNFormula -> [LVar] -> String -> Doc
+ppQueryFormulaExR keepTimeVars pe ridNames ruleIdEvents te fm vs attrs =
+  Precise.evalFresh (ppQueryFormulaR keepTimeVars pe ridNames ruleIdEvents te fm vs attrs) (avoidPrecise fm)
 
 ppRestrictFormulaR ::
   PVElement ->
+  M.Map String String ->
   S.Set String -> -- events requiring rule identifiers
   TypingEnvironment ->
   LNFormula ->
   String ->
   Precise.FreshT Data.Functor.Identity.Identity Doc
-ppRestrictFormulaR pe ruleIdEvents te frm attrs =
+ppRestrictFormulaR pe ridNames ruleIdEvents te frm attrs =
   if any (\(Fact tag _ _) -> factTagName tag == "KU") (formulaFacts frm) -- don't allow KU facts, nothing corresponding in PV
     || (hasLessOrTmpEqInPremise frm && not (hasDistinctFact frm)) -- by this point we have stripped the less if that was possible in the 1st place
     then pure $ ppFail frm
@@ -3259,7 +3467,7 @@ ppRestrictFormulaR pe ruleIdEvents te frm attrs =
       (_, _, fm') <- openFormulaPrefix fm
       handleUniversalFormula fm fm'
     pp fm = pure $ ppFail fm
-    ppOk f l = ppQueryFormulaExR keepTimeVars pe ruleIdEvents te f l attrs
+    ppOk f l = ppQueryFormulaExR keepTimeVars pe ridNames ruleIdEvents te f l attrs
       where
         keepTimeVars = case pe of
           R -> True
@@ -3378,7 +3586,7 @@ ppRestr ruleIdEvents te rstr =
          Just rewritten ->
            -- Successfully rewrote the negated restriction
            text "(* Original: " <> prettyLNFormula rstr._rstrFormula <> text " *)"
-           $$ Precise.evalFresh (ppRestrictFormulaR R ruleIdEvents te rewritten "") (avoidPrecise rewritten)
+           $$ Precise.evalFresh (ppRestrictFormulaR R (ridNamesFor rewritten) ruleIdEvents te rewritten "") (avoidPrecise rewritten)
          Nothing ->
            -- Check for unsupported patterns
            if hasNestedImplicationInConjunction fm
@@ -3396,16 +3604,18 @@ ppRestr ruleIdEvents te rstr =
            then text "(* " <> prettyLNFormula fm <> text " *)"
                 $$ text "(* Restriction has negated event which is not supported in ProVerif. *)"
                 $$ text ""
-           else Precise.evalFresh (ppRestrictFormulaR R ruleIdEvents te fm "") (avoidPrecise fm)
+           else Precise.evalFresh (ppRestrictFormulaR R (ridNamesFor fm) ruleIdEvents te fm "") (avoidPrecise fm)
   where
     -- Apply transformations for restrictions:
     -- 1. First simplify (converts A => F to Not A)
-    -- 2. Then move constraints to conclusion
-    -- 3. Then move negated actions to conclusion: (A & not(B)) => C -> A => (C | B)
-    -- 4. Then expand negated timepoint comparisons
-    -- 5. Then flatten nested implications: A => (B => C) -> (A & B) => C
+    -- 2. Then eliminate temporal equalities by unifying the equated timepoints
+    --    (must happen before constraints are moved to the conclusion)
+    -- 3. Then move constraints to conclusion
+    -- 4. Then move negated actions to conclusion: (A & not(B)) => C -> A => (C | B)
+    -- 5. Then expand negated timepoint comparisons
+    -- 6. Then flatten nested implications: A => (B => C) -> (A & B) => C
     --    (ProVerif doesn't allow nested implications in restrictions)
-    -- 6. Finally pull negations to top (converts All x. Not A to Not (Ex x. A))
+    -- 7. Finally pull negations to top (converts All x. Not A to Not (Ex x. A))
     -- This order is important: simplify first so A => F becomes Not A,
     -- then pullNegationsToTop can pull that Not to the top level
     simplifiedFormula =
@@ -3415,6 +3625,7 @@ ppRestr ruleIdEvents te rstr =
         $ expandNegatedTimepointComparisons
         $ moveNegatedActionsToConclusion
         $ moveConstraintsToConclusion
+        $ eliminateTemporalEqualities
         $ simplifyFormula rstr._rstrFormula
     needsRuleId = formulaHasSharedTimepoints simplifiedFormula
     timepointComment = if needsRuleId
@@ -3423,6 +3634,10 @@ ppRestr ruleIdEvents te rstr =
     fm = if needsRuleId
          then makeTimeVarsDistinct simplifiedFormula
          else simplifiedFormula
+    -- Per-occurrence rule-id variables (and rule-id equalities for surviving
+    -- temporal equalities, e.g. uniqueness restrictions on instrumented
+    -- events); split-timepoint restrictions keep the shared "rid" scheme.
+    ridNamesFor f = if needsRuleId then M.empty else ridOccurrenceNames ruleIdEvents f
 
     -- Check if a formula has a problematic negation (negated event at top level)
     hasProblematicNegation (Not f) = hasEventAnywhere f
@@ -3477,24 +3692,29 @@ ppAxiomLemma ruleIdEvents te l =
        then text "(* " <> prettyLNFormula l._lFormula <> text " *)"
             $$ text "(* Axiom has negated event (not(...event...)) which is not supported in ProVerif. *)"
             $$ text ""
-       else Precise.evalFresh (ppRestrictFormulaR RSL ruleIdEvents te fm "") (avoidPrecise fm)
+       else Precise.evalFresh (ppRestrictFormulaR RSL ridNames ruleIdEvents te fm "") (avoidPrecise fm)
   where
+    -- Per-occurrence rule-id variables, as for restrictions.
+    ridNames = if needsRuleId then M.empty else ridOccurrenceNames ruleIdEvents fm
     -- Apply same transformations as for restrictions
     -- Order matters:
-    -- 1. First move negated actions from premise to conclusion BEFORE pullNots
+    -- 1. First eliminate temporal equalities by unifying the equated timepoints
+    --    (must happen before constraints are moved to the conclusion)
+    -- 2. Then move negated actions from premise to conclusion BEFORE pullNots
     --    (pullNots combines negations via De Morgan, making individual movement impossible)
-    -- 2. Then move constraints to conclusion
-    -- 3. Then apply pullNots to normalize negations
-    -- 4. Then flatten nested implications: A => (B => C) -> (A & B) => C
-    -- 5. Then expand negated timepoint comparisons: not(i < j) -> (j < i) | (i = j)
-    -- 6. Finally simplify
+    -- 3. Then move constraints to conclusion
+    -- 4. Then apply pullNots to normalize negations
+    -- 5. Then flatten nested implications: A => (B => C) -> (A & B) => C
+    -- 6. Then expand negated timepoint comparisons: not(i < j) -> (j < i) | (i = j)
+    -- 7. Finally simplify
     simplifiedFormula =
       simplifyFormula
         $ flattenNestedImplications
         $ expandNegatedTimepointComparisons
         $ transformWithPullNots
         $ moveConstraintsToConclusion
-        $ moveNegatedActionsToConclusion l._lFormula
+        $ moveNegatedActionsToConclusion
+        $ eliminateTemporalEqualities l._lFormula
     needsRuleId = formulaHasSharedTimepoints simplifiedFormula
     timepointComment = if needsRuleId
                        then text "(* Timepoints in lemma have been split *)\n"
@@ -3592,4 +3812,4 @@ loadRestrictions sharedEventTags _ te thy =
 -- | Detect events that share timepoints in restrictions
 detectSharedTimepointEventsRestrictions :: [Restriction] -> S.Set String
 detectSharedTimepointEventsRestrictions restrictions =
-  S.unions $ map (eventsSharingTimepoints . _rstrFormula) restrictions
+  S.unions $ map (eventsSharingTimepoints . eliminateTemporalEqualities . _rstrFormula) restrictions

--- a/lib/export/src/Export.hs
+++ b/lib/export/src/Export.hs
@@ -117,11 +117,14 @@ buildDisjunction [] = TF False
 buildDisjunction [f] = f
 buildDisjunction fs = foldr1 (.||.) fs
 
--- | Wrap a formula with quantifiers of the given type.
--- Applies quantifiers from outer to inner (first element becomes outermost quantifier).
-wrapWithQuantifiers :: Quantifier -> [(String, LSort)] -> LNFormula -> LNFormula
-wrapWithQuantifiers _ [] body = body
-wrapWithQuantifiers q (v:vs) body = Qua q v (wrapWithQuantifiers q vs body)
+-- | Rebuild a quantifier prefix around a body that already contains the
+-- corresponding de Bruijn-bound variables. This deliberately uses 'Qua'
+-- directly: 'forAll' and 'exists' quantify free variables instead.
+-- Quantifiers are applied from outer to inner, so the first hint becomes the
+-- outermost quantifier.
+rewrapBoundPrefix :: Quantifier -> [(String, LSort)] -> LNFormula -> LNFormula
+rewrapBoundPrefix _ [] body = body
+rewrapBoundPrefix q (v:vs) body = Qua q v (rewrapBoundPrefix q vs body)
 
 -- | Check if a formula represents a valid existential disjunction pattern.
 -- Valid patterns include:
@@ -1290,8 +1293,7 @@ isQuantifierFree :: LNFormula -> Bool
 isQuantifierFree (Qua {}) = False
 isQuantifierFree (Ato _) = True
 isQuantifierFree (TF _) = True
-isQuantifierFree (Not (Ato (EqE _ _))) = True
-isQuantifierFree (Not _) = True
+isQuantifierFree (Not p) = isQuantifierFree p
 isQuantifierFree (Conn _ p q) = isQuantifierFree p && isQuantifierFree q
 
 -- | Count the number of quantifier alternations in a formula.
@@ -1731,7 +1733,7 @@ applyRewriteForShape shape fm = case shape of
             atoms = collectNegatedAtoms body
             -- Build the conjunction and wrap with existentials, then negate
             conjunction = buildConjunction atoms
-            existential = wrapWithQuantifiers Ex quants conjunction
+            existential = rewrapBoundPrefix Ex quants conjunction
         in Not existential
 
     collectQuantifiers :: LNFormula -> ([(String, LSort)], LNFormula)
@@ -2147,7 +2149,7 @@ convertNegExWithTimeConstraint fm = case fm of
             -- For #i < #j, conclusion is not(#i < #j) which we'll expand later
             conclusion = buildConclusionFromConstraints constraints
             -- Wrap with all the universal quantifiers (converted from existential)
-         in wrapWithQuantifiers All vars (Conn Imp premise conclusion)
+         in rewrapBoundPrefix All vars (Conn Imp premise conclusion)
       _ -> Not (convertNegExWithTimeConstraint fm')
 
   -- Recurse through other structures

--- a/lib/export/src/RuleTranslation.hs
+++ b/lib/export/src/RuleTranslation.hs
@@ -10,10 +10,12 @@
 -- Translation from multiset rewrite rules to ProVerif
 module RuleTranslation
   ( loadRules,
+    translateEmbeddedRuleAction,
     ppFunSym,
     sanitizeSymbol,
     replaceTrueFalse,
-    doubleFactInGuardsImpliesTmpEq,
+    makeEventHeaders,
+    multisetTheory
     -- , hasOnlyOnceFact
     -- , isOnlyOnceFact
   )
@@ -24,78 +26,165 @@ import Data.ByteString.Char8 qualified as BC
 import Data.Char
 import Data.List as List
 import Data.Map qualified as M
-import Data.Maybe (mapMaybe)
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.Set qualified as S
--- import Debug.Trace (trace)
 import Extension.Data.Label qualified as L
 import ProVerifHeader
 import Sapic.Exceptions
 import Sapic.Facts
 import Theory
 import Theory.Module
+import Theory.Text.Parser
 import Theory.Text.Pretty
 import TheoryObject (theoryMacros)
 
-loadRules :: OpenTheory -> ModuleType -> ([Doc], Doc, S.Set ProVerifHeader)
-loadRules thy m = case theoryRules thy of
-  [] -> ([], emptyDoc, S.empty)
+loadRules :: S.Set String -> OpenTheory -> ModuleType -> ([Doc], Doc, S.Set ProVerifHeader)
+loadRules ruleIdEvents thy m = case theoryRules thy of
+  [] -> ([text ""], text "", S.empty)
   rules -> (ruleDocs, ruleComb, headers)
     where
       (ruleDocs, destructors) =
-        foldl' (\acc@(_, destrs) r -> acc `combine2` translateOpenProtoRule r thy destrs) ([], M.empty) rulesMod
+        foldl' (\acc@(_, destrs) r -> acc `accumulateResult` translateOpenProtoRule ruleIdEvents r thy destrs) ([], M.empty) rulesMod
       headers = S.fromList (baseHeaders : desHeaders) `S.union` ruleHeaders
       baseHeaders = Sym "free" "publicChannel" ":channel" []
       desHeaders = map makeDestructorHeader $ M.toList destructors
-      ruleHeaders = foldMap (`makeHeadersFromRule` thy) rulesMod
+      ruleHeaders = foldMap (\r -> makeHeadersFromRule ruleIdEvents r thy) rulesMod
       ruleNames = map (\(OpenProtoRule ruE _) -> showRuleName ruE._rInfo._preName) rulesMod
       ruleComb = text ("( " ++ intercalate " | " (map ((++ ")") . ("!(" ++)) ruleNames) ++ " )")
       -- want to export restrictions and reuse/src lemmas => need to introduce fresh stamps (as there no timepoints in such formulas)
-      rulesMod = map (\(OpenProtoRule ruE rusAC) -> OpenProtoRule (applyMacroInRule (theoryMacros thy) $ ruE) rusAC) $ case m of
-        ModuleProVerif -> addUniqueActsAndStamps (uniqueAndOnlyOnceRestrActions thy) rules
+      rulesMod = map (\(OpenProtoRule ruE rusAC) -> OpenProtoRule (applyMacroInRule (theoryMacros thy) ruE) rusAC) $ case m of
+        ModuleProVerif -> rules
         _ -> error "Incompatible module!"
 
-uniqueAndOnlyOnceRestrActions :: OpenTheory -> [String]
-uniqueAndOnlyOnceRestrActions thy =
-  map (factTagName . factTag) $
-    concatMap getGuardFacts $
-      filter doubleFactInGuardsImpliesTmpEq $
-        map (formulaToGuarded_ . _rstrFormula) $
-          theoryRestrictions thy
+translateEmbeddedRuleAction ::
+  (HighlightDocument d) =>
+  S.Set String ->
+  [LNFact] ->
+  [LNFact] ->
+  [LNFact] ->
+  (d, S.Set ProVerifHeader, Bool)
+translateEmbeddedRuleAction matchedVars rprems racts rconcls =
+  (ruleDoc, headers, hasTailDocs)
   where
-    getGuardFacts (GGuarded _ _ as _) = [f | Action _ f <- as]
-    getGuardFacts _ = []
+    (headDocs, tailDocs, destructors) = translateRuleDocs S.empty Nothing matchedVars rprems racts rconcls M.empty
+    hasTailDocs = not (null tailDocs)
+    ruleDoc =
+      if hasTailDocs
+        then combineActionDocs headDocs tailDocs
+        else vcat headDocs
+    freeHeaders = makeFreeHeadersFromFacts rprems racts rconcls
+    tableHeaders = makeTableHeaders rprems rconcls
+    eventHeaders = makeEventHeaders S.empty racts
+    destructorHeaders = S.fromList $ map makeDestructorHeader (M.toList destructors)
+    headers =
+      S.unions
+        [ S.singleton (Sym "free" "publicChannel" ":channel" []),
+          freeHeaders,
+          tableHeaders,
+          eventHeaders,
+          destructorHeaders
+        ]
 
-doubleFactInGuardsImpliesTmpEq :: (Eq c, Eq v) => Guarded s c v -> Bool
-doubleFactInGuardsImpliesTmpEq (GGuarded _ _ as gf) =
-  case as of
-    [Action tmp1 (Fact tag1 _ _), Action tmp2 (Fact tag2 _ _)] ->
-      factTagName tag1 == factTagName tag2 && gfIsTmpEq tmp1 tmp2 gf
-    _ -> False
-  where
-    gfIsTmpEq t1 t2 (GAto (EqE t1' t2')) = (t1 == t1' && t2 == t2') || (t1 == t2' && t2 == t1')
-    gfIsTmpEq _ _ _ = False
-doubleFactInGuardsImpliesTmpEq _ = False
+-- Multiset semantics
+-- Steps:
+-- 1. For each non-persistent and non-output fact, create a fresh varible.
+--    - Add to each fact in conclusion
+--    - Add fresh facts to premise
+-- 2. For each fact in the premise that is non-persistent, non-fresh, and not the input fact, add stamp values.
+--  - For each of these facts add a DistinctFact event with the same arguments ensuring that they are only used once.
+-- 3. Add static restriction to theory.
 
-addUniqueActsAndStamps :: [String] -> [OpenProtoRule] -> [OpenProtoRule]
-addUniqueActsAndStamps rstrActs = map (((`OpenProtoRule` []) . modifyRule) . _oprRuleE)
+-- | Apply multisetSemantics to all rules in an OpenTheory
+mapRulesWithMultisetSemantics :: OpenTheory -> OpenTheory
+mapRulesWithMultisetSemantics =
+  L.modify thyItems (map updateRule)
   where
-    modifyRule ru = L.set rPrems newPrems $ L.set rActs newActs ru
-      where
-        (newActs, newPrems) = addUActBeforeAct rstrActs (L.get rActs ru, L.get rPrems ru)
-    addUActBeforeAct rsActs (acts, prems) =
-      (\(_, facts, vars) -> (sortOnlyOnceFirst facts, map frFactsFromVar vars ++ prems)) . foldr addUAct (1, [], []) $ acts
-      where
-        addUAct f@(Fact (ProtoFact m name arr) ann ts) (n, accFacts, accVars)
-          | name == "OnlyOnce" = (n + 1, Fact (ProtoFact m name (arr + 1)) ann (varTerm newVar : ts) : accFacts, newVar : accVars)
-          | name `elem` rsActs = (n + 1, Fact (ProtoFact m ("U" ++ name) (arr + 1)) ann (varTerm newVar : ts) : f : accFacts, newVar : accVars)
-          where
-            newVar = stampLVar n
-        addUAct f (n, accFacts, accVars) = (n, f : accFacts, accVars)
-    frFactsFromVar var = Fact FreshFact S.empty [varTerm var]
-    sortOnlyOnceFirst fs =
-      let (onlyOnceFacts, otherFacts) = partition ((==) "OnlyOnce" . (factTagName . factTag)) fs
-       in onlyOnceFacts ++ otherFacts
-    stampLVar n = LVar ("st" ++ show n) LSortFresh n
+    updateRule (RuleItem (OpenProtoRule ruE ruAC)) =
+      RuleItem (OpenProtoRule (multisetSemantics ruE) ruAC)
+    updateRule item = item
+
+multisetTheory :: OpenTheory -> OpenTheory
+multisetTheory thy =
+  let thy' = mapRulesWithMultisetSemantics thy
+      hasDistinctFact =
+        any ruleHasDistinctFact
+          [ ruE
+          | RuleItem (OpenProtoRule ruE _) <- L.get thyItems thy'
+          ]
+   in if hasDistinctFact
+        then case addRestriction (parseAndConvertRestriction resDistinctFact) thy' of
+               Just thy'' -> thy''
+               Nothing    -> error "Could not add restriction to theory"
+        else thy'
+
+-- Helper to check if a rule has a DistinctFact action
+ruleHasDistinctFact :: Rule i -> Bool
+ruleHasDistinctFact ru =
+  any (\f -> factTagName (factTag f) == "DistinctFact") (ru._rActs)
+
+resDistinctFact :: String
+resDistinctFact =
+  unlines
+    [ "restriction DistinctFact:",
+      "\"All x #i #j. DistinctFact(x)@i & DistinctFact(x)@j ==> #i = #j\""
+    ]
+
+parseAndConvertRestriction :: String -> Restriction
+parseAndConvertRestriction s =
+  case parseRestriction s of
+    Right (Restriction name synFormula _) ->
+      case toLNFormula synFormula of
+        Just lnFormula -> Restriction name lnFormula Nothing
+        Nothing -> error "Could not convert SyntacticRestriction to Restriction"
+    _ -> error $ "Could not parse restriction: " ++ s
+
+multisetSemantics :: HasRuleName (Rule i) => Rule i -> Rule i
+multisetSemantics r = r
+  { _rPrems = freshFacts ++ statPrems
+  , _rActs = distinctActions ++ r._rActs
+  , _rConcs = statConcs
+  }
+  where
+    statifyConcs :: String -> [LNFact] -> ([LNFact], [(FactTag, LNTerm)])
+    statifyConcs prefix facts =
+      let (_, factsWithVars) = mapAccumL (statify prefix) M.empty facts
+          (facts', vars) = unzip factsWithVars
+      in (facts', catMaybes vars)
+
+    statifyPrems :: String -> [LNFact] -> ([LNFact], [(FactTag, LNTerm, [LNTerm])])
+    statifyPrems prefix facts =
+      let (_, factsWithVars) = mapAccumL (statify prefix) M.empty facts
+          facts' = map fst factsWithVars
+          distincts = [ (tag, fresh, factTerms fact)
+                      | (fact, Just (tag, fresh)) <- factsWithVars ]
+      in (facts', distincts)
+
+    statify :: String -> M.Map String Int -> LNFact -> (M.Map String Int, (LNFact, Maybe (FactTag, LNTerm)))
+    statify prefix counts f
+      | isFrFact f || isInFact f || isOutFact f || isPersistentFact f = (counts, (f, Nothing))
+      | Fact tag ann ts <- f =
+          let name = factTagName tag
+              idx  = M.findWithDefault 0 name counts
+              counts' = M.insert name (idx + 1) counts
+              fresh = mkFreshTerm prefix name (toInteger idx)
+          in (counts', (Fact tag ann (fresh : ts), Just (tag, fresh)))
+
+    (statConcs, freshVars) = statifyConcs "R" r._rConcs
+    (statPrems, distinctVars) = statifyPrems "L" r._rPrems
+
+    freshFacts = map (mkFreshFact . snd) freshVars
+
+    distinctActions = [ Fact (ProtoFact Linear "DistinctFact" 0) S.empty [termsToPair args]
+                      | (_, _, args) <- distinctVars ]
+
+    mkFreshTerm prefix n idx = LIT $ Var $ LVar ("st" ++ prefix ++ "_" ++ n) LSortFresh idx
+    mkFreshFact fv = Fact FreshFact S.empty [fv]
+
+    termsToPair :: [LNTerm] -> LNTerm
+    termsToPair []     = error "termsToNestedPair: empty list"
+    termsToPair [x]    = x
+    termsToPair (x:xs) = fAppPair (x, termsToPair xs)
+
 
 ------------------------------------------------------------------------------
 -- Header generation
@@ -106,8 +195,8 @@ makeDestructorHeader ((dDef, atom), dName) =
   let (s1, s2) = break (== '#') dDef
    in Eq "reduc" s1 (dName ++ "(" ++ tail s2 ++ ") = " ++ showAtom False atom) "[private]"
 
-makeHeadersFromRule :: OpenProtoRule -> OpenTheory -> S.Set ProVerifHeader
-makeHeadersFromRule (OpenProtoRule ruE _) = makeHeadersFromProtoRule ruE
+makeHeadersFromRule :: S.Set String -> OpenProtoRule -> OpenTheory -> S.Set ProVerifHeader
+makeHeadersFromRule ruleIdEvents (OpenProtoRule ruE _) = makeHeadersFromProtoRule ruleIdEvents ruE
 
 notDiffRuleActs :: Rule ProtoRuleEInfo -> [Fact LNTerm]
 notDiffRuleActs ru = filter isNotDiffAnnotation ru._rActs
@@ -120,22 +209,30 @@ notDiffRuleActs ru = filter isNotDiffAnnotation ru._rActs
             factTerms = []
           }
 
-makeHeadersFromProtoRule :: Rule ProtoRuleEInfo -> OpenTheory -> S.Set ProVerifHeader
-makeHeadersFromProtoRule ru thy = S.unions [freeHeaders, tables, events]
+makeHeadersFromProtoRule :: S.Set String -> Rule ProtoRuleEInfo -> OpenTheory -> S.Set ProVerifHeader
+makeHeadersFromProtoRule ruleIdEvents ru thy = S.unions [freeHeaders, tables, events]
   where
     freeHeaders = makeFreeHeaders ru._rPrems (notDiffRuleActs ru) ru._rConcs thy
     tables = makeTableHeaders ru._rPrems ru._rConcs
-    events = makeEventHeaders (notDiffRuleActs ru)
+    events = makeEventHeaders ruleIdEvents (notDiffRuleActs ru)
 
 makeFreeHeaders :: [LNFact] -> [LNFact] -> [LNFact] -> OpenTheory -> S.Set ProVerifHeader
 makeFreeHeaders rprems racts rconcls thy = headers
   where
-    allTerms = foldMap factTerms (rprems ++ racts ++ rconcls)
-    termBitstrings = foldMap searchTermForBitstrings allTerms
+    termBitstrings = freeBitstringsFromFacts rprems racts rconcls
     lemmas = (._lFormula) <$> theoryLemmas thy
     lemmaBitstrings = foldMap searchLemmaForBitstrings lemmas
     bitstrings = termBitstrings `S.union` lemmaBitstrings
     headers = S.map (\x -> Sym "free" x ":bitstring" []) bitstrings
+
+makeFreeHeadersFromFacts :: [LNFact] -> [LNFact] -> [LNFact] -> S.Set ProVerifHeader
+makeFreeHeadersFromFacts rprems racts rconcls =
+  S.map (\x -> Sym "free" x ":bitstring" []) (freeBitstringsFromFacts rprems racts rconcls)
+
+freeBitstringsFromFacts :: [LNFact] -> [LNFact] -> [LNFact] -> S.Set String
+freeBitstringsFromFacts rprems racts rconcls = foldMap searchTermForBitstrings allTerms
+  where
+    allTerms = foldMap factTerms (rprems ++ racts ++ rconcls)
 
 searchLemmaForBitstrings :: ProtoFormula Unit2 (String, LSort) Name LVar -> S.Set String
 searchLemmaForBitstrings =
@@ -165,14 +262,21 @@ makeTableHeaders rprems rconcls =
     stateFact (t, _) = t `notElem` ["Fr", "In", "Out"]
     toTable (t, n) = Table t ("(" ++ intercalate ", " (replicate n "bitstring") ++ ")")
 
-makeEventHeaders :: [LNFact] -> S.Set ProVerifHeader
-makeEventHeaders racts =
+makeEventHeaders :: Ord a => S.Set String -> [Fact a] -> S.Set ProVerifHeader
+makeEventHeaders ruleIdEvents racts =
   S.map toHEvent
     . S.map getFactInfo
     $ S.fromList racts
   where
-    getFactInfo (Fact tag _ ts) = (showEventName tag, length ts)
-    toHEvent (t, n) = HEvent t ("(" ++ intercalate ", " (replicate n "bitstring") ++ ")")
+    getFactInfo (Fact tag _ ts) = (factTagName tag, length ts)
+    toHEvent (name, n) =
+      let extra = if name `S.member` ruleIdEvents then 1 else 0
+          eventName = showEventNameFromName name
+          arity = n + extra
+      in HEvent eventName ("(" ++ intercalate ", " (replicate arity "bitstring") ++ ")")
+
+showEventNameFromName :: String -> String
+showEventNameFromName tag = 'e' : tag
 
 ------------------------------------------------------------------------------
 -- Rule translation
@@ -180,11 +284,13 @@ makeEventHeaders racts =
 
 translateOpenProtoRule ::
   (HighlightDocument d) =>
+  S.Set String ->
   OpenProtoRule ->
   OpenTheory ->
   M.Map (String, String) String ->
   (d, M.Map (String, String) String)
-translateOpenProtoRule (OpenProtoRule ruE _) thy = translateProtoRule (checkTypes ruE thy)
+translateOpenProtoRule ruleIdEvents (OpenProtoRule ruE _) thy =
+  translateProtoRule ruleIdEvents (checkTypes ruE thy)
 
 -- Functions with user-defined types cannot be used in rewrite rules, they
 -- are currently written such that everything is treated as a bitstring
@@ -213,14 +319,16 @@ incorrectTermTypes thy t = case viewTerm t of
 
 translateProtoRule ::
   (HighlightDocument d) =>
+  S.Set String ->
   Rule ProtoRuleEInfo ->
   M.Map (String, String) String ->
-  (d, M.Map (String, String) String)
-translateProtoRule ru de =
+  (d, M.Map (String,String) String)
+translateProtoRule ruleIdEvents ru de =
   (ruleDoc, destructors)
   where
-    (factsDoc, destructors) = translateRule ru._rPrems (notDiffRuleActs ru) ru._rConcs de
-    ruleDoc = text "let" <-> text (showRuleName ru._rInfo._preName) <-> text "=" $-$ nest 8 factsDoc
+    rname = showRuleName ru._rInfo._preName
+    (factsDoc, destructors) = translateRule ruleIdEvents rname ru._rPrems (notDiffRuleActs ru) ru._rConcs de
+    ruleDoc = text "let" <-> text rname <-> text "=" $-$ nest 8 factsDoc
 
 showRuleName :: ProtoRuleName -> String
 showRuleName FreshRule = "rFresh"
@@ -228,27 +336,75 @@ showRuleName (StandRule s) = 'r' : s
 
 translateRule ::
   (HighlightDocument d) =>
+  S.Set String ->
+  String ->
   [LNFact] ->
   [LNFact] ->
   [LNFact] ->
   M.Map (String, String) String ->
   (d, M.Map (String, String) String)
-translateRule rprems racts rconcls destrs =
+translateRule ruleIdEvents rname rprems racts rconcls destrs =
+  let (headDocs, tailDocs, newDestrs) = translateRuleDocs ruleIdEvents (Just rname) S.empty rprems racts rconcls destrs
+   in (combineRuleDocs headDocs tailDocs, newDestrs)
+
+translateRuleDocs ::
+  (HighlightDocument d) =>
+  S.Set String ->
+  Maybe String ->
+  S.Set String ->
+  [LNFact] ->
+  [LNFact] ->
+  [LNFact] ->
+  M.Map (String, String) String ->
+  ([d], [d], M.Map (String, String) String)
+translateRuleDocs ruleIdEvents maybeRname initialVars rprems racts rconcls destrs =
   -- docsX contains the expression resulting from the given translation (as an instance of Doc)
   -- varsX is a set of all variables that have appeared in the rule translation until that point
   -- varsX' is a map where the keys are the patterns, which have appeared in the rule translation until that point,
   -- and the values are their helper variables
   -- destrX is a map where the keys are terms a and t, where a given destructor extracts a from t
   -- and the values are the given destructors (which have appeared in the rule translation until that point)
-  let (docs1, vars1, vars1', destr1) = translatePatterns rprems GET patternGetsFilter S.empty M.empty destrs
+  let ruleIdName = maybe "" ("rid_" ++) maybeRname
+      ruleUsesRuleId = any (\fact -> factTagName (factTag fact) `S.member` ruleIdEvents) racts
+      ruleIdDoc = text "new" <-> text ruleIdName <> text ": bitstring"
+      (docs1, vars1, vars1', destr1) = translatePatterns rprems GET patternGetsFilter initialVars M.empty destrs
       (docs2, vars2) = translateNonPatterns rprems GET nonPatternGetsFilter vars1
       (docs3, vars3, _, destr3) = translatePatterns rprems IN patternInsFilter vars2 vars1' destr1
       (docs4, vars4) = translateNonPatterns rprems IN nonPatternInsFilter vars3
       (docs5, vars5) = translateNonPatterns rprems NEW isFrFact vars4
-      (docs6, vars6) = translateNonPatterns racts EVENT (const True) vars5
+      -- Actions from embedded restrictions (_restrict(...)) as well as Eq, Neq need to come before all other actions.
+      -- The restriction holds only for variables after the restriction action.
+      (docs6, vars6) =
+        if ruleUsesRuleId
+          then translateNonPatternsWithRuleId ruleIdEvents ruleIdName (sortActionsByPriority racts) EVENT (const True) vars5
+          else translateNonPatterns (sortActionsByPriority racts) EVENT (const True) vars5
       (docs7, vars7) = translateNonPatterns (rconcls \\ rprems) INSERT isStorage vars6
       (docs8, _) = translateNonPatterns rconcls OUT isOutFact vars7
-   in (combineRuleDocs (docs1 ++ docs2 ++ docs3) (docs4 ++ docs5 ++ docs6 ++ docs7 ++ docs8), destr3)
+      rulePrefixDocs = [ruleIdDoc | ruleUsesRuleId]
+      headDocs = docs1 ++ docs2 ++ docs3
+      tailDocs = rulePrefixDocs ++ docs4 ++ docs5 ++ docs6 ++ docs7 ++ docs8
+   in (headDocs, tailDocs, destr3)
+
+-- Sorts the actions by putting actions from embedded restrictions, then Eq and Neq, and then the remaming actions.
+sortActionsByPriority :: [LNFact] -> [LNFact]
+sortActionsByPriority facts = restrictionFacts ++ eqNeqFacts ++ otherFacts
+  where
+    (restrictionFacts, nonRestrictionFacts) = partition (hasRstrPrefix restrPrefix) facts
+    (eqNeqFacts, otherFacts) = partition isEqOrNeqFact nonRestrictionFacts
+
+    hasRstrPrefix :: String -> LNFact -> Bool
+    hasRstrPrefix prefix fact = prefix `isPrefixOf` factTagName (factTag fact)
+
+    -- TOOD: Which ones to add?
+    isEqOrNeqFact :: LNFact -> Bool
+    isEqOrNeqFact fact = factTagName (factTag fact) `elem` ["Eq", "Equal", "Neq", "Unequal"]
+
+combineActionDocs :: (HighlightDocument d) => [d] -> [d] -> d
+combineActionDocs rd1 rd2 = vcat rd1 $-$ separateActionDocs rd2
+  where
+    separateActionDocs [r] = r
+    separateActionDocs (r : rs) = r <> semi $-$ separateActionDocs rs
+    separateActionDocs [] = text ""
 
 combineRuleDocs :: (HighlightDocument d) => [d] -> [d] -> d
 combineRuleDocs rd1 rd2 = vcat rd1 $-$ separateRuleDocs rd2
@@ -288,7 +444,7 @@ translatePatterns facts factType filterFunction vars helperVars destructors =
   -- Translate all selected pattern facts, while keeping track of the variables that have already
   -- appeared and also continuously updating the maps with the helper vars and the destructors.
   foldl'
-    (\acc@(_, vs', hvs', destrs') f -> acc `combine4` translate f vs' hvs' destrs')
+    (\acc@(_, vs', hvs', destrs') f -> acc `accumulateWith4` translate f vs' hvs' destrs')
     ([], vars, helperVars, destructors)
     patternFacts
   where
@@ -321,7 +477,7 @@ translatePatterns facts factType filterFunction vars helperVars destructors =
         -- of destructors is also updated continiuously.
         (destrDocList, newVars, newDestructors) =
           foldl'
-            (\acc@(_, vset, des) t -> acc `combine3` makeDestructorExpressions vset newHelperVars des t)
+            (\acc@(_, vset, des) t -> acc `accumulateWith3` makeDestructorExpressions vset newHelperVars des t)
             ([], vs `S.union` literals, destrs)
             patternTerms
 
@@ -331,12 +487,37 @@ translatePatterns facts factType filterFunction vars helperVars destructors =
         patternTerms = filter isPattern ts
         literals = S.fromList $ foldMap (map show . lits) $ filter (not . isPattern) ts
 
-    combine4 (as, b, c, d) (a, b1, c1, d1) = (as ++ [a], b <> b1, c <> c1, d <> d1)
-    combine3 (as, b, c) (a, b1, c1) = (as ++ [a], b <> b1, c <> c1)
+    -- | Accumulate result with 4 semigroup values
+    accumulateWith4 (as, b, c, d) (a, b1, c1, d1) = (as ++ [a], b <> b1, c <> c1, d <> d1)
+    -- | Accumulate result with 3 semigroup values
+    accumulateWith3 (as, b, c) (a, b1, c1) = (as ++ [a], b <> b1, c <> c1)
+
+-- | Like translateNonPatterns but includes a rule ID as the first argument to EVENT facts
+translateNonPatternsWithRuleId :: (HighlightDocument d) => S.Set String -> String -> [LNFact] -> FactType -> (LNFact -> Bool) -> S.Set String -> ([d], S.Set String)
+translateNonPatternsWithRuleId ruleIdEvents ruleIdName facts factType filterFunction vars =
+  foldl' (\acc@(_, currVars) f -> acc `accumulateResult` translate f currVars) ([], vars) nonPatternFacts
+  where
+    nonPatternFacts = filter filterFunction facts
+    translate prem@(Fact tag _ ts) vs = (factDoc, atoms)
+      where
+        factName = factTagName tag
+        useRuleId = factType == EVENT && factName `S.member` ruleIdEvents
+        factDoc =
+          if factType `elem` [OUT, INSERT, EVENT] && checkForNewIDs
+            then idConstructor $-$ renderFact
+            else renderFact
+        renderFact =
+          if useRuleId
+            then translateFactWithRuleId prem factType vs ruleIdName
+            else translateFact prem factType vs
+        atoms = S.fromList $ foldMap (map show . lits) ts
+        checkForNewIDs = not (atoms `S.isSubsetOf` vs) && any (('$' ==) . head) (atoms `S.difference` vs)
+        idConstructor = idExp . S.toList $ atoms `S.difference` vs
+        idExp = vcat . map (\a -> text "in(publicChannel, " <> text (showAtom True a) <> text ": bitstring);") . filter (('$' ==) . head)
 
 translateNonPatterns :: (HighlightDocument d) => [LNFact] -> FactType -> (LNFact -> Bool) -> S.Set String -> ([d], S.Set String)
 translateNonPatterns facts factType filterFunction vars =
-  foldl' (\acc@(_, currVars) f -> acc `combine2` translate f currVars) ([], vars) nonPatternFacts
+  foldl' (\acc@(_, currVars) f -> acc `accumulateResult` translate f currVars) ([], vars) nonPatternFacts
   where
     nonPatternFacts = filter filterFunction facts
     translate prem@(Fact _ _ ts) vs = (factDoc, atoms)
@@ -349,6 +530,24 @@ translateNonPatterns facts factType filterFunction vars =
         checkForNewIDs = not (atoms `S.isSubsetOf` vs) && any (('$' ==) . head) (atoms `S.difference` vs)
         idConstructor = idExp . S.toList $ atoms `S.difference` vs
         idExp = vcat . map (\a -> text "in(publicChannel, " <> text (showAtom True a) <> text ": bitstring);") . filter (('$' ==) . head)
+
+-- | Like translateFact but includes rule ID as first argument for EVENT facts
+translateFactWithRuleId :: (Document d) => LNFact -> FactType -> S.Set String -> String -> d
+translateFactWithRuleId (Fact tag _ ts) factType vars ruleIdName = case factType of
+  GET -> text "get" <-> text (showFactName tag) <> translateTerms vars True <> text " in"
+  IN ->
+    text "in(publicChannel," <-> translateTerm vars True (head ts)
+      <> text (if head (printTerm True vars True (head ts)) == '=' then ")" else ": bitstring)")
+  NEW -> text "new" <-> translateTerm S.empty False (head ts) <> text ": bitstring"
+  INSERT -> text "insert" <-> text (showFactName tag) <> translateTerms S.empty False
+  OUT -> text "out(publicChannel," <-> translateTerm S.empty False (head ts) <> text ")"
+  EVENT -> text "event" <-> text (showEventName tag) <> translateTermsWithRuleId S.empty False ruleIdName
+  where
+    translateTerms varSet checkEq =
+      text "(" <> (fsep . punctuate comma $ map (translateTerm varSet checkEq) ts) <> text ")"
+    -- For events, prepend the rule ID to the term list
+    translateTermsWithRuleId varSet checkEq rid =
+      text "(" <> text rid <> (if null ts then text "" else comma <-> (fsep . punctuate comma $ map (translateTerm varSet checkEq) ts)) <> text ")"
 
 translateFact :: (Document d) => LNFact -> FactType -> S.Set String -> d
 translateFact (Fact tag _ ts) factType vars = case factType of
@@ -375,7 +574,7 @@ translatePatternFact (Fact tag _ ts) factType vars helperVars =
   (factDoc, newHelperVars)
   where
     (doclist, newHelperVars) =
-      foldl' (\acc@(_, helpers) t -> acc `combine2` translatePatternTerm vars helpers t) ([], helperVars) ts
+      foldl' (\acc@(_, helpers) t -> acc `accumulateResult` translatePatternTerm vars helpers t) ([], helperVars) ts
     factDoc = case factType of
       GET -> text "get" <-> text (showFactName tag) <> text "(" <> (fsep . punctuate comma $ doclist) <> text ") in"
       IN -> text "in(publicChannel," <-> head doclist <> text ": bitstring);"
@@ -442,6 +641,7 @@ reservedWords =
     "secret",
     "select",
     "set",
+    "sid",
     "suchthat",
     "sync",
     "table",
@@ -455,7 +655,8 @@ showAtom :: Bool -> String -> String
 showAtom sanitized a = case head a of
   '~' -> sanitize . replaceDots $ tail a
   '$' -> sanitize . replaceDots $ tail a
-  '\'' -> sanitizeName $ 's' : (replaceDots . init $ tail a)
+  -- Needs to match ppPubName in Export.hs
+  '\'' -> sanitizeName $ 'v' : (replaceDots . init $ tail a)
   _ -> sanitize $ replaceDots a
   where
     replaceDots = map (\c -> if c == '.' then '_' else c)
@@ -565,7 +766,7 @@ makeDestructorExpressions vars helperVars destructors t =
   where
     (doclist, newDestructors) =
       foldl'
-        (\acc@(_, destrs) a -> acc `combine2` makeDestructorExpression vars helperVars destrs t a)
+        (\acc@(_, destrs) a -> acc `accumulateResult` makeDestructorExpression vars helperVars destrs t a)
         ([], destructors)
         atoms
     atoms = nub $ map show $ lits t
@@ -599,5 +800,7 @@ makeDestructorExpression vars helperVars destructors t a =
         <> text var
         <> text ") in"
 
-combine2 :: (Semigroup b) => ([a], b) -> (a, b) -> ([a], b)
-combine2 (as, b) (a, b1) = (as ++ [a], b <> b1)
+-- | Accumulate a result into a list while combining semigroup values.
+-- Used for folding over facts during rule translation.
+accumulateResult :: (Semigroup b) => ([a], b) -> (a, b) -> ([a], b)
+accumulateResult (as, b) (a, b1) = (as ++ [a], b <> b1)

--- a/lib/export/src/RuleTranslation.hs
+++ b/lib/export/src/RuleTranslation.hs
@@ -385,7 +385,8 @@ translateRuleDocs ruleIdEvents maybeRname initialVars rprems racts rconcls destr
       tailDocs = rulePrefixDocs ++ docs4 ++ docs5 ++ docs6 ++ docs7 ++ docs8
    in (headDocs, tailDocs, destr3)
 
--- Sorts the actions by putting actions from embedded restrictions, then Eq and Neq, and then the remaming actions.
+-- | Put embedded restrictions first, equality checks second, and all remaining
+-- actions last. 'partition' preserves the source order within each group.
 sortActionsByPriority :: [LNFact] -> [LNFact]
 sortActionsByPriority facts = restrictionFacts ++ eqNeqFacts ++ otherFacts
   where
@@ -395,9 +396,12 @@ sortActionsByPriority facts = restrictionFacts ++ eqNeqFacts ++ otherFacts
     hasRstrPrefix :: String -> LNFact -> Bool
     hasRstrPrefix prefix fact = prefix `isPrefixOf` factTagName (factTag fact)
 
-    -- TOOD: Which ones to add?
     isEqOrNeqFact :: LNFact -> Bool
-    isEqOrNeqFact fact = factTagName (factTag fact) `elem` ["Eq", "Equal", "Neq", "Unequal"]
+    isEqOrNeqFact fact = factTagName (factTag fact) `elem` equalityActionNames
+
+    -- "Eq" is produced by SAPIC. Keep the corresponding negative name and
+    -- the long-form spellings for hand-written embedded MSR actions.
+    equalityActionNames = ["Eq", "Neq", "Equal", "Unequal"]
 
 combineActionDocs :: (HighlightDocument d) => [d] -> [d] -> d
 combineActionDocs rd1 rd2 = vcat rd1 $-$ separateActionDocs rd2

--- a/lib/sapic/src/Sapic/Typing.hs
+++ b/lib/sapic/src/Sapic/Typing.hs
@@ -56,7 +56,7 @@ data TypingEnvironment = TypingEnvironment {
         vars :: Map.Map LVar SapicType
     ,   funs :: Map.Map NoEqSym ([SapicType],SapicType)
     ,   events :: Map.Map FactTag [SapicType]
-}
+} deriving (Show, Eq)
 
 -- | Try to type term `t` with a type more specific than `tt`. Returns typed
 -- term and its type in a Throw-Monad that contains the TypingEnvironment state.

--- a/lib/theory/src/Theory/Model/Restriction.hs
+++ b/lib/theory/src/Theory/Model/Restriction.hs
@@ -23,6 +23,7 @@ module Theory.Model.Restriction (
   , RestrictionAttribute(..)
   , rstrName
   , rstrFormula
+  , restrPrefix
   , varNow
   , fromRuleRestriction
   , applyMacroInRestriction

--- a/manual/src/006_protocol-specification-processes.md
+++ b/manual/src/006_protocol-specification-processes.md
@@ -334,7 +334,7 @@ these results. The correctness of the translation is proven in [@sapicplus].
 
 The `-m` flag selects an output module:
 ```
- -m --output-module[=spthy|spthytyped|msr|proverif|deepsec]
+ -m --output-module[=spthy|spthytyped|msr|proverif|proverifequiv|deepsec]
 ``` 
 
 The following outputs are supported:
@@ -344,6 +344,9 @@ The following outputs are supported:
 - *msr* - parse and type .spthy file and translate processes to multiset-rewrite rules
 - *proverif*: - translate to the
   [ProVerif](https://bblanche.gitlabpages.inria.fr/proverif/) input format. 
+  The export supports SAPIC processes and multiset rewrite rules. It also
+  translates supported Tamarin restrictions, selected lemmas as ProVerif
+  queries, and `reuse` or `sources` lemmas as ProVerif axioms.
   The translation of lookups/inserts relies on features that are not yet
   available in ProVerif (at the time of writing) and require preprocessing 
   with [GSVerif's protocol platform branch](https://gitlab.inria.fr/chevalvi/gsverif/-/tree/protocol_platform?ref_type=heads).
@@ -360,6 +363,25 @@ lemma secrecy[reuse, output=[proverif,msr]]:
 ```
 Lemmas are omitted when the currently selected output module is not in that
 list.
+
+For `-m=proverif`, regular lemmas are exported as ProVerif queries. Lemmas
+annotated with `reuse` or `sources` are instead exported as ProVerif axioms, so
+that they can be used as assumptions for the exported queries. If `--lemma` is
+used to select a specific lemma, the selected lemma is exported as a query;
+other `reuse` and `sources` lemmas may still be exported as supporting axioms
+unless this is disabled with the flags below.
+
+The ProVerif export has additional control flags:
+
+- `--proverif-no-reuse-lemmas`: do not export `reuse` lemmas as ProVerif
+  axioms.
+- `--proverif-no-source-lemmas`: do not export `sources` lemmas as ProVerif
+  axioms.
+- `--proverif-no-restrictions`: do not export restrictions.
+- `--proverif-no-multiset`: do not add the encoding that enforces Tamarin's
+  linear multiset semantics in ProVerif.
+- `--proverif-no-precise`: do not emit `set preciseActions = true.` in the
+  generated ProVerif file.
 
 ## Exporting queries
 

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -177,13 +177,25 @@ theoryLoadFlags =
       --  , flagOpt "" ["diff"] (updateArg "diff") "OFF|ON"
       --      "Turn on observational equivalence (default OFF).",
     flagNone
-      ["no-reuse"]
-      (addEmptyArg "no-reuse")
-      "Do not export reuse or source lemmas",
+      ["proverif-no-reuse-lemmas"]
+      (addEmptyArg "proverif-no-reuse-lemmas")
+      "Do not export reuse lemmas as ProVerif axioms",
     flagNone
-      ["no-restrictions"]
-      (addEmptyArg "no-restrictions")
-      "Do not export restrictions",
+      ["proverif-no-source-lemmas"]
+      (addEmptyArg "proverif-no-source-lemmas")
+      "Do not export source lemmas as ProVerif axioms",
+    flagNone
+      ["proverif-no-restrictions"]
+      (addEmptyArg "proverif-no-restrictions")
+      "Do not export restrictions to ProVerif",
+    flagNone
+      ["proverif-no-multiset"]
+      (addEmptyArg "proverif-no-multiset")
+      "Do not export multiset semantics to ProVerif (DistinctFact events and restriction)",
+    flagNone
+      ["proverif-no-precise"]
+      (addEmptyArg "proverif-no-precise")
+      "Do not set preciseActions in ProVerif output",
     flagOpt
       "3"
       ["replication-bound"]
@@ -216,8 +228,11 @@ data TheoryLoadOptions = TheoryLoadOptions
     openChain :: Integer,
     saturation :: Integer,
     derivationChecks :: Int,
-    noReuse :: Bool,
+    noReuseLemmas :: Bool,
+    noSourceLemmas :: Bool,
     noRestrictions :: Bool,
+    noMultiset :: Bool,
+    noPrecise :: Bool,
     replicationBound :: Int
   }
   deriving (Show)
@@ -244,8 +259,11 @@ defaultTheoryLoadOptions =
       openChain = 10,
       saturation = 5,
       derivationChecks = 5,
-      noReuse = False,
+      noReuseLemmas = False,
+      noSourceLemmas = False,
       noRestrictions = False,
+      noMultiset = False,
+      noPrecise = False,
       replicationBound = 3
     }
 
@@ -281,8 +299,11 @@ mkTheoryLoadOptions as =
     <*> openchain
     <*> saturation
     <*> deriv
-    <*> noReuse
+    <*> noReuseLemmas
+    <*> noSourceLemmas
     <*> noRestrictions
+    <*> noMultiset
+    <*> noPrecise
     <*> replicationBound
   where
     proveMode = pure $ argExists "prove" as
@@ -325,8 +346,11 @@ mkTheoryLoadOptions as =
     verboseMode = pure $ argExists "verbose" as
     quitOnWarning = pure $ argExists "quit-on-warning" as
     autoSources = pure $ argExists "auto-sources" as
-    noReuse = pure $ argExists "no-reuse" as
-    noRestrictions = pure $ argExists "no-restrictions" as
+    noReuseLemmas = pure $ argExists "proverif-no-reuse-lemmas" as
+    noSourceLemmas = pure $ argExists "proverif-no-source-lemmas" as
+    noRestrictions = pure $ argExists "proverif-no-restrictions" as
+    noMultiset = pure $ argExists "proverif-no-multiset" as
+    noPrecise = pure $ argExists "proverif-no-precise" as
 
     outputModule = case findArg "outModule" as of
       Just str -> case find ((str ==) . show) [minBound ..] of
@@ -469,7 +493,7 @@ checkTranslatedTheory ::
 checkTranslatedTheory thyOpts sign thy = do
   let transReport =
         either
-          (\thy -> checkWellformedness incompleteMSRs thy sign)
+          (\openThy -> checkWellformedness incompleteMSRs openThy sign)
           (`checkWellformednessDiff` sign)
           thy
 
@@ -687,12 +711,16 @@ prettyOpenTheoryByModule thyOpts = case  thyOpts.outputModule of
   Just ModuleSpthyTyped -> pure . prettyOpenTheory
   Just ModuleMsr -> pure . prettyOpenTranslatedTheory . removeTranslationItems
   Just ModuleProVerifEquivalence -> Export.prettyProVerifEquivTheory <=< Sapic.typeTheoryEnv
-  Just ModuleProVerif -> Export.prettyProVerifTheory ModuleProVerif noReuse noRestrictions lemmas <=< Sapic.typeTheoryEnv
+  Just ModuleProVerif -> Export.prettyProVerifTheory ModuleProVerif noReuseLemmas noSourceLemmas noRestrictions noMultiset noPrecise hasSpecificLemmas lemmas <=< Sapic.typeTheoryEnv
   Just ModuleDeepSec -> Export.prettyDeepSecTheory replicationBound
   where
     lemmas = lemmaSelector thyOpts
-    noReuse = thyOpts.noReuse
+    hasSpecificLemmas = not (null thyOpts.lemmaNames || thyOpts.lemmaNames == [""] || thyOpts.lemmaNames == ["", ""])
+    noReuseLemmas = thyOpts.noReuseLemmas
+    noSourceLemmas = thyOpts.noSourceLemmas
     noRestrictions = thyOpts.noRestrictions
+    noMultiset = thyOpts.noMultiset
+    noPrecise = thyOpts.noPrecise
     replicationBound = thyOpts.replicationBound
 
 -- | Construct an 'AutoProver' from the given arguments (--bound, --stop-on-trace).


### PR DESCRIPTION
This PR implements the significant extensions to Tamarin's export to ProVerif presented in our paper “A Sound Translation from Tamarin to ProVerif: Enabling Comparative Analysis”, which will be presented at ACM CCS 2026.

Extend the existing ProVerif export with the property-translation and semantic-bridge machinery needed to compare Tamarin theories against ProVerif. The main focus is translating a substantially larger class of Tamarin lemmas, reusable lemmas, source lemmas, and restrictions into ProVerif queries, axioms, and restrictions.

Add formula handling for all-trace and exists-trace properties, timepoint constraints, query splitting, and negation rewriting. Unsupported formulas and best-effort cases are reported explicitly rather than translated silently.

Broaden the underlying rule export where needed to support those properties: pattern matching, public variables, destructors, embedded SAPIC MSR actions, simultaneous action facts, optional multiset semantics, and precise action handling.

Scope the export controls as ProVerif-specific flags, including separate switches for reusable lemmas and source lemmas, plus controls for restrictions, multiset semantics, and precise actions.

Adjust a small set of MSR examples so translation-relevant equalities are explicit restrictions and equality premises in OnlyOnce restrictions are eliminated. SAPIC-only examples, evaluation tooling, and generated artifacts are intentionally excluded.