### PR TITLE
Fix inexistent action warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,12 @@ case-studies$(SUBDIR)%_analyzed.spthy:	examples/%.spthy $(TAMARIN)
 	mv $<.tmp $@
 	\rm -f $<.out
 
+# ProVerif exports used as regression artifacts.
+case-studies$(SUBDIR)%_proverif.pv:	examples/%.spthy $(TAMARIN)
+	mkdir -p $(dir $@)
+	$(TAMARIN) $< --output-module=proverif >$@.tmp
+	mv $@.tmp $@
+
 # individual case studies, special case with auto-sources
 case-studies$(SUBDIR)%_analyzed-auto-sources.spthy:	examples/%.spthy $(TAMARIN)
 	mkdir -p $(dir $@)
@@ -482,8 +488,11 @@ accountability-case-studies:	$(ACCOUNTABILITY_CS_TARGETS)
 ## Regression (old issues)
 ##########################
 
-FAST_REGRESSION_CASE_STUDIES=issue446-1.spthy issue446-2.spthy issue753-4.spthy issue753-5.spthy issue753-6.spthy issue834.spthy issue777.spthy issue770.spthy
+FAST_REGRESSION_CASE_STUDIES=issue446-1.spthy issue446-2.spthy issue753-4.spthy issue753-5.spthy issue753-6.spthy issue834.spthy issue777.spthy issue770.spthy issue916.spthy
 FAST_REGRESSION_TARGETS=$(subst .spthy,_analyzed.spthy,$(addprefix case-studies$(SUBDIR)regression/trace/,$(FAST_REGRESSION_CASE_STUDIES)))
+
+FAST_PROVERIF_REGRESSION_CASE_STUDIES=issue916-process.spthy
+FAST_PROVERIF_REGRESSION_TARGETS=$(subst .spthy,_proverif.pv,$(addprefix case-studies$(SUBDIR)regression/trace/,$(FAST_PROVERIF_REGRESSION_CASE_STUDIES)))
 
 
 REGRESSION_CASE_STUDIES=issue216.spthy issue193.spthy issue310.spthy issue519.spthy issue527.spthy issue515.spthy
@@ -594,7 +603,7 @@ case-studies: 	case-studies$(SUBDIR)system.info $(CS_TARGETS)
 ## Fast case studies
 ####################
 
-FAST_CS_TARGETS = case-studies$(SUBDIR)Tutorial_analyzed.spthy $(CCS15_PCS_TARGETS) $(TESTOBSEQ_TARGETS) $(FEATURES_CS_TARGETS) $(REGRESSION_OBSEQ_TARGETS) $(CSF12_CS_TARGETS) $(IND_CS_TARGETS) $(CCS15_CS_TARGETS) $(XOR_TRACE_TARGETS) $(POST17_TRACE_TARGETS) $(CLASSIC_CS_TARGETS) $(AKE_BP_CS_TARGETS) $(SEQDFS_TARGETS) $(DEFAULTORACLE_CASE_TARGETS) $(FAST_REGRESSION_TARGETS) $(XOR_DIFF_OBSEQONLY_TARGETS) $(DERIVATION_CHECK_CS_TARGETS) $(FAST_AC_CS_TARGETS) $(FAST_AC_DIFF_CS_TARGETS)
+FAST_CS_TARGETS = case-studies$(SUBDIR)Tutorial_analyzed.spthy $(CCS15_PCS_TARGETS) $(TESTOBSEQ_TARGETS) $(FEATURES_CS_TARGETS) $(REGRESSION_OBSEQ_TARGETS) $(CSF12_CS_TARGETS) $(IND_CS_TARGETS) $(CCS15_CS_TARGETS) $(XOR_TRACE_TARGETS) $(POST17_TRACE_TARGETS) $(CLASSIC_CS_TARGETS) $(AKE_BP_CS_TARGETS) $(SEQDFS_TARGETS) $(DEFAULTORACLE_CASE_TARGETS) $(FAST_REGRESSION_TARGETS) $(FAST_PROVERIF_REGRESSION_TARGETS) $(XOR_DIFF_OBSEQONLY_TARGETS) $(DERIVATION_CHECK_CS_TARGETS) $(FAST_AC_CS_TARGETS) $(FAST_AC_DIFF_CS_TARGETS)
 
 fast-case-studies: case-studies$(SUBDIR)system.info $(FAST_CS_TARGETS)
 	mkdir -p case-studies$(SUBDIR)

--- a/case-studies-regression/fast-tests/regression/trace/issue916-process_proverif.pv
+++ b/case-studies-regression/fast-tests/regression/trace/issue916-process_proverif.pv
@@ -1,0 +1,42 @@
+set preciseActions = true.
+free att:channel.
+fun fst(bitstring):bitstring.
+fun pair(bitstring,bitstring):bitstring.
+fun snd(bitstring):bitstring.
+event eProcessAction().
+equation forall x_1:bitstring, x_2:bitstring;   fst((x_1, x_2)) = x_1.
+equation forall x_1:bitstring, x_2:bitstring;   snd((x_1, x_2)) = x_2.
+
+(* Restrictions *)
+
+
+(*process_restriction_action*)
+(* ¬(∃ #i. ProcessAction( ) @ #i) *)
+(* Restriction has negated event which is not supported in ProVerif. *)
+
+
+
+(* Lemmas (queries) *)
+
+(*process_action*)
+query i:time; event(eProcessAction( ))@i.
+
+
+
+
+(* Process *)
+
+process
+    event eProcessAction( )
+
+(*
+All wellformedness checks were successful.
+*)
+
+(*
+Generated from:
+Tamarin version 1.13.0
+Maude version 3.4
+Git revision: 48a968e3595e7a17441ea77a87f0269b52d5ac31 (with uncommited changes), branch: fix/inexistent-action-warnings
+Compiled at: 2026-08-12 11:28:07.89975 UTC
+*)

--- a/case-studies-regression/fast-tests/regression/trace/issue916_analyzed.spthy
+++ b/case-studies-regression/fast-tests/regression/trace/issue916_analyzed.spthy
@@ -1,0 +1,76 @@
+theory issue916
+
+begin
+
+// Function signature and definition of the equational theory E
+
+functions: fst/1, pair/2, snd/1
+equations: fst(<x.1, x.2>) = x.1, snd(<x.1, x.2>) = x.2
+
+rule (modulo E) ExistingAction:
+   [ ] --[ ExistingAction( ) ]-> [ ]
+
+  /* has exactly the trivial AC variant */
+
+lemma missing_action:
+  exists-trace "∃ #i. MissingAction( ) @ #i"
+/*
+guarded formula characterizing all satisfying traces:
+"∃ #i. (MissingAction( ) @ #i)"
+*/
+simplify
+by solve( MissingAction( ) @ #i )
+
+restriction missing_restriction_action:
+  "∀ #i. (MissingRestrictionAction( ) @ #i) ⇒ (⊥)"
+  // safety formula
+
+  /*
+  expanded formula:
+  "∀ #i. (MissingRestrictionAction( ) @ #i) ⇒ (⊥)"
+  */
+
+/*
+WARNING: the following wellformedness checks failed!
+
+Inexistent lemma actions
+========================
+
+  Lemma `missing_action' references action 
+    fact "MissingAction" (arity 0, Linear) 
+  but no rule has such an action.
+
+Inexistent restriction actions
+==============================
+
+  Restriction `missing_restriction_action' references action 
+    fact "MissingRestrictionAction" (arity 0, Linear) 
+  but no rule has such an action.
+*/
+
+/*
+Generated from:
+Tamarin version 1.13.0
+Maude version 3.4
+Git revision: 48a968e3595e7a17441ea77a87f0269b52d5ac31 (with uncommited changes), branch: fix/inexistent-action-warnings
+Compiled at: 2026-08-12 11:28:07.89975 UTC
+*/
+
+end
+/* Output
+
+==============================================================================
+summary of summaries:
+
+analyzed: examples/regression/trace/issue916.spthy
+
+  output:          examples/regression/trace/issue916.spthy.tmp
+  processing time: 0.07s
+  
+  WARNING: 2 wellformedness check failed!
+           The analysis results might be wrong!
+  
+  missing_action (exists-trace): falsified - no trace found (2 steps)
+
+==============================================================================
+*/

--- a/examples/regression/trace/issue916-process.spthy
+++ b/examples/regression/trace/issue916-process.spthy
@@ -1,0 +1,13 @@
+theory issue916_process
+begin
+
+process:
+  event ProcessAction()
+
+lemma process_action: exists-trace
+  "Ex #i. ProcessAction() @ i"
+
+restriction process_restriction_action:
+  "All #i. ProcessAction() @ i ==> F"
+
+end

--- a/examples/regression/trace/issue916.spthy
+++ b/examples/regression/trace/issue916.spthy
@@ -1,0 +1,13 @@
+theory issue916
+begin
+
+rule ExistingAction:
+  [] --[ ExistingAction() ]-> []
+
+lemma missing_action: exists-trace
+  "Ex #i. MissingAction() @ i"
+
+restriction missing_restriction_action:
+  "All #i. MissingRestrictionAction() @ i ==> F"
+
+end

--- a/lib/theory/src/Theory/Tools/Wellformedness.hs
+++ b/lib/theory/src/Theory/Tools/Wellformedness.hs
@@ -59,9 +59,11 @@
 module Theory.Tools.Wellformedness (
 
   -- * Wellformedness checking
-    WfErrorReport
+    ActionFactInfo
+  , WfErrorReport
   , checkWellformedness
   , checkWellformednessDiff
+  , processActionFactInfos
 
   , prettyWfErrorReport
   , underlineTopic
@@ -112,6 +114,7 @@ import Term.SubtermRule ( CtxtStRule, prettyCtxtStRule, filterNonSubtermCtxtRule
 type Topic         = String
 type WfError       = (Topic, Doc)
 type WfErrorReport = [WfError]
+type ActionFactInfo = (FactTag, Int, Multiplicity)
 type RuleAndFact   = (String, LNFact) -- String : name of rule where the fact is
                                       -- LNFact : the rule
 
@@ -171,8 +174,18 @@ underlineTopic topic = topic ++"\n" ++
                       ++"\n"
 
 -- | To get the informations of a fact
-factInfo :: Fact t -> (FactTag, Int, Multiplicity)
+factInfo :: Fact t -> ActionFactInfo
 factInfo fa    = (factTag fa, factArity fa, factMultiplicity fa)
+
+-- | Action facts declared directly by a SAPIC process. These actions exist in
+-- the source theory even in output modes that consume the process without
+-- translating it to multiset-rewrite rules first.
+processActionFactInfos :: OpenTheory -> [ActionFactInfo]
+processActionFactInfos = concatMap (pfoldMap actionFactInfos) . theoryProcesses
+  where
+    actionFactInfos (ProcessAction (Event fa) _ _) = [factInfo fa]
+    actionFactInfos (ProcessAction (MSR _ acts _ _ _) _ _) = map factInfo acts
+    actionFactInfos _ = []
 
 -- | To bind a list of premise facts with their most similar conclusion facts. The most similar fact
 -- | has the minimual editing distance and the value of the distance must be
@@ -575,12 +588,13 @@ freshFactArguments' rules = do
         text ("rule " ++ quote (showRuleCaseName ru)) <->
         text "fact:" <-> prettyLNFact fa
 
--- | Report on facts usage. Skip checks on non-existant actions if `incompleteMSRs` is True.
-factReports :: Bool -> OpenTranslatedTheory -> WfErrorReport
-factReports incompleteMSRs thy =
-    concat  [ reservedReport, reservedFactNameRules, freshFactArguments, specialFactsUsage
-    , factUsage, factLhsOccurNoRhs]
-    ++ concat [ inexistentActions ++ inexistentActionsRestrictions | incompleteMSRs ]
+-- | Report on facts usage. SAPIC process actions supplement actions from MSR
+-- rules when the selected output mode does not translate the process first.
+factReports :: [ActionFactInfo] -> OpenTranslatedTheory -> WfErrorReport
+factReports processActions thy = concat
+    [ reservedReport, reservedFactNameRules, freshFactArguments, specialFactsUsage
+    , factUsage, factLhsOccurNoRhs, inexistentActions, inexistentActionsRestrictions
+    ]
   where
     ruleFacts ru =
       ( "Rule " ++ quote (showRuleCaseName ru)
@@ -692,12 +706,14 @@ factReports incompleteMSRs thy =
     -- Check that every fact referenced in a formula is present as an action
     -- of a protocol rule. We have to add the linear "K/1" fact, as the
     -- WF-check cannot rely on a loaded intruder theory.
-    ruleActions = S.fromList $ map factInfo $
-          kLogFact undefined
-        : dedLogFact undefined
-        : kuFact undefined
-        : (do ru <- thyProtoRules thy; get rActs ru)
-          ++ (do RuleItem ru <- get thyItems thy; racs <- get oprRuleAC ru; get rActs racs)
+    ruleActions = S.fromList $
+        processActions ++ map factInfo
+          ( kLogFact undefined
+          : dedLogFact undefined
+          : kuFact undefined
+          : (do ru <- thyProtoRules thy; get rActs ru)
+            ++ (do RuleItem ru <- get thyItems thy; racs <- get oprRuleAC ru; get rActs racs)
+          )
 
     -- Report a protocol fact occurs in an LHS but not in any RHS
     factLhsOccurNoRhs :: WfErrorReport
@@ -1264,18 +1280,18 @@ checkWellformednessDiff thy sig = -- trace ("checkWellformednessDiff: " ++ show 
     , natWellSortedReportDiff
     ] ++ (if not (isUserMarkedConvergentDiff thy) then checkDiffEquationsSubtermConvergence thy else [])
 
--- | Returns a list of errors, if there are any. `incompleteMSR`, if true, indicates
--- that the MSRs are incomplete (e.g., when we export to ProVerif) and that
--- checks that rely on that should not be performed.
-checkWellformedness :: Bool -> OpenTranslatedTheory -> SignatureWithMaude -> WfErrorReport
-checkWellformedness incompleteMSRs thy sig = concatMap ($ thy) (
+-- | Returns a list of errors, if there are any. The supplied action facts come
+-- from SAPIC processes that may not have been translated to MSR rules in the
+-- selected output mode.
+checkWellformedness :: [ActionFactInfo] -> OpenTranslatedTheory -> SignatureWithMaude -> WfErrorReport
+checkWellformedness processActions thy sig = concatMap ($ thy) (
     [ checkIfLemmasInTheory
     , unboundReport
     , freshNamesReport
     , publicNamesReport
     , ruleSortsReport
     , ruleVariantsReport sig
-    , factReports incompleteMSRs
+    , factReports processActions
     , formulaReports
     , lemmaAttributeReport
     , multRestrictedReport

--- a/regressionTests.py
+++ b/regressionTests.py
@@ -1,5 +1,5 @@
 from html import parser
-import subprocess, sys, re, os, argparse, logging, datetime, shutil
+import subprocess, sys, re, os, argparse, logging, datetime, shutil, difflib
 
 
 class colors:
@@ -33,13 +33,39 @@ def getColorQuality(valueA, valueB):
 
 
 def iterFolder(folder):
-	""" Yields all files in the folder that have a .spthy ending. """
+	"""Yields all theory and export regression artifacts in the folder."""
 	for dname, dirs, files in os.walk(folder):
 		for fname in files:
 			fpath = os.path.join(dname, fname)
-			if not fpath.endswith(".spthy"):
+			if not fpath.endswith((".spthy", ".pv")):
 				continue
 			yield fpath
+
+def stripGeneratedMetadata(output):
+	"""Removes build-specific metadata from a generated ProVerif export."""
+	return re.sub(r"\n\(\*\nGenerated from:\n.*?\n\*\)\s*$", "\n", output, flags=re.DOTALL)
+
+def compareExportFile(pathB):
+	"""Compares a generated ProVerif export with its regression reference."""
+	pathA = settings.folderA + pathB.split(settings.folderB, 1)[-1]
+	try:
+		with open(pathA, 'r') as expectedFile:
+			expected = stripGeneratedMetadata(expectedFile.read())
+		with open(pathB, 'r') as actualFile:
+			actual = stripGeneratedMetadata(actualFile.read())
+	except Exception as ex:
+		return False, f"There was an error while reading an export regression artifact: {ex}"
+
+	if expected == actual:
+		return True, ""
+
+	diff = difflib.unified_diff(
+		expected.splitlines(keepends=True),
+		actual.splitlines(keepends=True),
+		fromfile=pathA,
+		tofile=pathB,
+	)
+	return False, "".join(diff)
 
 ## functions for cutting and parsing part of the proof ##
 def parseTest(lines, tester):
@@ -316,6 +342,14 @@ def compare():
 	parseTestsTotal, parseTestsFailed = 0, 0
 	
 	for pathB in iterFolder(settings.folderB):
+		if pathB.endswith(".pv"):
+			exportsMatch, exportDiff = compareExportFile(pathB)
+			if not exportsMatch:
+				logging.error(color(colors.RED + colors.BOLD, f"The ProVerif export changed for {pathB}"))
+				if settings.verbose >= 6:
+					logging.error(exportDiff)
+				majorDifferences = True
+			continue
 
 		## Tamarin parse testing for the output file##
 		if not settings.no_output_parse_test:

--- a/src/Main/TheoryLoader.hs
+++ b/src/Main/TheoryLoader.hs
@@ -554,12 +554,13 @@ checkTranslatedTheory ::
   (MonadIO m, MonadError TheoryLoadError m) =>
   TheoryLoadOptions ->
   SignatureWithMaude ->
+  [ActionFactInfo] ->
   Either OpenTranslatedTheory OpenDiffTheory ->
   m (WfErrorReport, SignatureWithMaude, Either OpenTranslatedTheory OpenDiffTheory)
-checkTranslatedTheory thyOpts sign thy = do
+checkTranslatedTheory thyOpts sign processActions thy = do
   let transReport =
         either
-          (\openThy -> checkWellformedness incompleteMSRs openThy sign)
+          (\openThy -> checkWellformedness processActions openThy sign)
           (`checkWellformednessDiff` sign)
           thy
 
@@ -599,7 +600,6 @@ checkTranslatedTheory thyOpts sign thy = do
   pure (report, signWithMaude, deducThy)
   where
     mh = sign._sigMaudeInfo
-    incompleteMSRs = False -- TODO how do we know if we do not have all MSRs due to translation?
     autoSources = thyOpts.autoSources
     derivChecks = thyOpts.derivationChecks
     derivTimeoutMsg =
@@ -724,8 +724,9 @@ closeTheory ::
   m (WfErrorReport, Either ClosedTheory ClosedDiffTheory)
 closeTheory version loadedThyOpts sign srcThy = do
   (preReport, transThy) <- translateTheory thyOpts srcThy
-  let removedThy = first removeTranslationItems transThy
-  (postReport, sign', checkedThy) <- checkTranslatedTheory thyOpts sign removedThy
+  let processActions = either processActionFactInfos (const []) transThy
+      removedThy = first removeTranslationItems transThy
+  (postReport, sign', checkedThy) <- checkTranslatedTheory thyOpts sign processActions removedThy
   closedThy <- closeTranslatedTheory thyOpts sign' checkedThy
   finalThy <- withVersionAndReport version thyOpts (preReport ++ postReport) closedThy
 
@@ -774,8 +775,9 @@ translateAndCheckTheory ::
   m (WfErrorReport, Either OpenTheory OpenDiffTheory)
 translateAndCheckTheory version thyOpts sign srcThy = do
   (preReport, transThy) <- translateTheory thyOpts srcThy
-  let removedThy = first removeTranslationItems transThy
-  (postReport, _, _) <- checkTranslatedTheory thyOpts sign removedThy
+  let processActions = either processActionFactInfos (const []) transThy
+      removedThy = first removeTranslationItems transThy
+  (postReport, _, _) <- checkTranslatedTheory thyOpts sign processActions removedThy
   finalThy <- withVersionAndReport version thyOpts (preReport ++ postReport) transThy
   pure (preReport ++ postReport, finalThy)
 


### PR DESCRIPTION
Supersedes #916.

Wellformedness checks for actions referenced in lemmas and restrictions but never produced by any rule were effectively disabled: the incompleteMSRs condition in factReports was inverted and the only call site always passed False (with a TODO on how to detect incomplete MSRs). As a result, ordinary MSR theories referencing inexistent actions produced no warning.

Simply dropping the flag (as #916 does) reintroduces the check but produces spurious warnings in exporter modes such as --output-module=proverif, where the SAPIC process is consumed directly and its actions are never translated into MSR rules.

This PR always performs the check, but supplements the actions collected from MSR rules with the action facts declared directly in SAPIC processes (processActionFactInfos). The Bool flag and the TODO are removed.

Regressions:
- issue916.spthy: a plain MSR theory referencing missing lemma and restriction actions now reports them.
- issue916-process.spthy: a valid SAPIC theory exported to ProVerif reports no missing-action warnings. This adds a _proverif.pv regression target to the Makefile and teaches regressionTests.py to diff .pv exports (ignoring the generated-from metadata footer).

Build, existing self-tests, and the regressions pass.