### PR TITLE
Reject unknown tactic presorts gracefully

### DIFF
--- a/lib/theory/src/Theory/Text/Parser/Tactics.hs
+++ b/lib/theory/src/Theory/Text/Parser/Tactics.hs
@@ -45,7 +45,7 @@ goalRankingPresort :: Bool -> Parser (GoalRanking ProofContext)
 goalRankingPresort diff = regularRanking <?> "proof method ranking"
    where
        regularRanking = do
-           name <- (:) <$> letter <*> manyTill letter (lookAhead $ notFollowedBy letter *> anyChar)
+           name <- many1 letter
            case toGoalRanking name of
                Just ranking -> ranking <$ skipMany (char ' ')
                Nothing      -> fail $ "Unknown proof method ranking '" ++ name

--- a/lib/theory/src/Theory/Text/Parser/Tactics.hs
+++ b/lib/theory/src/Theory/Text/Parser/Tactics.hs
@@ -44,9 +44,15 @@ tacticName = do
 goalRankingPresort :: Bool -> Parser (GoalRanking ProofContext)
 goalRankingPresort diff = regularRanking <?> "proof method ranking"
    where
-       regularRanking = toGoalRanking <$> many1 letter <* skipMany (char ' ')
+       regularRanking = do
+           name <- (:) <$> letter <*> manyTill letter (lookAhead $ notFollowedBy letter *> anyChar)
+           case toGoalRanking name of
+               Just ranking -> ranking <$ skipMany (char ' ')
+               Nothing      -> fail $ "Unknown proof method ranking '" ++ name
+                   ++ "'. Use one of the following:\n" ++ listGoalRankingsForMode
 
-       toGoalRanking = if diff then stringToGoalRankingDiff True else stringToGoalRanking True
+       toGoalRanking = if diff then stringToGoalRankingDiffMay True else stringToGoalRankingMay True
+       listGoalRankingsForMode = if diff then listGoalRankingsDiff True else listGoalRankings True
 
 -- Default heuristic
 selectedPreSort :: Bool -> Parser (GoalRanking ProofContext)


### PR DESCRIPTION
An unknown heuristic in the tactic presort currently causes a crash, this is just a minor fix so it is rejected gracefully.

Repro file if you'd like:
```spthy
theory UnknownPresort
begin

tactic: bad_ranking
presort: z

end
```

Currently produces
```text
tamarin-prover: Unknown proof method ranking 'z'. Use one of the following:
[...]
CallStack (from HasCallStack):
  error, called at src/Theory/Constraint/System.hs:654:6 in tamarin-prover-theory-1.13.0-8wixYaxm5uHCGl2uEzaKzP:Theory.Constraint.System
```

now produces a proper parser error with the line and column number and no callstack

```
"/tmp/unknown-presort.spthy" (line 5, column 11):
Unknown proof method ranking 'z'. Use one of the following:
[...]
```
