### PR TITLE
Fix #897 by keeping strings in UTF-8 throughout

### DIFF
--- a/lib/theory/src/Theory/Constraint/System/JSON.hs
+++ b/lib/theory/src/Theory/Constraint/System/JSON.hs
@@ -42,7 +42,8 @@ import           Data.Aeson.Encode.Pretty   -- to do pretty printing of JSON
 import           Data.Foldable
 import qualified Data.Map                   as M
 import           Data.Maybe
-import qualified Data.ByteString.Lazy.Char8 as BC (unpack)
+import qualified Data.ByteString            as B
+import qualified Data.ByteString.Lazy       as BL
 import           Control.Monad.Reader
 import           Text.PrettyPrint.Class     -- for Doc and the pretty printing functions 
 import           Theory.Constraint.System hiding (Edge, resolveNodeConcFact, resolveNodePremFact)
@@ -221,12 +222,21 @@ pps :: Doc -> String
 pps d = cleanString $ render d
 
 -- | EncodePretty encodes '<' as "\u003c" and '>' as "\u003e".
--- This function replaces these characters. 
-removePseudoUnicode :: [Char] -> [Char]
-removePseudoUnicode [] = []
-removePseudoUnicode ('\\':'u':'0':'0':'3':'c':xs) = ('<':removePseudoUnicode xs)
-removePseudoUnicode ('\\':'u':'0':'0':'3':'e':xs) = ('>':removePseudoUnicode xs)
-removePseudoUnicode (x:xs) = (x:removePseudoUnicode xs)
+-- This function replaces these escape sequences. Both patterns and both
+-- replacements are pure ASCII, so the byte-level rewrite cannot split or
+-- corrupt a multi-byte UTF-8 sequence elsewhere in the document.
+removePseudoUnicode :: BL.ByteString -> BL.ByteString
+removePseudoUnicode =
+    BL.fromStrict . replaceAll "\\u003e" ">" . replaceAll "\\u003c" "<" . BL.toStrict
+  where
+    replaceAll :: B.ByteString -> B.ByteString -> B.ByteString -> B.ByteString
+    replaceAll pat rep = go
+      where
+        go s =
+          let (pre, rest) = B.breakSubstring pat s
+          in if B.null rest
+               then pre
+               else pre <> rep <> go (B.drop (B.length pat) rest)
 
 -- | Remove " from start and end of string.
 plainstring :: String -> String
@@ -538,31 +548,32 @@ sequentsToJSONGraphs pretty systems =
     }
 
 -- | Generate JSON bytestring from an abstract graph.
-sequentsToJSON :: GraphOptions -> [(String, System)] -> String
+sequentsToJSON :: GraphOptions -> [(String, System)] -> BL.ByteString
 sequentsToJSON graphOptions systems =
   let graphs = map (\(label, system) -> (label, systemToGraph system graphOptions , nodeColorMap (M.elems $ get sNodes system))) systems
       graphJSON = sequentsToJSONGraphs False graphs
   in
-    BC.unpack $ encode graphJSON
+    encode graphJSON
 
 -- | NOTE (dschoop): encodePretty encodes < and > as "\u003c" and "\u003e" respectively.
 -- The encoding is removed with function removePseudoUnicode since Data.Strings.Util is non-standard.
--- The function encodePretty returns Data.ByteString.Lazy.Internal.ByteString containing
--- 8-bit bytes. However, eventually some other ByteString or String is expected by writeFile 
--- in /src/Web/Theory.hs.
-sequentsToJSONPretty :: GraphOptions -> [(String, System)] -> String
+-- The result stays a (UTF-8 encoded) ByteString all the way to the consumer,
+-- which must write it with a byte-oriented writer (e.g. 'BL.writeFile');
+-- round-tripping through String would either mangle non-ASCII characters
+-- (byte-per-Char unpacking) or depend on the locale encoding.
+sequentsToJSONPretty :: GraphOptions -> [(String, System)] -> BL.ByteString
 sequentsToJSONPretty graphOptions systems =
   let graphs = map (\(label, system) -> (label, systemToGraph system graphOptions , nodeColorMap (M.elems $ get sNodes system))) systems
       graphJSON = sequentsToJSONGraphs True graphs
   in
-    removePseudoUnicode $ BC.unpack $ encodePretty graphJSON
+    removePseudoUnicode $ encodePretty graphJSON
 
 -- | Generate JSON bytestring from an abstract graph and write to a file.
 writeSequentAsJSONToFile :: FilePath -> GraphOptions -> String -> System -> IO ()
 writeSequentAsJSONToFile fp graphOptions l se =
-  do writeFile fp $ sequentsToJSON graphOptions [(l, se)]
+  do BL.writeFile fp $ sequentsToJSON graphOptions [(l, se)]
 
 -- | Generate JSON bytestring with pretty formatting from an abstract graph and write to a file.
 writeSequentAsJSONPrettyToFile :: FilePath -> GraphOptions -> String -> System -> IO ()
 writeSequentAsJSONPrettyToFile fp graphOptions l se =
-  do writeFile fp $ sequentsToJSONPretty graphOptions [(l, se)]
+  do BL.writeFile fp $ sequentsToJSONPretty graphOptions [(l, se)]

--- a/src/Main/Mode/Batch.hs
+++ b/src/Main/Mode/Batch.hs
@@ -32,6 +32,7 @@ import Main.Console
 import Main.Environment
 import Main.TheoryLoader
 import Main.Utils
+import Data.ByteString.Lazy qualified as BL
 import Data.Map qualified as M
 import Theory.Constraint.System.Dot
 import Text.Dot qualified as D
@@ -268,7 +269,7 @@ run thisMode as
               Nothing -> pure ()
               Just outfile ->
                 let serialized = serializeJSON labelledSystems in
-                writeFile outfile serialized
+                BL.writeFile outfile serialized
           where
             -- | Collect all solved (i.e. a trace was found) systems of the theory along with their
             -- path in the proof and the lemma in which they appear in the given theory.

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -58,6 +58,8 @@ import System.Directory
 import System.FilePath
 
 import Text.Blaze.Html (preEscapedToMarkup, toHtml)
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Lazy.Char8 qualified as BC (unpack)
 import Text.Dot qualified as D
 import Text.Hamlet (Html, hamlet)
 import Text.PrettyPrint.Html
@@ -1303,7 +1305,7 @@ htmlThyDbgPath thy path = go path
 -}
 -- | Send the constraint system and the legend as JSON
 graphJsonThyPath :: FilePath       -- ^ Tamarin's cache directory
-                 -> (String -> System -> String)
+                 -> (String -> System -> BL.ByteString)
                                    -- ^ Function to convert constraint system to JSON
                  -> Bool           -- ^ True iff we want abbreviation
                  -> ClosedTheory
@@ -1315,32 +1317,32 @@ graphJsonThyPath cacheDir_ showJsonGraphFunct abbreviate thy path = go path
     go (TheoryProof l p)    = renderJson $ proofPathCode l p
     go _                    = error "Unhandled theory path. This is a bug."
 
-    casesCode :: SourceKind -> Int -> Int -> String
+    casesCode :: SourceKind -> Int -> Int -> BL.ByteString
     casesCode k i j =
       showJsonGraphFunct ("Theory: " ++ thy._thyName ++ " Case: " ++ show i ++ ":" ++ show j) (snd $ cases !! (i-1) !! (j-1))
       where
         cases = map (getDisj . (._cdCases)) (getSource k thy)
 
-    proofPathCode :: String -> ProofPath -> String
+    proofPathCode :: String -> ProofPath -> BL.ByteString
     proofPathCode lemma proofPath   =
-      fromMaybe ("") $ do
+      fromMaybe BL.empty $ do
         subProof <- resolveProofPath thy lemma proofPath
         sequent <- psInfo $ root subProof
         let (sys, legend) = State.evalState (Web.Utils.abbrev abbreviate 30 sequent) M.empty
             jsonGraph = showJsonGraphFunct ("Theory: " ++ thy._thyName ++ " Lemma: " ++ lemma) sys
         return jsonGraph
 
-    renderJson :: String -> IO FilePath
+    renderJson :: BL.ByteString -> IO FilePath
     renderJson str = do
-      let graphPath = cacheDir_ </> getGraphPath OutJSON str
+      let graphPath = cacheDir_ </> getGraphPath OutJSON (BC.unpack str)
           jsonPath = addExtension graphPath ("json")
       createDirectoryIfMissing True (takeDirectory jsonPath)
-      writeFile jsonPath str
+      BL.writeFile jsonPath str
       return jsonPath
 
 -- | Send the constraint system and the legend as JSON for diff theory and given path.
 graphJsonDiffThyPath :: FilePath                    -- ^ Tamarin's cache directory
-                    -> (String -> System -> String)  -- ^ Function to convert constraint system to JSON
+                    -> (String -> System -> BL.ByteString)  -- ^ Function to convert constraint system to JSON
                     -> Bool                          -- ^ True iff we want abbreviation
                     -> ClosedDiffTheory
                     -> DiffTheoryPath
@@ -1360,14 +1362,14 @@ graphJsonDiffThyPath cacheDir_ showJsonGraphFunct abbreviate thy path mirror = g
         cases = map (getDisj . (._cdCases)) (getDiffSource s isdiff k thy)
 
     proofPathCode s lemma proofPath =
-      fromMaybe "" $ do
+      fromMaybe BL.empty $ do
         subProof <- resolveProofPathDiff thy s lemma proofPath
         sequent <- psInfo $ root subProof
         let (sys, _) = State.evalState (Web.Utils.abbrev abbreviate 30 sequent) M.empty
         return $ showJsonGraphFunct ("Theory: " ++ thy._diffThyName ++ " Lemma: " ++ lemma) sys
 
     proofPathCodeDiff lemma proofPath mir =
-      fromMaybe "" $ do
+      fromMaybe BL.empty $ do
         subProof <- resolveProofPathDiffLemma thy lemma proofPath
         diffSequent <- dpsInfo $ root subProof
         sys <- if mir
@@ -1383,10 +1385,10 @@ graphJsonDiffThyPath cacheDir_ showJsonGraphFunct abbreviate thy path mirror = g
         return $ showJsonGraphFunct ("Theory: " ++ thy._diffThyName ++ " Lemma: " ++ lemma) sys
 
     renderJson str = do
-      let graphPath = cacheDir_ </> getGraphPath OutJSON str
+      let graphPath = cacheDir_ </> getGraphPath OutJSON (BC.unpack str)
           jsonPath = addExtension graphPath "json"
       createDirectoryIfMissing True (takeDirectory jsonPath)
-      writeFile jsonPath str
+      BL.writeFile jsonPath str
       return jsonPath
 
 -- | Output either JSON or an image corresponding to the given theory path and return the generated file's path.
@@ -1395,7 +1397,7 @@ imgThyPath :: ImageFormat                  -- ^ The preferred image output forma
            -> OutputCommand                -- ^ Choice and command for rendering.
            -> FilePath                     -- ^ Tamarin's cache directory
            -> (System -> D.Dot ())         -- ^ Function to render a System to Graphviz dot format.
-           -> (String -> System -> String) -- ^ Function to render a System to JSON.
+           -> (String -> System -> BL.ByteString) -- ^ Function to render a System to JSON.
            -> ClosedTheory                 -- ^ Theory from which to extract the 'System'.
            -> TheoryPath                   -- ^ Path of the 'System' in the theory.
            -> IO (Maybe FilePath)          -- ^ Path to the generated file.
@@ -1404,8 +1406,8 @@ imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath =
       Nothing -> return Nothing
       Just (jsonLabel, system) -> do
         let code = case outputCommand.ocFormat  of
-                     OutDot -> prefixedShowDot $ toDot system
-                     OutJSON -> toJSON jsonLabel system
+                     OutDot -> Left $ prefixedShowDot $ toDot system
+                     OutJSON -> Right $ toJSON jsonLabel system
         renderGraphCode code
   where
     thyPathSystem :: TheoryPath -> Maybe (String, System)
@@ -1436,9 +1438,9 @@ imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath =
         ruleList :: HasRuleName (Rule i) => [Rule i] -> String
         ruleList = intercalate ", " . nub . map showRuleCaseName
 
-    -- Render a piece of dot or JSON code
+    -- Render a piece of dot (Left, textual) or JSON (Right, UTF-8 bytes) code
     renderGraphCode code = do
-      let graphPath = cacheDir_ </> getGraphPath outputCommand.ocFormat code
+      let graphPath = cacheDir_ </> getGraphPath outputCommand.ocFormat (either id BC.unpack code)
           imgPath = addExtension graphPath $ show imageFormat
 
           -- A busy wait loop with a maximal number of iterations
@@ -1463,7 +1465,7 @@ imgThyPath imageFormat outputCommand cacheDir_ toDot toJSON thy thyPath =
           renderedOrRendering 50,
           -- create dot-file and render to image
           do
-            writeFile graphPath code
+            either (writeFile graphPath) (BL.writeFile graphPath) code
             -- select the correct command to generate img
             case outputCommand.ocFormat of
               OutDot  -> dotToImg "dot" graphPath imgPath


### PR DESCRIPTION
Fix for https://github.com/tamarin-prover/tamarin-prover/issues/897, this moves the encoding out so it doesn't happen repeatedly through the string passing.

I should say there's also a one-line fix for this, which is just to decode an extra time in JSON.hs:560:

```haskell
import qualified Data.Text.Lazy             as TL (unpack)
import qualified Data.Text.Lazy.Encoding    as TLE (decodeUtf8)
[...]

removePseudoUnicode $ TL.unpack $ TLE.decodeUtf8 $ encodePretty graphJSON
```

But that feels a bit wrong to do, encoding just to decode to encode again. Open to suggestions though!