### PR TITLE
Fix nested binders in nat sort checks

### DIFF
--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -286,7 +286,8 @@ boundTerms l (GDisj disj)             = concatMap (boundTerms l) disj
 boundTerms l (GConj conj)             = concatMap (boundTerms l) conj
 boundTerms l (GGuarded _ ss _ gf)     = boundTerms extendedVarAssignment gf
   where
-    extendedVarAssignment = zip [0..] [LVar name sort 0 | (name, sort) <- reverse ss] ++ l
+    extendedVarAssignment = zip [0..] [LVar name sort 0 | (name, sort) <- reverse ss]
+                         ++ [(i + fromIntegral (length ss), var) | (i, var) <- l]
 boundTerms _ _                        = [] --cannot happen
 
 -- | check nat-Sorting (i.e., below + is only nat)


### PR DESCRIPTION
The wellformedness `boundTerms` tracks quantified variables by (de Bruijn) index. When entering a nested quantifier, it adds the inner binders at indices starting from zero but does not shift the existing outer binders, so references to outer variables end up resolving incorrectly (or not at all). Then you get a wellformedness check failure with an extremely puzzling error message.

Easy to fix though.

Repro:
```
theory NestedBinderNat begin

builtins: natural-numbers

rule A:
  [ ] --[ A(%1) ]-> [ ]

lemma nested:
  "All %x #i. A(%x) @ i ==>
     (All #j. A(%x) @ j ==> %x %+ %1 = %x)"

end
```

On develop this produces
```
[Theory NestedBinderNat] Theory closed
quit-on-warning mode selected - aborting on wellformedness errors.

WARNING: the following wellformedness checks failed!

Nat Sorts
=========

  boundVar.2 in term (boundVar.2%+%1) must be of sort nat
```

even though there's nothing wrong, and it's also a very confusing error message.

After this minor fix:
```
[Theory NestedBinderNat] Theory closed

/* All wellformedness checks were successful. */
```