### PR TITLE
Fix various bits of invalid HTML

### DIFF
--- a/data/css/tamarin-prover-ui.css
+++ b/data/css/tamarin-prover-ui.css
@@ -597,3 +597,9 @@ div#logo img {
     display: inline;
 }
 
+
+/* Instructions shown by the lemma add, edit and delete views. */
+.wrap-text li {
+    white-space: normal;
+    word-wrap: break-word;
+}

--- a/src/Web/Hamlet.hs
+++ b/src/Web/Hamlet.hs
@@ -67,8 +67,7 @@ rootTpl theories = [whamlet|
                   \ #{showVersion version}
     \^{introTpl}
     <div class="intropage">
-      <p>
-        \^{theoriesTpl theories}
+      \^{theoriesTpl theories}
       <h2>Loading a new theory
       <p>
         You can load a new theory file from disk in order to work with it.
@@ -85,14 +84,15 @@ theoriesTpl :: TheoryMap -> Widget
 theoriesTpl thmap = [whamlet|
     $newline never
     $if M.null thmap
-      <strong>No theories loaded!</strong>
+      <strong>No theories loaded!
     $else
       <table>
         <thead>
-          <th>Theory name
-          <th>Time
-          <th>Version
-          <th>Origin
+          <tr>
+            <th>Theory name
+            <th>Time
+            <th>Version
+            <th>Origin
         $forall tgroup <- processMap thmap
           ^{theoryTpl (head tgroup)}
           $forall th <- ntail 4 tgroup

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -1047,27 +1047,27 @@ htmlThyPath renderUrl renderImgUrl info path lPlaintext = case path of
             <ul .wrap-text>
               <li>
                Modifying the lemma in the box above and clicking the submit button will attempt to modify the lemma in the current theory.
-               <br>&zwnj;
+               <br>
+               \ &zwnj;
               <li>
                Failures in parsing the lemma or verifying its well-formedness will result in an error, and the lemma will NOT be modified.
                However, your changes will be kept on this page until you leave this right panel.
-               <br>&zwnj;
+               <br>
+               \ &zwnj;
               <li>
                Editing a lemma will NOT modify the file it was loaded from, but clicking on "Append modified lemmas to file" in the Actions menu adds all modified lemmas as a comment at the end of the file on disk they were loaded from.
-               <br>&zwnj;
+               <br>
+               \ &zwnj;
               <li>
                Clicking on "Download source" in the Actions menu will download the modified version of the theory (including the modified lemmas), but not modify the file on disk.
-               <br>&zwnj;
+               <br>
+               \ &zwnj;
               <li>
                Modifying a reuse lemma will invalidate all subsequent proofs.
-               <br>&zwnj;
+               <br>
+               \ &zwnj;
               <li>
                Modifying a sources lemma is not supported and will result in an error.
-            <style>
-               .wrap-text li {
-                   white-space: normal;
-                   word-wrap: break-word;
-               }
     |] renderUrl
     where textHeight = 2 + length (filter (=='\n') lPlaintext)
 
@@ -1090,20 +1090,18 @@ htmlThyPath renderUrl renderImgUrl info path lPlaintext = case path of
         <ul .wrap-text>
           <li>
            Clicking on the button above will delete the lemma from the loaded theory.
-           <br>&zwnj;
+           <br>
+           \ &zwnj;
           <li>
            Deleting a lemma will NOT modify the file it was loaded from, but clicking on "Download source" in the Actions menu will download the modified version of the theory (so without the deleted lemmas).
-           <br>&zwnj;
+           <br>
+           \ &zwnj;
           <li>
            Deleting a reuse lemma will invalidate all subsequent proofs.
-           <br>&zwnj;
+           <br>
+           \ &zwnj;
           <li>
            Deleting a source lemma is not supported and will result in an error.
-         <style>
-             .wrap-text li {
-                 white-space: normal;
-                 word-wrap: break-word;
-             }
          |] renderUrl
 
   TheoryAdd name -> do
@@ -1125,17 +1123,14 @@ htmlThyPath renderUrl renderImgUrl info path lPlaintext = case path of
           <ul .wrap-text>
             <li>
              Adds the lemma in the current position in the theory, but will throw an error if a lemma with the same name exists, the parsing fails, or the lemma isn't well-formed.
-             <br>&zwnj;
+             <br>
+             \ &zwnj;
             <li>
              Adding a lemma will NOT modify the loaded source file, but clicking on "Append modified lemmas to file" in the Actions menu appends all added lemmas as a comment at the end of the current theory file.
-             <br>&zwnj;
+             <br>
+             \ &zwnj;
             <li>
              Clicking on "Download source" in the Actions menu will download the modified version of the theory (including the added lemmas).
-          <style>
-              .wrap-text li {
-                  white-space: normal;
-                  word-wrap: break-word;
-              }
           |] renderUrl
 
   TheoryHelp -> helpHtml info.theory._thyName info renderUrl
@@ -1211,9 +1206,9 @@ helpHtml theoryName info renderUrl = [hamlet|
       <li>
         When a theory is initially loaded, there will be a line at the
         \ end of each theorem stating #
-        <tt>"by sorry // not yet proven"
+        <code>"by sorry // not yet proven"
         .  Click on #
-        <tt>sorry
+        <code>sorry
         \ to inspect the proof state.
       <li>
         Right-click to show further options, such as autoprove.
@@ -1240,7 +1235,7 @@ helpHtml theoryName info renderUrl = [hamlet|
           Jump to the next/previous open constraint within the currently
           \ focused lemma, or to the next/previous lemma if there are no
           \ more #
-          <tt>sorry
+          <code>sorry
           \ steps in the proof of the current lemma.
       <tr>
         <td>
@@ -1258,7 +1253,7 @@ helpHtml theoryName info renderUrl = [hamlet|
           \ <span class="keys">A</span>
           \ searches for all solutions.
           \ Needs to have a #
-          <tt>sorry
+          <code>sorry
           \ selected to work.
       <tr>
         <td>
@@ -1271,7 +1266,7 @@ helpHtml theoryName info renderUrl = [hamlet|
           \ <span class="keys">B</span>
           \ searches for all solutions.
           \ Needs to have a #
-          <tt>sorry
+          <code>sorry
           \ selected to work.
       <tr>
         <td>

--- a/src/Web/Theory.hs
+++ b/src/Web/Theory.hs
@@ -1041,9 +1041,9 @@ htmlThyPath renderUrl renderImgUrl info path lPlaintext = case path of
           <noscript>
             <div class="warning">
               Warning: JavaScript must be enabled for the
-              <span class="tamarin">Tamarin</span>
+              <span class="tamarin">Tamarin
               prover GUI to function properly.
-          <p>
+          <div>
             <ul .wrap-text>
               <li>
                Modifying the lemma in the box above and clicking the submit button will attempt to modify the lemma in the current theory.
@@ -1084,9 +1084,9 @@ htmlThyPath renderUrl renderImgUrl info path lPlaintext = case path of
       <noscript>
         <div class="warning">
           Warning: JavaScript must be enabled for the
-          <span class="tamarin">Tamarin</span>
+          <span class="tamarin">Tamarin
           prover GUI to function properly.
-      <p>
+      <div>
         <ul .wrap-text>
           <li>
            Clicking on the button above will delete the lemma from the loaded theory.
@@ -1119,9 +1119,9 @@ htmlThyPath renderUrl renderImgUrl info path lPlaintext = case path of
         <noscript>
           <div class="warning">
             Warning: JavaScript must be enabled for the
-            <span class="tamarin">Tamarin</span>
+            <span class="tamarin">Tamarin
             prover GUI to function properly.
-        <p>
+        <div>
           <ul .wrap-text>
             <li>
              Adds the lemma in the current position in the theory, but will throw an error if a lemma with the same name exists, the parsing fails, or the lemma isn't well-formed.
@@ -1197,97 +1197,96 @@ helpHtml theoryName info renderUrl = [hamlet|
     Theory: #{theoryName}
     \ (Loaded at #{formatTime defaultTimeLocale "%T" info.time}
     \ from #{show info.origin})
-    \ #{preEscapedToMarkup info.errorsHtml}
+  \ #{preEscapedToMarkup info.errorsHtml}
   <div id="help">
     <h3>Quick introduction
     <noscript>
       <div class="warning">
         Warning: JavaScript must be enabled for the
-        <span class="tamarin">Tamarin</span>
+        <span class="tamarin">Tamarin
         prover GUI to function properly.
     <p>
       <em>Left pane: Proof scripts display.
-      <ul>
-        <li>
-          When a theory is initially loaded, there will be a line at the
-          \ end of each theorem stating #
-          <tt>"by sorry // not yet proven"
-          .  Click on #
-          <tt>sorry
-          \ to inspect the proof state.
-        <li>
-          Right-click to show further options, such as autoprove.
+    <ul>
+      <li>
+        When a theory is initially loaded, there will be a line at the
+        \ end of each theorem stating #
+        <tt>"by sorry // not yet proven"
+        .  Click on #
+        <tt>sorry
+        \ to inspect the proof state.
+      <li>
+        Right-click to show further options, such as autoprove.
     <p>
       <em>Right pane: Visualization.
-      <ul>
-        <li>
-          Visualization and information display relating to the
-          \ currently selected item.
+    <ul>
+      <li>
+        Visualization and information display relating to the
+        \ currently selected item.
 
   <h3>Keyboard shortcuts
-  <p>
-    <div id="shortcuts">
-      <table>
-        <tr>
-          <td>
-            <span class="keys">j/k
-          <td>
-            Jump to the next/previous proof path within the currently
-            \ focused lemma.
-        <tr>
-          <td>
-            <span class="keys">J/K
-          <td>
-            Jump to the next/previous open constraint within the currently
-            \ focused lemma, or to the next/previous lemma if there are no
-            \ more #
-            <tt>sorry
-            \ steps in the proof of the current lemma.
-        <tr>
-          <td>
-            <span class="keys">1-9
-          <td>
-            Apply the proof method with the given number as shown in the
-            \ applicable proof method section in the main view.
-        <tr>
-          <td>
-            <span class="keys">a/A
-          <td>
-            Apply the autoprove method to the focused proof step.
-            \ <span class="keys">a</span>
-            \ stops after finding a solution, and
-            \ <span class="keys">A</span>
-            \ searches for all solutions.
-            \ Needs to have a #
-            <tt>sorry
-            \ selected to work.
-        <tr>
-          <td>
-            <span class="keys">b/B
-          <td>
-            Apply a bounded-depth version of the autoprove method to the
-            \ focused proof step.
-            \ <span class="keys">b</span>
-            \ stops after finding a solution, and
-            \ <span class="keys">B</span>
-            \ searches for all solutions.
-            \ Needs to have a #
-            <tt>sorry
-            \ selected to work.
-        <tr>
-          <td>
-            <span class="keys">s/S
-          <td>
-            Apply the autoprove method to all lemmas.
-            \ <span class="keys">s</span>
-            \ stops after finding a solution, and
-            \ <span class="keys">S</span>
-            \ searches for all solutions.
-        <tr>
-          <td>
-            <span class="keys">?
-          <td>
-            Display this help message.
+  <div id="shortcuts">
+    <table>
+      <tr>
+        <td>
+          <span class="keys">j/k
+        <td>
+          Jump to the next/previous proof path within the currently
+          \ focused lemma.
+      <tr>
+        <td>
+          <span class="keys">J/K
+        <td>
+          Jump to the next/previous open constraint within the currently
+          \ focused lemma, or to the next/previous lemma if there are no
+          \ more #
+          <tt>sorry
+          \ steps in the proof of the current lemma.
+      <tr>
+        <td>
+          <span class="keys">1-9
+        <td>
+          Apply the proof method with the given number as shown in the
+          \ applicable proof method section in the main view.
+      <tr>
+        <td>
+          <span class="keys">a/A
+        <td>
+          Apply the autoprove method to the focused proof step.
+          \ <span class="keys">a</span>
+          \ stops after finding a solution, and
+          \ <span class="keys">A</span>
+          \ searches for all solutions.
+          \ Needs to have a #
+          <tt>sorry
+          \ selected to work.
+      <tr>
+        <td>
+          <span class="keys">b/B
+        <td>
+          Apply a bounded-depth version of the autoprove method to the
+          \ focused proof step.
+          \ <span class="keys">b</span>
+          \ stops after finding a solution, and
+          \ <span class="keys">B</span>
+          \ searches for all solutions.
+          \ Needs to have a #
+          <tt>sorry
+          \ selected to work.
+      <tr>
+        <td>
+          <span class="keys">s/S
+        <td>
+          Apply the autoprove method to all lemmas.
+          \ <span class="keys">s</span>
+          \ stops after finding a solution, and
+          \ <span class="keys">S</span>
+          \ searches for all solutions.
+      <tr>
+        <td>
+          <span class="keys">?
+        <td>
+          Display this help message.
 |] renderUrl
 
 {-

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -703,7 +703,7 @@ defaultLayout' w = do
   withUrlRenderer [hamlet|
     $newline never
     !!!
-    <html>
+    <html lang=en>
       <head>
         <title>#{pageTitle page}
         <link rel=stylesheet href=/static/css/intdot-style.css>
@@ -804,7 +804,7 @@ intdotLayout includeAbstractToggle w = do
   withUrlRenderer [hamlet|
     $newline never
     !!!
-    <html>
+    <html lang=en>
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/Web/Types.hs
+++ b/src/Web/Types.hs
@@ -710,16 +710,16 @@ defaultLayout' w = do
         <link rel=stylesheet href=/static/css/tamarin-prover-ui.css>
         <link rel=stylesheet href=/static/css/jquery-contextmenu.css>
         <link rel=stylesheet href=/static/css/smoothness/jquery-ui.css>
-        <script src=/static/js/jquery.js></script>
-        <script src=/static/js/jquery-ui.js></script>
-        <script src=/static/js/jquery-layout.js></script>
-        <script src=/static/js/jquery-cookie.js></script>
-        <script src=/static/js/jquery-superfish.js></script>
-        <script src=/static/js/jquery-contextmenu.js></script>
-        <script src=/static/js/tamarin-prover-ui.js></script>
-        <script type="module" src=/static/js/intdot-graph.es.js></script>
-        <script type="module" src=/static/js/intdot-staticgraph.es.js></script>
-        <script type="module" src=/static/js/intdot-dynamicgraph.es.js></script>
+        <script src=/static/js/jquery.js>
+        <script src=/static/js/jquery-ui.js>
+        <script src=/static/js/jquery-layout.js>
+        <script src=/static/js/jquery-cookie.js>
+        <script src=/static/js/jquery-superfish.js>
+        <script src=/static/js/jquery-contextmenu.js>
+        <script src=/static/js/tamarin-prover-ui.js>
+        <script type="module" src=/static/js/intdot-graph.es.js>
+        <script type="module" src=/static/js/intdot-staticgraph.es.js>
+        <script type="module" src=/static/js/intdot-dynamicgraph.es.js>
         ^{pageHead page}
       <body>
         $maybe msg <- message
@@ -732,7 +732,7 @@ defaultLayout' w = do
         <div#confirm-dialog>
         <ul#contextMenu>
           <li.autoprove>
-            <a href="#autoprove">Autoprove</a>
+            <a href="#autoprove">Autoprove
   |]
           -- <li.delstep>
             -- <a href="#del/path">Remove step</a>
@@ -812,12 +812,12 @@ intdotLayout includeAbstractToggle w = do
         <style> body,html{width: 100%; height: 100%; overflow: hidden; margin: 0; padding: 0; }
         <link rel=stylesheet href=/static/css/intdot-style.css>
         <link rel=stylesheet href=/static/css/tamarin-prover-ui.css>
-        <script src=/static/js/jquery.js></script>
-        <script src=/static/js/jquery-cookie.js></script>
-        <script src=/static/js/jquery-superfish.js></script>
-        <script>window.tamarinPopoutGraph = (window.self === window.top); if (!window.tamarinPopoutGraph) { document.documentElement.classList.add("graph-embedded"); }</script>
-        <script src=/static/js/tamarin-prover-ui.js></script>
-        <script type="module" src=/static/js/intdot-graph.es.js></script>
+        <script src=/static/js/jquery.js>
+        <script src=/static/js/jquery-cookie.js>
+        <script src=/static/js/jquery-superfish.js>
+        <script>window.tamarinPopoutGraph = (window.self === window.top); if (!window.tamarinPopoutGraph) { document.documentElement.classList.add("graph-embedded"); }
+        <script src=/static/js/tamarin-prover-ui.js>
+        <script type="module" src=/static/js/intdot-graph.es.js>
         ^{pageHead page}
       <body>
         ^{pageBody page}


### PR DESCRIPTION
This is the most inconsequential PR I've opened yet I think; it changes nothing visible to a user. So, with that said:
- Tamarin currently outputs a bunch of duplicate closing tags in its HTML.
- There are invalid `</br>` tags on lemma add/edit/delete pages
- `<tt>` is obsolete and has been replaced by `<code>`

Browsers are very used to html being non-compliant and fixing it up silently in the background. Then tamarin-rs came along and I wanted to render HTML pages as similar to tamarin-prover as possible, and discovered that some of the HTML is invalid.

Anyway, this fixes that. 

# Note for reviewers:
hamlet treats text on the same line as a tag as being inside that tag, which is pretty unintuitive. That's why this diff is mainly just removing `</tag>` elements, and probably why these were accidentally introduced in the first place! The `<br>` ones are for the same reason, hamlet will assume anything after `<br>` on the same line is 'inside' the `<br>` tag, which is not a thing, and that's why it outputs (e.g.) `<br>&zwnj;</br>` instead of `<br>&zwnj;`
