### PR TITLE
Fix operator binding for Iff in accountability

### DIFF
--- a/lib/accountability/src/Accountability/Generation.hs
+++ b/lib/accountability/src/Accountability/Generation.hs
@@ -301,8 +301,8 @@ mergeQuantifiers = mergeQuantifiers1 [All, Ex]
       Conn And p q -> pullQuantifiers quans $ mergeQuantifiers1 quans p .&&.  mergeQuantifiers1 quans q
       Conn Or  p q -> pullQuantifiers quans $ mergeQuantifiers1 quans p .||.  mergeQuantifiers1 quans q
       Conn Imp p q -> pullQuantifiers quans $ mergeQuantifiers1 quans p .==>. mergeQuantifiers1 quans q
-      Conn Iff p q -> pullQuantifiers quans $ mergeQuantifiers1 quans p .==>. mergeQuantifiers1 quans q .&&.
-                                              mergeQuantifiers1 quans q .==>. mergeQuantifiers1 quans p
+      Conn Iff p q -> pullQuantifiers quans $ (mergeQuantifiers1 quans p .==>. mergeQuantifiers1 quans q) .&&.
+                                              (mergeQuantifiers1 quans q .==>. mergeQuantifiers1 quans p)
       _            -> fm
 
 


### PR DESCRIPTION
As written `.&&.` binds more tightly than `.==>.` so this becomes `p .==>. ((q .&&. q) .==>. p)` rather than `(p .==>. q) .&&. q .==>. p`.

The following file gives a minimal reproduction of the bug. `verif_empty` does not call `mergeQuantifiers` while `verif_nonempty` does, so you can make a file that generates some very odd results

```
theory IffBug
begin

rule R:
  [ ] --[ A($x), Corrupted($x), B($x) ]-> [ ]

test t1:
  "Ex #i. A(x) @ #i"

lemma acc:
  t1 accounts for
  "All x #i. A(x) @ #i ==> ((B(x) @ #i) <=> (C(x) @ #i))"

end
```

Which produces on current develop:
```
[...]
lemma acc_verif_empty:
  all-traces
  "(¬(∃ x #i. A( x ) @ #i)) ⇒
   (∀ x #i. (A( x ) @ #i) ⇒ ((B( x ) @ #i) ⇔ (C( x ) @ #i)))"

[..]

lemma acc_t1_verif_nonempty:
  all-traces
  "∀ x #i.
    (A( x ) @ #i) ⇒
    (¬(∀ x.1 #i.1.
        (A( x.1 ) @ #i.1) ⇒
        ((B( x.1 ) @ #i.1) ⇒
         (((C( x.1 ) @ #i.1) ∧ (C( x.1 ) @ #i.1)) ⇒ (B( x.1 ) @ #i.1)))))"
[..]
```
Note the `B( x.1 ) @ #i.1) ⇒
         (((C( x.1 ) @ #i.1) ∧ (C( x.1 ) @ #i.1)) ⇒ (B( x.1 ) @ #i.1` produced by the operator binding bug in `verif_nonempty`, while `verif_empty` correctly produces `((B( x ) @ #i) ⇔ (C( x ) @ #i))`.