### PR TITLE
Enable inexistent actions warnings

### DIFF
--- a/examples/regression/trace/inexistentfact.spthy
+++ b/examples/regression/trace/inexistentfact.spthy
@@ -1,0 +1,7 @@
+theory InexistentFact
+begin
+
+lemma Test:
+  "All #x. P() @ #x ==> F"
+
+end

--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -575,12 +575,11 @@ freshFactArguments' rules = do
         text ("rule " ++ quote (showRuleCaseName ru)) <->
         text "fact:" <-> prettyLNFact fa
 
--- | Report on facts usage. Skip checks on non-existant actions if `incompleteMSRs` is True.
-factReports :: Bool -> OpenTranslatedTheory -> WfErrorReport
-factReports incompleteMSRs thy =
+factReports :: OpenTranslatedTheory -> WfErrorReport
+factReports thy =
     concat  [ reservedReport, reservedFactNameRules, freshFactArguments, specialFactsUsage
     , factUsage, factLhsOccurNoRhs]
-    ++ concat [ inexistentActions ++ inexistentActionsRestrictions | incompleteMSRs ]
+    ++ concat [ inexistentActions ++ inexistentActionsRestrictions ]
   where
     ruleFacts ru =
       ( "Rule " ++ quote (showRuleCaseName ru)
@@ -1267,15 +1266,15 @@ checkWellformednessDiff thy sig = -- trace ("checkWellformednessDiff: " ++ show 
 -- | Returns a list of errors, if there are any. `incompleteMSR`, if true, indicates
 -- that the MSRs are incomplete (e.g., when we export to ProVerif) and that
 -- checks that rely on that should not be performed.
-checkWellformedness :: Bool -> OpenTranslatedTheory -> SignatureWithMaude -> WfErrorReport
-checkWellformedness incompleteMSRs thy sig = concatMap ($ thy) (
+checkWellformedness :: OpenTranslatedTheory -> SignatureWithMaude -> WfErrorReport
+checkWellformedness thy sig = concatMap ($ thy) (
     [ checkIfLemmasInTheory
     , unboundReport
     , freshNamesReport
     , publicNamesReport
     , ruleSortsReport
     , ruleVariantsReport sig
-    , factReports incompleteMSRs
+    , factReports
     , formulaReports
     , lemmaAttributeReport
     , multRestrictedReport

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -559,7 +559,7 @@ checkTranslatedTheory ::
 checkTranslatedTheory thyOpts sign thy = do
   let transReport =
         either
-          (\openThy -> checkWellformedness incompleteMSRs openThy sign)
+          (\openThy -> checkWellformedness openThy sign)
           (`checkWellformednessDiff` sign)
           thy
 
@@ -599,7 +599,6 @@ checkTranslatedTheory thyOpts sign thy = do
   pure (report, signWithMaude, deducThy)
   where
     mh = sign._sigMaudeInfo
-    incompleteMSRs = False -- TODO how do we know if we do not have all MSRs due to translation?
     autoSources = thyOpts.autoSources
     derivChecks = thyOpts.derivationChecks
     derivTimeoutMsg =


### PR DESCRIPTION
There was some "dead" code around a bool flag that was passed only to the `factReports` function, which generates warning on fact usage. The flag was set to `False` only and marked with a TODO, but the logic of its usage in `factReports` was inverted. The documentation claimed to not generate warnings when the flag was `True`, but the opposite was the case. Thus, no warnings were generated for using inexistent facts.

Instead of fixing only the inversed logic, I decided to remove the flag. It was undocumented what its purpose might be, and how that'd interact with `factReports`.

@kevinmorio You added that code so maybe you have something to add!