### PR TITLE
examples: Escape literal regex metacharacters in tactics

### DIFF
--- a/examples/csf20-disputeResolution/mixvote_ShHh_RF_functionalLHS.spthy
+++ b/examples/csf20-disputeResolution/mixvote_ShHh_RF_functionalLHS.spthy
@@ -24,39 +24,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(encp(v"
+  regex " !KU\( sg\(encp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: VoterC 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -66,39 +66,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: TimelyP 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -108,39 +108,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: AuthP 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -150,39 +150,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Uniqueness 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -192,49 +192,49 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Observational_equivalence 
 prio:
-  regex "!KU( ~sk"
+  regex "!KU\( ~sk"
 prio:
-  regex "!KU( ~ssk"
+  regex "!KU\( ~ssk"
 prio:
   regex "Out_IR"
 prio:
-  regex "Out_A("
+  regex "Out_A\("
 prio:
   regex "~~>"
 prio:
   regex "In_S"
 prio:
-  regex "!KD( "
+  regex "!KD\( "
 prio:
   regex "AgSt"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
-  regex "!KU( sg(encp("
+  regex "!KU\( sg\(encp\("
 prio:
   regex "'pr'"
 prio:
   regex "'bs'"
 prio:
-  regex "sg(cp("
+  regex "sg\(cp\("
 prio:
   regex "In_A"
 prio:
@@ -242,7 +242,7 @@ prio:
 prio:
   regex "~~>"
 prio:
-  regex "cp("
+  regex "cp\("
 
 rule (modulo E) ChanOut_S:
    [ Out_S( $A, $B, x ) ]

--- a/examples/csf20-disputeResolution/mixvote_ShHh_RF_functionalRHS.spthy
+++ b/examples/csf20-disputeResolution/mixvote_ShHh_RF_functionalRHS.spthy
@@ -24,39 +24,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(encp(v"
+  regex " !KU\( sg\(encp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: VoterC 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -66,39 +66,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: TimelyP 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -108,39 +108,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: AuthP 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -150,39 +150,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Uniqueness 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -192,49 +192,49 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Observational_equivalence 
 prio:
-  regex "!KU( ~sk"
+  regex "!KU\( ~sk"
 prio:
-  regex "!KU( ~ssk"
+  regex "!KU\( ~ssk"
 prio:
   regex "Out_IR"
 prio:
-  regex "Out_A("
+  regex "Out_A\("
 prio:
   regex "~~>"
 prio:
   regex "In_S"
 prio:
-  regex "!KD( "
+  regex "!KD\( "
 prio:
   regex "AgSt"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
-  regex "!KU( sg(encp("
+  regex "!KU\( sg\(encp\("
 prio:
   regex "'pr'"
 prio:
   regex "'bs'"
 prio:
-  regex "sg(cp("
+  regex "sg\(cp\("
 prio:
   regex "In_A"
 prio:
@@ -242,7 +242,7 @@ prio:
 prio:
   regex "~~>"
 prio:
-  regex "cp("
+  regex "cp\("
 
 rule (modulo E) ChanOut_S:
    [ Out_S( $A, $B, x ) ]

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_ShHh.spthy
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_ShHh.spthy
@@ -86,21 +86,21 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: indivVerif_b 
 prio:
@@ -114,33 +114,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRvoterC 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -150,33 +150,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRvoterT 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -186,33 +186,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRauth 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -222,33 +222,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Uniqueness 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -258,27 +258,27 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: secretSskD 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "'zkp'"
 prio:
@@ -286,21 +286,21 @@ prio:
 prio:
   regex "In_S"
 prio:
-  regex "!KU( ~sk"
+  regex "!KU\( ~sk"
 prio:
   regex "~sskD"
 prio:
   regex "AgSt"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "!KU( sg(cp("
+  regex "!KU\( sg\(cp\("
 prio:
   regex "'pr'"
 prio:
   regex "'bs'"
 prio:
-  regex "sg(cp("
+  regex "sg\(cp\("
 prio:
   regex "In_A"
 prio:
@@ -308,13 +308,13 @@ prio:
 prio:
   regex "~~>"
 prio:
-  regex "cp("
+  regex "cp\("
 
 tactic: EligVerif_DR 
 prio:
   regex "AgSt_A0"
 prio:
-  regex "In_A( 'BB'"
+  regex "In_A\( 'BB'"
 
 tactic: ballotsFromVoters 
 prio:
@@ -328,15 +328,15 @@ prio:
 prio:
   regex "~sskD"
 prio:
-  regex "h("
+  regex "h\("
 prio:
-  regex "encp("
+  regex "encp\("
 
 tactic: Tall_As_Rec_D 
 prio:
   regex "AgSt_A0"
 prio:
-  regex "In_A( 'BB'"
+  regex "In_A\( 'BB'"
 
 
 /* ==========

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_ShHh_RF.spthy
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_ShHh_RF.spthy
@@ -96,21 +96,21 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(encp(v"
+  regex " !KU\( sg\(encp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: indivVerif_b 
 prio:
@@ -124,39 +124,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(encp(v"
+  regex " !KU\( sg\(encp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRvoterC 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -166,39 +166,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRvoterT 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -208,39 +208,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRauth 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -250,39 +250,39 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Uniqueness 
 prio:
   regex "~~>"
 prio:
-  regex "($H = 'H1')"
+  regex "\(\$H = 'H1'\)"
 prio:
-  regex "($H.1 = 'H1')"
+  regex "\(\$H\.1 = 'H1'\)"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "AgSt_H"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -292,49 +292,49 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Observational_equivalence 
 prio:
-  regex "!KU( ~sk"
+  regex "!KU\( ~sk"
 prio:
-  regex "!KU( ~ssk"
+  regex "!KU\( ~ssk"
 prio:
   regex "Out_IR"
 prio:
-  regex "Out_A("
+  regex "Out_A\("
 prio:
   regex "~~>"
 prio:
   regex "In_S"
 prio:
-  regex "!KD( "
+  regex "!KD\( "
 prio:
   regex "AgSt"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
-  regex "!KU( sg(encp("
+  regex "!KU\( sg\(encp\("
 prio:
   regex "'pr'"
 prio:
   regex "'bs'"
 prio:
-  regex "sg(cp("
+  regex "sg\(cp\("
 prio:
   regex "In_A"
 prio:
@@ -342,7 +342,7 @@ prio:
 prio:
   regex "~~>"
 prio:
-  regex "cp("
+  regex "cp\("
 
 
 /* ==========

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_ShHm.spthy
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_ShHm.spthy
@@ -60,13 +60,13 @@ tactic: DRauth
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -76,27 +76,27 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: secretSskD 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "'zkp'"
 prio:
@@ -104,21 +104,21 @@ prio:
 prio:
   regex "In_S"
 prio:
-  regex "!KU( ~sk"
+  regex "!KU\( ~sk"
 prio:
   regex "~sskD"
 prio:
   regex "AgSt"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "!KU( sg(cp("
+  regex "!KU\( sg\(cp\("
 prio:
   regex "'pr'"
 prio:
   regex "'bs'"
 prio:
-  regex "sg(cp("
+  regex "sg\(cp\("
 prio:
   regex "In_A"
 prio:
@@ -126,7 +126,7 @@ prio:
 prio:
   regex "~~>"
 prio:
-  regex "cp("
+  regex "cp\("
 
 
 

--- a/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_SmHh.spthy
+++ b/examples/thesis-LaraSchmid-evoting/chapter4_DisputeResolution/aletheaDR_SmHh.spthy
@@ -81,21 +81,21 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: indivVerif_b 
 prio:
@@ -109,33 +109,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRvoterC 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -145,33 +145,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: DRvoterT 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -181,33 +181,33 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: Uniqueness 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex " 'S', <'b'"
 prio:
-  regex " In_A( $BB, <'b'"
+  regex " In_A\( \$BB, <'b'"
 prio:
-  regex "!KU( sg(encp(v"
+  regex "!KU\( sg\(encp\(v"
 prio:
   regex "AgSt"
 prio:
@@ -217,27 +217,27 @@ prio:
 prio:
   regex "'pkD'"
 prio:
-  regex " !KU( sg(cp(v"
+  regex " !KU\( sg\(cp\(v"
 prio:
-  regex "In_A( $S"
+  regex "In_A\( \$S"
 prio:
-  regex " In_A( 'S', <'pkD'"
+  regex " In_A\( 'S', <'pkD'"
 prio:
   regex "AgSt_A0"
 prio:
   regex "'bs'"
 prio:
-  regex "!KU( ~skS"
+  regex "!KU\( ~skS"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "In_A( $S, <'vs'"
+  regex "In_A\( \$S, <'vs'"
 
 tactic: secretSskD 
 prio:
   regex "~~>"
 prio:
-  regex "!KU( ~sskD"
+  regex "!KU\( ~sskD"
 prio:
   regex "'zkp'"
 prio:
@@ -245,21 +245,21 @@ prio:
 prio:
   regex "In_S"
 prio:
-  regex "!KU( ~sk"
+  regex "!KU\( ~sk"
 prio:
   regex "~sskD"
 prio:
   regex "AgSt"
 prio:
-  regex "!KU( ~skD"
+  regex "!KU\( ~skD"
 prio:
-  regex "!KU( sg(cp("
+  regex "!KU\( sg\(cp\("
 prio:
   regex "'pr'"
 prio:
   regex "'bs'"
 prio:
-  regex "sg(cp("
+  regex "sg\(cp\("
 prio:
   regex "In_A"
 prio:
@@ -267,13 +267,13 @@ prio:
 prio:
   regex "~~>"
 prio:
-  regex "cp("
+  regex "cp\("
 
 tactic: EligVerif_DR 
 prio:
   regex "AgSt_A0"
 prio:
-  regex "In_A( 'BB'"
+  regex "In_A\( 'BB'"
 
 
 tactic: ballotsFromVoters 
@@ -288,15 +288,15 @@ prio:
 prio:
   regex "~sskD"
 prio:
-  regex "h("
+  regex "h\("
 prio:
-  regex "encp("
+  regex "encp\("
 
 tactic: Tall_As_Rec_D 
 prio:
   regex "AgSt_A0"
 prio:
-  regex "In_A( 'BB'"
+  regex "In_A\( 'BB'"
 
 /* ==========
 Channel rules


### PR DESCRIPTION
Fix tactic regex patterns in the Alethea dispute-resolution and related mixvote examples where literal Tamarin syntax was interpreted as PCRE metacharacters.