### PR TITLE
Add --load-json support to interactive mode for standalone JSON graph viewing

### DIFF
--- a/data/css/tamarin-prover-ui.css
+++ b/data/css/tamarin-prover-ui.css
@@ -294,6 +294,32 @@ a.remove-step:hover {
     filter: alpha(opacity=100);
 }
 
+/* Floating options bar used in the pop-out graph window, which has no
+   layout panes (north/west/east) to host the regular header navigation. */
+div#popout-options {
+    display: inline-block;
+    position: fixed;
+    top: 0.5em;
+    right: 10px;
+    z-index: 1000;
+}
+
+/* The regular header navigation reserves right-hand spacing between menu
+   items. The pop-out has only one item, so remove that inherited spacing to
+   align the visible Options button with the abbreviation legend. */
+div#popout-options ul#navigation,
+div#popout-options ul#navigation li {
+    margin-right: 0;
+}
+
+/* The same graph page is also embedded as an iframe inside the main theory
+   window (e.g. via <static-graph>/<dynamic-graph>). The main window already
+   has its own Options menu in the header, so hide the redundant floating
+   one there; only show it in the actual pop-out window. */
+html.graph-embedded div#popout-options {
+    display: none;
+}
+
 ul#navigation {
     list-style: none;
     float: right;

--- a/data/js/tamarin-prover-ui.js
+++ b/data/js/tamarin-prover-ui.js
@@ -186,8 +186,6 @@ var ui = {
         }
 
         // $.cookie("simplification", 2, { path: '/' });
-        // Navigation drop-down menus
-        $("ul#navigation").superfish();
 
         // Add keyboard shortcuts
         var shortcuts = {
@@ -337,94 +335,6 @@ var ui = {
             mainDisplay.toggleOption(debug_toggle);
         });
 
-       // Click handlers for graph simplification handlers
-        var f = {};
-        f.makeHandler = function (obj,i) {
-            obj.click(function(ev) {
-                ev.preventDefault();
-                $.cookie("simplification", i, { path: '/' });
-	        for (var j=0;j<10;j++) {
-	            var olink = "a#lvl"+j+"-toggle";
-		    var obj = $(olink);
-	            if (i == j) {
-    		        obj.removeClass('inactive-option');
-		            obj.addClass('active-option');
-		        } else {
-		            obj.removeClass('active-option');
-		            obj.addClass('inactive-option');
-		        }
-	        }
-                $("a.active-link").click();
-            });
-        }
-	for (var i=0;i<10;i++) {
-	    var linkname = "a#lvl"+i+"-toggle";
-            f.makeHandler($(linkname),i);
-	}
- 
-       // Click handler for abbreviation toggle
-        var abbrv_toggle = $('a#abbrv-toggle');
-        abbrv_toggle.click(function(ev) {
-            ev.preventDefault();
-            if ($.cookie("abbreviate")) {
-                $.cookie("abbreviate", null, { path: '/' });
-            } else {
-                $.cookie("abbreviate", true, { path: '/' });
-            }
-            $("a.active-link").click();
-            mainDisplay.toggleOption(abbrv_toggle);
-        });
-
-        // Click handler for auto-sources' toggle
-        var auto_toggle = $('a#auto-toggle');
-        auto_toggle.click(function(ev) {
-            ev.preventDefault();
-            var pathname = window.location.href;
-            if ($.cookie("auto-sources")) {      
-                $.cookie("auto-sources", null, { path: '/' });  
-            } else {
-                $.cookie("auto-sources", true, { path: '/' });
-              
-            }
-            mainDisplay.toggleOption(auto_toggle);  
-            // to tell that this is a call from the toggle
-            $.cookie("not-init",true,{path: "/"});
-            $("a.active-link").click();
-        });
-
-        // Click handler for clustering toggle
-        var agent_toggle = $('a#agent-toggle');
-        agent_toggle.click(function(ev) {
-            ev.preventDefault();
-            if ($.cookie("clustering")) {
-                $.cookie("clustering", null, { path: '/' });
-            } else {
-                $.cookie("clustering", true, { path: '/' });
-            }
-            $("a.active-link").click();
-            mainDisplay.toggleOption(agent_toggle);
-        });
-
-        // Abstract node content toggle
-        var abstr_toggle = $('a#abstr-toggle');
-        abstr_toggle.click(function(ev) {
-            ev.preventDefault();
-            // store and set cookie to true if toggle turned on 
-            // meaning on interactive graph, node content will be simplified
-            // note that it is NOT the same as the simplification level of the graph.
-            if ($.cookie("abstract")) {
-                $.cookie("abstract", null, { path: '/' });
-            } else {
-                $.cookie("abstract", true, { path: '/' });
-            }
-            // refresh page
-            $("a.active-link").click();
-            // update toggle button style
-            mainDisplay.toggleOption(abstr_toggle);
-        });
-
-
-
         // Install event handlers
         events.installScrollHandler(
             "west",
@@ -490,7 +400,17 @@ var ui = {
             var pos = $.cookie("west-position");
             $("div.ui-layout-west div.scroll-wrapper").scrollTop(pos);
         }
+    },
 
+    /**
+     * Initialize the active/inactive/disabled icon state of the
+     * visualization options menu (graph simplification level, abbreviate
+     * terms, clustering, auto-sources, abstract node content) from cookies.
+     *
+     * Shared between the main window and the pop-out graph window, which
+     * both show this menu but do not share any other UI chrome.
+     */
+    loadOptionSettings: function() {
 	/* If no simplification level specified yet, default to 1 */
 	if ($.cookie("simplification") == null) {
 	    $.cookie("simplification", 2, { path: '/' });
@@ -528,6 +448,121 @@ var ui = {
             $("a#abstr-toggle").addClass("active-option");
         } else {
             $("a#abstr-toggle").addClass("disabled-option");
+        }
+    },
+
+    /**
+     * Wire up the visualization options drop-down: graph simplification
+     * level, abbreviate terms, clustering by role, auto-sources and
+     * abstract node content.
+     *
+     * Shared between the main theory window (where this menu lives in the
+     * north header bar) and the pop-out graph window (where it is shown as
+     * a floating bar in the top-right corner), so the toggles are only
+     * wired up in one place.
+     */
+    initOptionsMenu: function() {
+        // Navigation drop-down menu
+        $("ul#navigation").superfish();
+
+        // Click handlers for graph simplification handlers
+        var f = {};
+        f.makeHandler = function (obj,i) {
+            obj.click(function(ev) {
+                ev.preventDefault();
+                $.cookie("simplification", i, { path: '/' });
+	        for (var j=0;j<10;j++) {
+	            var olink = "a#lvl"+j+"-toggle";
+		    var obj = $(olink);
+	            if (i == j) {
+    		        obj.removeClass('inactive-option');
+			            obj.addClass('active-option');
+		        } else {
+			            obj.removeClass('active-option');
+			            obj.addClass('inactive-option');
+		        }
+	        }
+                ui.refreshGraphView();
+            });
+        }
+	for (var i=0;i<10;i++) {
+	    var linkname = "a#lvl"+i+"-toggle";
+            f.makeHandler($(linkname),i);
+	}
+
+        // Click handler for abbreviation toggle
+        var abbrv_toggle = $('a#abbrv-toggle');
+        abbrv_toggle.click(function(ev) {
+            ev.preventDefault();
+            if ($.cookie("abbreviate")) {
+                $.cookie("abbreviate", null, { path: '/' });
+            } else {
+                $.cookie("abbreviate", true, { path: '/' });
+            }
+            ui.refreshGraphView();
+            mainDisplay.toggleOption(abbrv_toggle);
+        });
+
+        // Click handler for auto-sources' toggle
+        var auto_toggle = $('a#auto-toggle');
+        auto_toggle.click(function(ev) {
+            ev.preventDefault();
+            if ($.cookie("auto-sources")) {      
+                $.cookie("auto-sources", null, { path: '/' });  
+            } else {
+                $.cookie("auto-sources", true, { path: '/' });
+              
+            }
+            mainDisplay.toggleOption(auto_toggle);  
+            // to tell that this is a call from the toggle
+            $.cookie("not-init",true,{path: "/"});
+            ui.refreshGraphView();
+        });
+
+        // Click handler for clustering toggle
+        var agent_toggle = $('a#agent-toggle');
+        agent_toggle.click(function(ev) {
+            ev.preventDefault();
+            if ($.cookie("clustering")) {
+                $.cookie("clustering", null, { path: '/' });
+            } else {
+                $.cookie("clustering", true, { path: '/' });
+            }
+            ui.refreshGraphView();
+            mainDisplay.toggleOption(agent_toggle);
+        });
+
+        // Abstract node content toggle
+        var abstr_toggle = $('a#abstr-toggle');
+        abstr_toggle.click(function(ev) {
+            ev.preventDefault();
+            // store and set cookie to true if toggle turned on 
+            // meaning on interactive graph, node content will be simplified
+            // note that it is NOT the same as the simplification level of the graph.
+            if ($.cookie("abstract")) {
+                $.cookie("abstract", null, { path: '/' });
+            } else {
+                $.cookie("abstract", true, { path: '/' });
+            }
+            // refresh page
+            ui.refreshGraphView();
+            // update toggle button style
+            mainDisplay.toggleOption(abstr_toggle);
+        });
+    },
+
+    /**
+     * Refresh the graph view after an options toggle changed a cookie.
+     *
+     * In the main window, this re-navigates the currently active proof-tree
+     * link, reloading the visualization pane with the new settings. The
+     * pop-out graph window has no such link (and no proof-tree pane), so a
+     * full page reload is used instead to pick up the new cookie values.
+     */
+    refreshGraphView: function() {
+        $("a.active-link").click();
+        if (window.tamarinPopoutGraph) {
+            location.reload();
         }
     },
 
@@ -1016,6 +1051,14 @@ var mainDisplay = {
  * Initialize when document is ready.
  */
 $(document).ready(function() {
+    // Wire up the visualization options menu wherever it appears (the main
+    // window's header, or the floating bar in the pop-out graph window).
+    // Harmless no-op if the menu is not present on the current page.
+    if ($("ul#navigation").length) {
+        ui.loadOptionSettings();
+        ui.initOptionsMenu();
+    }
+
     // Only run rest of script if the main display is available
     var main_display = $("#ui-main-display");
     if(main_display.length != 1) return;

--- a/frontend/src/wcs/graph.css
+++ b/frontend/src/wcs/graph.css
@@ -34,6 +34,18 @@ dot-graph-viz>svg{
   display: block;
 }
 
+.graph-render-error {
+  margin: 1em;
+  padding: 0.75em 1em;
+  border: 1px solid #c0392b;
+  border-radius: 4px;
+  background-color: #fdecea;
+  color: #922b21;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  max-width: 40em;
+}
+
 /* styles for the legend box
  *
  * Scoped under `.graph-page`, the top-level container wrapping the whole

--- a/frontend/src/wcs/graph.css
+++ b/frontend/src/wcs/graph.css
@@ -34,9 +34,30 @@ dot-graph-viz>svg{
   display: block;
 }
 
-/* styles for the legend box */
+/* styles for the legend box
+ *
+ * Scoped under `.graph-page`, the top-level container wrapping the whole
+ * graph page -- the floating Options bar (pop-out window only), the graph
+ * itself and its abbreviation legend (see `intdotLayout` in
+ * Web/Types.hs). This page also loads the shared tamarin-prover-ui.css
+ * (for the Options menu styling), which defines generic `table`/`th`/`td`
+ * rules meant for the main theory window's own tables. Resetting those
+ * properties here -- with the extra `.graph-page` class giving these
+ * rules higher specificity -- keeps the legend table's look
+ * self-contained regardless of what tamarin-prover-ui.css defines,
+ * instead of requiring one-off overrides whenever another property leaks
+ * through. */
 
-.lgd-container {
+.graph-page table,
+.graph-page table th,
+.graph-page table td {
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: inherit;
+}
+
+.graph-page .lgd-container {
   position: fixed;
   bottom: 10px;
   right: 10px;
@@ -48,26 +69,26 @@ dot-graph-viz>svg{
   background-color: white;
 }
 
-.lgd-container > table {
+.graph-page .lgd-container > table {
   border-collapse: collapse;
 }
-.lgd-container td {
+.graph-page .lgd-container td {
     white-space: pre-wrap;
 }
 
-tr.lgd-item > td {
+.graph-page tr.lgd-item > td {
   padding: 4px;
   font-size: 12px;
   font-family: Arial, Helvetica, sans-serif;
 }
 
-tr.lgd-item:hover {
+.graph-page tr.lgd-item:hover {
   background-color: grey;
   color: white;
   cursor: pointer;
 }
 
-tr.lgd-item.active {
+.graph-page tr.lgd-item.active {
   background-color: yellow;
   color: black;
 }

--- a/frontend/src/wcs/graph.ts
+++ b/frontend/src/wcs/graph.ts
@@ -210,11 +210,30 @@ export class DotGraphViz extends HTMLElement {
         if (this.isAbbreviationEnabled) {
           this.renderLegend(ctx);
         }
+      }).catch(err => {
+        // Rendering very large graphs (long, deeply-nested terms) without
+        // abbreviations can exceed the Graphviz WASM engine's memory, which
+        // otherwise fails silently, leaving a blank page. Surface a visible,
+        // actionable message instead.
+        console.error("[dot-graph-viz]: Error occurs during rendering\n", err);
+        const message = this.isAbbreviationEnabled
+          ? "Failed to render this graph."
+          : "Failed to render this graph, possibly because it is too large to " +
+            "display without abbreviations. Try enabling abbreviations in the Options menu.";
+        this.innerHTML = "";
+        this.appendChild(this.renderErrorMessage(message));
       });
 
     }
 
 
+  }
+
+  renderErrorMessage = (message: string): HTMLDivElement => {
+    const errorBox = document.createElement("div");
+    errorBox.setAttribute("class", "graph-render-error");
+    errorBox.textContent = message;
+    return errorBox;
   }
 
   /**

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -146,9 +146,9 @@ data JSONGraphs = JSONGraphs
     } deriving (Show)
 
 -- | Derive ToJSON and FromJSON. 
-concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphCluster, ''JSONGraphAbbrev, ''JSONGraph, ''JSONGraphs]
+concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphCluster, ''JSONGraphAbbrev, ''JSONGraphs]
 
--- Older JSON graph exports omit the presentation-only edge color. The frontend
+-- Some JSON graph exports omit the presentation-only edge color. The frontend
 -- already treats an empty color as the default black, so accept that format too.
 instance FromJSON JSONGraphEdge where
   parseJSON = withObject "JSONGraphEdge" $ \o -> JSONGraphEdge
@@ -163,6 +163,28 @@ instance ToJSON JSONGraphEdge where
       , "jgeRelation" .= relation
       , "jgeTarget" .= target
       , "jgeColor" .= color
+      ]
+
+-- Cluster and abbreviation collections are optional.
+instance FromJSON JSONGraph where
+  parseJSON = withObject "JSONGraph" $ \o -> JSONGraph
+      <$> o .: "jgDirected"
+      <*> o .: "jgType"
+      <*> o .: "jgLabel"
+      <*> o .: "jgNodes"
+      <*> o .: "jgEdges"
+      <*> o .:? "jgClusters" .!= []
+      <*> o .:? "jgAbbrevs" .!= []
+
+instance ToJSON JSONGraph where
+  toJSON (JSONGraph directed graphType label nodes edges clusters abbrevs) = object
+      [ "jgDirected" .= directed
+      , "jgType" .= graphType
+      , "jgLabel" .= label
+      , "jgNodes" .= nodes
+      , "jgEdges" .= edges
+      , "jgClusters" .= clusters
+      , "jgAbbrevs" .= abbrevs
       ]
 
 -- | Optional fields are not handled correctly with automatically derived instances

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -31,7 +31,9 @@ module Theory.Constraint.System.JSON (
     sequentsToJSON,                     
     writeSequentAsJSONToFile,
     sequentsToJSONPretty,
-    writeSequentAsJSONPrettyToFile
+    writeSequentAsJSONPrettyToFile,
+    JSONGraph(..),
+    JSONGraphs(..)
   ) where
 import           Extension.Data.Label       as L (get)
 import           Data.Aeson

--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -146,7 +146,24 @@ data JSONGraphs = JSONGraphs
     } deriving (Show)
 
 -- | Derive ToJSON and FromJSON. 
-concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphEdge, ''JSONGraphCluster, ''JSONGraphAbbrev, ''JSONGraph, ''JSONGraphs]
+concat <$> mapM (deriveJSON defaultOptions) [''JSONGraphNodeFact, ''JSONGraphNodeMetadata, ''JSONGraphCluster, ''JSONGraphAbbrev, ''JSONGraph, ''JSONGraphs]
+
+-- Older JSON graph exports omit the presentation-only edge color. The frontend
+-- already treats an empty color as the default black, so accept that format too.
+instance FromJSON JSONGraphEdge where
+  parseJSON = withObject "JSONGraphEdge" $ \o -> JSONGraphEdge
+      <$> o .: "jgeSource"
+      <*> o .: "jgeRelation"
+      <*> o .: "jgeTarget"
+      <*> o .:? "jgeColor" .!= ""
+
+instance ToJSON JSONGraphEdge where
+  toJSON (JSONGraphEdge source relation target color) = object
+      [ "jgeSource" .= source
+      , "jgeRelation" .= relation
+      , "jgeTarget" .= target
+      , "jgeColor" .= color
+      ]
 
 -- | Optional fields are not handled correctly with automatically derived instances
 -- hence, we have our own here.

--- a/manual/src/011_advanced-features.md
+++ b/manual/src/011_advanced-features.md
@@ -914,3 +914,29 @@ of the dot command line program.
 For JSON, the standard schema already defines a single top-level object with a
 "graphs" key that holds a list of the individual graphs, which we use to output
 the constrain systems.
+
+Viewing exported JSON graphs in the interactive GUI {#sec:load-json}
+-------------------------------------------------------------------
+
+A JSON file produced by `--output-json` (as described above) can be loaded
+directly into the interactive GUI for standalone viewing, without needing to
+reload or re-prove the original theory.
+This is useful for sharing a set of found attack traces or example graphs
+with someone else, or for revisiting old outputs later.
+
+To do so, either pass the JSON filename as the working-directory argument of
+`interactive` mode, or use the explicit `--load-json` flag:
+
+    tamarin-prover interactive traces.json
+    tamarin-prover interactive --load-json=traces.json
+
+A positional argument is treated as a JSON file to load automatically
+whenever it ends in the `.json` extension, therwise it is interpreted as
+usual, i.e., as a theory file or a directory of theory files.
+
+Once the server is ready, browse to `/loadjson` (e.g.
+<http://127.0.0.1:3001/loadjson>) to view the loaded graphs. If the file
+contains a single graph, you are redirected there directly; if it contains
+several, you will see a list of links, one per graph, labeled with the
+corresponding theory and lemma name.
+

--- a/src/Main/Mode/Interactive.hs
+++ b/src/Main/Mode/Interactive.hs
@@ -11,6 +11,8 @@ module Main.Mode.Interactive (
 
 import Control.Basics
 import Control.Exception (IOException, handle)
+import Data.Aeson (eitherDecode)
+import Data.ByteString.Lazy qualified as BSL
 import Data.Char (toLower)
 import Data.List
 import Data.Maybe
@@ -24,7 +26,7 @@ import Network.Wai.Handler.Warp (defaultSettings, setHost, setPort)
 import Network.Wai.Handler.Warp qualified as Warp
 import Web.Dispatch
 import Web.Settings qualified
-import Web.Types (OutputCommand(..), OutputFormat(..))
+import Web.Types (JSONGraphs, OutputCommand(..), OutputFormat(..))
 
 import Main.Console
 import Main.Environment
@@ -54,6 +56,8 @@ interactiveMode = tamarinMode
       , flagOpt "" ["interface","i"] (updateArg "interface") "INTERFACE"
                 "Interface to listen on (use '*4' for all IPv4 interfaces)"
       , flagOpt "" ["image-format"] (updateArg "image-format") "PNG|SVG" "image format used for graphs (default SVG)"
+      , flagOpt "" ["load-json"] (updateArg "load-json") "FILE"
+                "Load a JSON graph file (see --output-json) for standalone viewing at /loadjson (WORKDIR may be omitted)"
       , flagNone ["debug"] (addEmptyArg "debug") "Show server debugging output"
       , flagNone ["no-logging"] (addEmptyArg "no-logging") "Suppress web server logs."
       -- , flagNone ["autosave"] (addEmptyArg "autosave") "Automatically save proof state"
@@ -66,13 +70,19 @@ interactiveMode = tamarinMode
 
 -- | Start the interactive theorem proving mode.
 run :: TamarinMode -> Arguments -> IO ()
-run thisMode as = case findArg "workDir" as of
+run thisMode as = case findArg "workDir" as <|> (takeDirectory <$> findArg "load-json" as) of
+  -- WORKDIR may be omitted when --load-json is given: the JSON file's own
+  -- directory is used instead, since there is then usually no theory to load.
   Nothing -> helpAndExit thisMode (Just "no working directory specified")
   Just workDir0 -> do
     -- determine working directory
     wdIsFile <- doesFileExist workDir0
     let workDir | wdIsFile  = takeDirectory workDir0
                 | otherwise = workDir0
+        -- Passing a FILENAME.json positional argument is equivalent to
+        -- passing it as --load-json=FILENAME.json.
+        isJsonArg = wdIsFile && map toLower (takeExtension workDir0) == ".json"
+        loadJsonFileArg = findArg "load-json" as <|> (if isJsonArg then Just workDir0 else Nothing)
     wdIsDir  <- doesDirectoryExist workDir
     if wdIsDir then do
       -- determine caching directory
@@ -81,6 +91,9 @@ run thisMode as = case findArg "workDir" as of
       unixLoginName <- lookupEnv "USER"
       let loginName = fromMaybe "" (winLoginName <|> unixLoginName)
           cacheDir = tempDir </> ("tamarin-prover-cache-" ++ loginName)
+
+      -- Load and parse an externally exported JSON graph file, if requested.
+      loadedJsonGraphs <- readLoadJsonFileArg loadJsonFileArg
 
       -- Ensure Maude and get the Version in the arguments (__versionPrettyPrint__)
       version <- ensureMaudeAndGetVersion as
@@ -92,16 +105,20 @@ run thisMode as = case findArg "workDir" as of
 
       port <- readPort
       let webUrl = serverUrl port
+          -- When viewing an externally loaded JSON file, point the user
+          -- directly at /loadjson instead of reporting both the plain
+          -- server URL and the /loadjson URL separately.
+          readyUrl = maybe webUrl (const $ webUrl ++ "/loadjson") loadedJsonGraphs
       putStrLn $ intercalate "\n"
         [ "The server is starting up on port " ++ show port ++ "."
-        , "Browse to " ++ webUrl ++ " once the server is ready."
+        , "Browse to " ++ readyUrl ++ " once the server is ready."
         , ""
         , "Loading the security protocol theories '" ++ workDir </> "*.spthy"  ++ "' ..."
         , ""
         ]
 
       withWebUI
-        ("Finished loading theories ... server ready at \n\n    " ++ webUrl ++ "\n")
+        ("Finished loading theories ... server ready at \n\n    " ++ readyUrl ++ "\n")
         cacheDir
         workDir
 
@@ -116,6 +133,7 @@ run thisMode as = case findArg "workDir" as of
 
         (argExists "debug" as) (readOutputCommand as) readImageFormat
         (constructAutoProver thyLoadOptions)
+        loadedJsonGraphs
         (runWarp port)
 
     else
@@ -127,6 +145,19 @@ run thisMode as = case findArg "workDir" as of
     thyLoadOptions = case mkTheoryLoadOptions as of
       Left (ArgumentError e) -> error e
       Right opts             -> opts
+
+    -- Load and parse an externally exported JSON graph file (--load-json).
+    -----------------------------------------------------------------------
+    readLoadJsonFileArg :: Maybe FilePath -> IO (Maybe JSONGraphs)
+    readLoadJsonFileArg Nothing = pure Nothing
+    readLoadJsonFileArg (Just jsonFile) = do
+      exists <- doesFileExist jsonFile
+      unless exists $ error $
+        "--load-json: file '" ++ jsonFile ++ "' does not exist."
+      contents <- BSL.readFile jsonFile
+      case eitherDecode contents of
+        Left decodeErr -> error $ "--load-json: failed to parse '" ++ jsonFile ++ "': " ++ decodeErr
+        Right jgs -> pure $ Just jgs
 
     -- Port argument
     ----------------

--- a/src/Web/Dispatch.hs
+++ b/src/Web/Dispatch.hs
@@ -86,10 +86,12 @@ withWebUI
   -- ^ together with indication of choice "dot", "json", ...
   -> ImageFormat           -- ^ The preferred image format
   -> AutoProver            -- ^ The default autoprover.
+  -> Maybe JSONGraphs      -- ^ Graphs loaded from an externally exported JSON file, if any.
   -> (Application -> IO b) -- ^ Function to execute
   -> IO b
 withWebUI readyMsg cacheDir workDir enableLogging loadState autosave thyOpts
-          loadThy closeThy debug outputCmd imageFormat defaultAutoProver f = do
+          loadThy closeThy debug outputCmd imageFormat defaultAutoProver
+          loadedJsonGraphs f = do
   thy <- getTheos
   threadVar <- newMVar M.empty
   theoryVar <- newMVar thy
@@ -116,6 +118,7 @@ withWebUI readyMsg cacheDir workDir enableLogging loadState autosave thyOpts
                     , imageFormat
                     , defaultAutoProver
                     , debug
+                    , loadedJsonGraphs
                     }
       in if enableLogging then
         toWaiApp webUI

--- a/src/Web/Hamlet.hs
+++ b/src/Web/Hamlet.hs
@@ -187,15 +187,7 @@ headerTpl info = [whamlet|
                 <form method=POST action=@{AppendNewLemmasR idx filename} class=ajax-form>
                   <button type=submit class=link-button>Append modified lemmas to file
         <li><a href="#">Options</a>
-          <ul class="list-with-toggles">
-            <li><a id=abbrv-toggle href="#">Abbreviate terms</a>
-            <li><a id=agent-toggle href="#">Clustering by role</a>
-            <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
-            <li><a id=abstr-toggle href="#">Abstract node content</a>
-            <li><a id=lvl0-toggle href="#">Graph simplification off</a>
-            <li><a id=lvl1-toggle href="#">Graph simplification L1</a>
-            <li><a id=lvl2-toggle href="#">Graph simplification L2</a>
-            <li><a id=lvl3-toggle href="#">Graph simplification L3</a>
+          ^{optionsMenuItemTpl True}
   |]
   where
             -- <li><a id=debug-toggle href="#">Debug pane</a>
@@ -240,14 +232,7 @@ headerDiffTpl info = [whamlet|
             <li><a target=_blank href=@{TheorySourceDiffR idx}>Show source</a>
             <li><a href=@{DownloadTheoryDiffR idx filename}>Download source</a>
         <li><a href="#">Options</a>
-          <ul class="list-with-toggles">
-            <li><a id=abbrv-toggle href="#">Abbreviate terms</a>
-            <li><a id=agent-toggle href="#">Clustering by role</a>
-            <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
-            <li><a id=lvl0-toggle href="#">Graph simplification off</a>
-            <li><a id=lvl1-toggle href="#">Graph simplification L1</a>
-            <li><a id=lvl2-toggle href="#">Graph simplification L2</a>
-            <li><a id=lvl3-toggle href="#">Graph simplification L3</a>
+          ^{optionsMenuItemTpl False}
   |]
   where
             -- <li><a id=debug-toggle href="#">Debug pane</a>

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -60,6 +60,9 @@ module Web.Handler
   , postReloadTheoryDiffR
   , getUnloadTheoryR
   , getUnloadTheoryDiffR
+  , getLoadJsonR
+  , getLoadJsonViewR
+  , getLoadJsonDataR
   )
 where
 
@@ -929,6 +932,65 @@ getInteractiveDotGraphMirrorDiffR idx path = withDiffTheory idx (\ti -> do
         [hamlet|
             <dot-graph-viz dotsrc="#{dotPath}">
         |])
+
+-- | Show a list of the graphs contained in an externally loaded JSON file
+-- (see --load-json), or redirect directly to the graph if there is only one.
+getLoadJsonR :: Handler Html
+getLoadJsonR = do
+  jsonGraphs <- getLoadedJsonGraphs
+  case jsonGraphs.graphs of
+    [_singleGraph] -> redirect (LoadJsonViewR 0)
+    gs -> defaultLayout $ do
+      let indexedGraphs = zip [0 :: Int ..] gs
+      setTitle "Loaded JSON graphs"
+      [whamlet|
+          $newline never
+          <h1>Loaded JSON graphs
+          <ul>
+            $forall (idx, g) <- indexedGraphs
+              <li>
+                <a href=@{LoadJsonViewR idx}>#{g.jgLabel}
+      |]
+
+-- | Show one graph from an externally loaded JSON file.
+getLoadJsonViewR :: Int -> Handler Html
+getLoadJsonViewR idx = do
+  g <- getLoadedJsonGraph idx
+  renderF <- getUrlRender
+  let dotPath = T.unpack $ renderF (LoadJsonDataR idx)
+  intdotLayout True $ do
+      setTitle (toHtml $ "Loaded graph: " ++ g.jgLabel)
+      toWidget
+        [hamlet|
+            <dot-graph-viz dotsrc="#{dotPath}">
+        |]
+
+-- | Serve a single graph from an externally loaded JSON file, wrapped back
+-- into the multi-graph JSON schema expected by <dot-graph-viz>.
+getLoadJsonDataR :: Int -> Handler RepJson
+getLoadJsonDataR idx = do
+  g <- getLoadedJsonGraph idx
+  pure $ RepJson $ toContent $ toJSON (JSONGraphs [g])
+
+-- | Look up the externally loaded JSON graphs (see --load-json),
+-- or fail with 404 if none were loaded.
+getLoadedJsonGraphs :: Handler JSONGraphs
+getLoadedJsonGraphs = do
+  yesod <- getYesod
+  case yesod.loadedJsonGraphs of
+    Nothing  -> notFound
+    Just jgs -> pure jgs
+
+-- | Look up a single graph by index from the externally loaded JSON file.
+getLoadedJsonGraph :: Int -> Handler JSONGraph
+getLoadedJsonGraph idx = do
+  jsonGraphs <- getLoadedJsonGraphs
+  -- Guard against negative indices explicitly: 'drop' on a negative count is
+  -- a no-op (returns the whole list) rather than failing, which would
+  -- otherwise make e.g. '/loadjson/-1' silently show graph 0 instead of 404.
+  case if idx < 0 then Nothing else listToMaybe (drop idx jsonGraphs.graphs) of
+    Nothing -> notFound
+    Just g  -> pure g
 
 -- | Show overview over diff theory (framed layout).
 getOverviewDiffR :: TheoryIdx -> DiffTheoryPath -> Handler Html

--- a/src/Web/Handler.hs
+++ b/src/Web/Handler.hs
@@ -901,7 +901,7 @@ getInteractiveDotGraphR :: TheoryIdx -> TheoryPath -> Handler Html
 getInteractiveDotGraphR idx path = withTheory idx ( \ti -> do
   renderF <- getUrlRender
   let dotPath = T.unpack $ renderF (TheoryGraphJsonR idx path)
-  intdotLayout $ do 
+  intdotLayout True $ do 
       setTitle (toHtml $ "Theory: " ++ ti.theory._thyName)
       toWidget
         [hamlet|
@@ -912,7 +912,7 @@ getInteractiveDotGraphDiffR :: TheoryIdx -> DiffTheoryPath -> Handler Html
 getInteractiveDotGraphDiffR idx path = withDiffTheory idx (\ti -> do
   renderF <- getUrlRender
   let dotPath = T.unpack $ renderF (TheoryGraphJsonDiffR idx path)
-  intdotLayout $ do
+  intdotLayout False $ do
       setTitle (toHtml $ "DiffTheory: " ++ ti.theory._diffThyName)
       toWidget
         [hamlet|
@@ -923,7 +923,7 @@ getInteractiveDotGraphMirrorDiffR :: TheoryIdx -> DiffTheoryPath -> Handler Html
 getInteractiveDotGraphMirrorDiffR idx path = withDiffTheory idx (\ti -> do
   renderF <- getUrlRender
   let dotPath = T.unpack $ renderF (TheoryGraphJsonMirrorDiffR idx path)
-  intdotLayout $ do
+  intdotLayout False $ do
       setTitle (toHtml $ "DiffTheory: " ++ ti.theory._diffThyName)
       toWidget
         [hamlet|

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -51,6 +51,8 @@ module Web.Types
   , OutputFormat(..)
   , OutputCommand(..)
   , intdotLayout
+  , optionsMenuItemTpl
+  , popoutOptionsTpl
   )
 where
 
@@ -727,9 +729,70 @@ defaultLayout' w = do
           -- <li.delstep>
             -- <a href="#del/path">Remove step</a>
 
-intdotLayout :: Widget -> Handler Html
-intdotLayout w = do
-  page <- widgetToPageContent w
+-- | The list of visualization toggles (abbreviate terms, clustering by
+-- role, auto-sources, node content abstraction and graph simplification
+-- level) shown inside the "Options" drop-down.
+--
+-- Shared between the main theory header ('Web.Hamlet.headerTpl' and
+-- 'Web.Hamlet.headerDiffTpl') and the floating options bar shown in the
+-- pop-out graph window ('popoutOptionsTpl'), so the toggles (and the ids
+-- relied upon by @tamarin-prover-ui.js@) are only defined once. Callers are
+-- responsible for wrapping this in the "Options" menu item (@<li>@).
+optionsMenuItemTpl :: Bool -- ^ Whether to include the "Abstract node content" toggle (omitted for diff theories).
+                   -> Widget
+optionsMenuItemTpl includeAbstractToggle = [whamlet|
+    $newline never
+    <ul class="list-with-toggles">
+      <li><a id=abbrv-toggle href="#">Abbreviate terms</a>
+      <li><a id=agent-toggle href="#">Clustering by role</a>
+      <li><a id=auto-toggle href="#">Show annotation auto-sources</a>
+      $if includeAbstractToggle
+        <li><a id=abstr-toggle href="#">Abstract node content</a>
+      <li><a id=lvl0-toggle href="#">Graph simplification off</a>
+      <li><a id=lvl1-toggle href="#">Graph simplification L1</a>
+      <li><a id=lvl2-toggle href="#">Graph simplification L2</a>
+      <li><a id=lvl3-toggle href="#">Graph simplification L3</a>
+|]
+
+-- | Floating options bar shown in the top-right corner of the pop-out /
+-- interactive graph window, which has no header/navigation bar of its own.
+-- Re-uses 'optionsMenuItemTpl' so the pop-out window offers exactly the
+-- same visualization toggles as the main theory view.
+popoutOptionsTpl :: Bool -> Widget
+popoutOptionsTpl includeAbstractToggle = [whamlet|
+    $newline never
+    <div #popout-options>
+      <ul #navigation>
+        <li><a href="#">Options</a>
+          ^{optionsMenuItemTpl includeAbstractToggle}
+|]
+
+-- | Layout for the interactive graph page (@\/thy\/.\/intdot\/...@). This
+-- same page is used both as the actual pop-out window (opened via
+-- @window.open@) and as the iframe embedded inside each graph display in
+-- the main theory window (via @\<static-graph\>@\/@\<dynamic-graph\>@). The
+-- main window already has its own Options menu in the header, so the
+-- floating 'popoutOptionsTpl' bar is only shown when this page is not
+-- embedded in another window (detected client-side via
+-- @window.self === window.top@; see the inline script below).
+--
+-- Everything on this page (the floating options bar, the graph itself and
+-- its abbreviation legend) is wrapped in a single top-level @.graph-page@
+-- container. This page also loads the shared @tamarin-prover-ui.css@ (for
+-- the Options menu styling), which contains generic rules (e.g. for
+-- @table@\/@a@) meant for the main theory window's own content; scoping
+-- the graph\/legend's own styling (in @graph.css@) under @.graph-page@
+-- keeps it self-contained and immune to such rules, rather than requiring
+-- one-off overrides for each leaking property.
+intdotLayout :: Bool -- ^ Whether to include the "Abstract node content" toggle (omitted for diff theories).
+             -> Widget -> Handler Html
+intdotLayout includeAbstractToggle w = do
+  page <- widgetToPageContent [whamlet|
+      $newline never
+      <div .graph-page>
+        ^{popoutOptionsTpl includeAbstractToggle}
+        ^{w}
+  |]
   withUrlRenderer [hamlet|
     $newline never
     !!!
@@ -740,6 +803,12 @@ intdotLayout w = do
         <title>#{pageTitle page}
         <style> body,html{width: 100%; height: 100%; overflow: hidden; margin: 0; padding: 0; }
         <link rel=stylesheet href=/static/css/intdot-style.css>
+        <link rel=stylesheet href=/static/css/tamarin-prover-ui.css>
+        <script src=/static/js/jquery.js></script>
+        <script src=/static/js/jquery-cookie.js></script>
+        <script src=/static/js/jquery-superfish.js></script>
+        <script>window.tamarinPopoutGraph = (window.self === window.top); if (!window.tamarinPopoutGraph) { document.documentElement.classList.add("graph-embedded"); }</script>
+        <script src=/static/js/tamarin-prover-ui.js></script>
         <script type="module" src=/static/js/intdot-graph.es.js></script>
         ^{pageHead page}
       <body>

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -50,6 +50,7 @@ module Web.Types
   , imageFormatMIME
   , OutputFormat(..)
   , OutputCommand(..)
+  , JSONGraphs
   , intdotLayout
   , optionsMenuItemTpl
   , popoutOptionsTpl
@@ -75,6 +76,7 @@ import Yesod.Core
 import Yesod.Static
 
 import Theory
+import Theory.Constraint.System.JSON (JSONGraphs)
 import Theory.Tools.Wellformedness (WfErrorReport)
 import Main.TheoryLoader
 
@@ -155,6 +157,9 @@ data WebUI = WebUI
     -- ^ The default prover to use for automatic proving.
   , debug              :: Bool
     -- ^ Output debug messages
+  , loadedJsonGraphs   :: Maybe JSONGraphs
+    -- ^ Graphs loaded from an externally exported JSON file (see --load-json),
+    -- for standalone viewing via the \/loadjson routes.
   }
 
 
@@ -620,6 +625,9 @@ mkYesodData "WebUI" [parseRoutes|
 /thy/equiv/#Int/del/path/*DiffTheoryPath      DeleteStepDiffR             GET
 /thy/equiv/#Int/reload                           ReloadTheoryDiffR           POST
 /thy/equiv/#Int/unload                           UnloadTheoryDiffR           GET
+/loadjson                                        LoadJsonR                   GET
+/loadjson/#Int                                    LoadJsonViewR               GET
+/loadjson/data/#Int                               LoadJsonDataR               GET
 /kill                                      KillThreadR             GET
 -- /threads                                   ThreadsR                GET
 /robots.txt                                RobotsR                 GET

--- a/tamarin-prover.cabal
+++ b/tamarin-prover.cabal
@@ -123,6 +123,7 @@ executable tamarin-prover
 
     build-depends:
         HUnit
+      , aeson
       , base
       , binary
       , binary-orphans


### PR DESCRIPTION
Allow directly browsing constraint-system graphs exported via --output-json.

- New `--load-json=FILE` flag (also auto-detected when the positional WORKDIR argument is a `.json` file); WORKDIR is now optional when --load-json is given.
- New /loadjson, /loadjson/#Int and /loadjson/data/#Int routes/handlers, reusing the existing intdotLayout/<dot-graph-viz> rendering path.

Also fix graph.ts to catch rendering failures (e.g. Graphviz-WASM running out of memory on very large graphs with abbreviations disabled) and show a visible error message instead of silently leaving a blank page.

Documented new switch in the manual.

Additionally, the pop-out window now also has the options dropdown menu.

This addresses #891 and #890.