### PR TITLE
Fix default oracle path resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ case-studies$(SUBDIR)%_analyzed-seqdfs.spthy: examples/%.spthy $(TAMARIN)
 case-studies$(SUBDIR)%_analyzed-deforacle.spthy: examples/%.spthy $(TAMARIN)
 	mkdir -p $(dir $@)
 	# Use -N3, as the fourth core is used by the OS and the console
-	cd examples/regression/trace && $(TAMARIN) defaultoracle.spthy --prove -d=0 +RTS -N3 -RTS -odefaultoracle.spthy.tmp >defaultoracle.spthy.out
+	$(TAMARIN) $< --prove -d=0 +RTS -N3 -RTS -o$<.tmp >$<.out
 	# We only produce the target after the run, otherwise aborted
 	# runs already 'finish' the case.
 	printf "\n/* Output\n" >>$<.tmp

--- a/lib/theory/src/Theory/Constraint/System.hs
+++ b/lib/theory/src/Theory/Constraint/System.hs
@@ -260,7 +260,7 @@ import           GHC.Generics                         (Generic)
 import           Data.Binary
 import qualified Data.ByteString.Char8                as BC
 import qualified Data.DAG.Simple                      as D
-import           Data.List                            (foldl', partition, intersect,find,intercalate, groupBy)
+import           Data.List                            (foldl', partition, intersect,find,intercalate)
 import qualified Data.Map                             as M
 import           Data.Maybe                           (fromMaybe,mapMaybe, isNothing)
 -- import           Data.Monoid                          (Monoid(..))
@@ -552,12 +552,14 @@ defaultOracleNames srcThyInFileName = map (mapOracleRanking remapOracle)
   where
     remapOracle o@(Oracle workDir relPath) =
       if isNothing relPath
-        then if unsafePerformIO (doesFileExist inFileOracleName)
-               then Oracle workDir (Just inFileOracleName)
-               else Oracle workDir (Just "oracle")
+        then
+          let oracleDir = fromMaybe (takeDirectory srcThyInFileName) workDir
+              mkOracle = Oracle (Just oracleDir) . Just
+          in if unsafePerformIO (doesFileExist (oracleDir </> inFileOracleName))
+               then mkOracle inFileOracleName
+               else mkOracle "oracle"
         else o
-    inFileOracleName =
-      last (groupBy (\_ b -> b /= '/') $ head $ groupBy (\_ b -> b /= '.') srcThyInFileName) ++ ".oracle"
+    inFileOracleName = takeBaseName srcThyInFileName <.> "oracle"
 
 maybeSetOracleWorkDir :: Maybe FilePath -> Oracle -> Oracle
 maybeSetOracleWorkDir p o = o{ oracleWorkDir = p }

--- a/manual/src/011_advanced-features.md
+++ b/manual/src/011_advanced-features.md
@@ -80,7 +80,11 @@ The syntax of the tactics will be detailed below in the part `Using a tactic`. H
   that runs independently of Tamarin and ranks the proof methods.
   The path of the program can be specified after the proof method ranking, e.g., `o "oracles/oracle-default"`
   to use the program `oracles/oracle-default` as the oracle.
-  If no path is specified, the default is `oracle`.
+  If no path is specified, Tamarin first looks in the protocol file's directory for an oracle with the
+  same base name as the protocol file and the `.oracle` extension. If that file does not exist, Tamarin
+  falls back to a file named `oracle` in the same directory. For example, if `models/MyProtocol.spthy`
+  contains `heuristic: o`, then running `tamarin-prover --prove models/MyProtocol.spthy` from the parent
+  directory uses `models/MyProtocol.oracle` if it exists, and otherwise uses `models/oracle`.
   The path of the program is relative to the directory of the protocol file containing the proof method ranking.
   If the heuristic is specified using the `--heuristic` option, the path can be given using the
   `--oraclename` command line option. In this case, the path is relative to the current working directory.


### PR DESCRIPTION
When running:

  tamarin-prover examples/regression/trace/defaultoracle.spthy

Tamarin should automatically use the neighboring file:

  examples/regression/trace/defaultoracle.oracle

The old code incorrectly extracted the oracle filename from a path containing directories. It therefore missed defaultoracle.oracle and tried the fallback file oracle, which did not exist.

The fix now reliably takes the theory’s filename and looks for its matching .oracle file in the same directory. Explicitly supplied oracle paths still work as before. The regression test now runs from the repository root so this bug cannot be hidden by first changing into the theory’s directory.